### PR TITLE
Octopus.Web.BaseUrl variable description edit

### DIFF
--- a/docs/deploying-applications/variables/system-variables.md
+++ b/docs/deploying-applications/variables/system-variables.md
@@ -188,7 +188,7 @@ Server-level variables describe the Octopus server on which the deployment is ru
 
 | Name and Description | Example                                  | 
 | -------------------  | ---------------------------------------- |
-| **`Octopus.Web.BaseUrl`** <br/>The default URL at which the server can be accessed | *[https://my-octopus](https://my-octopus)* |
+| **`Octopus.Web.BaseUrl`** <br/>The default URL at which the server can be accessed. Note that this is based off the server's ListenPrefixes and works in simple configuration scenarios. If you have a load balancer or reverse proxy this value will likely not be suitable for use in referring to the server from a client perspective, e.g. in email templates etc. | *[https://my-octopus](https://my-octopus)* |
 
 ## Tracking deployment status {#Systemvariables-DeploymentStatusTrackingdeploymentstatus}
 


### PR DESCRIPTION
Line 191: Added disclaimer to description explaining why this variable behind a load balancer/reverse proxy may not be suitable.
Source: http://help.octopusdeploy.com/discussions/questions/10909