### PR TITLE
Update ssh-keygen command in format Octopus is looking for

### DIFF
--- a/docs/deployment-targets/ssh-targets/configuring-ssh-connection.md
+++ b/docs/deployment-targets/ssh-targets/configuring-ssh-connection.md
@@ -29,7 +29,7 @@ If you didn't run the discovery process or the fingerprint on the target has cha
 **Finding the fingerprint**
 
 ```bash
-ssh-keygen -lf /etc/ssh/ssh_host_rsa_key.pub | cut -d' ' -f2 | awk '{ print $1}'
+ssh-keygen -E md5 -lf /etc/ssh/ssh_host_rsa_key.pub | cut -d' ' -f2 | awk '{ print $1}' | cut -d':' -f2-
 ```
 
 :::success


### PR DESCRIPTION
The updated command is what works on Ubuntu 16.04.  I think it's also a bit more future-proof assuming that Octopus itself isn't flexible on the format of the thumbprint.