### PR TITLE
Update names for Package Feed, Id and Version vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Add a file anywhere in the docs repository that is suffixed with `.include.md`. 
 ### Using an include
 
 Add the following to the markdown: `!include <key>`
+You need to include the `<>` around the key name
 
 ## Partials
 Partials are version specific files that contain markdown.
@@ -253,7 +254,8 @@ Add a file in the same folder as the page where you will use the partial to the 
 
 ### Using a partial
 
-Add the following to the markdown: `!partial <key>`
+Add the following to the markdown: `!partial <key>` 
+You need to include the `<>` around the key name
 
 ## Anchors
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Add a file anywhere in the docs repository that is suffixed with `.include.md`. 
 ### Using an include
 
 Add the following to the markdown: `!include <key>`
+
 You need to include the `<>` around the key name
 
 ## Partials
@@ -255,6 +256,7 @@ Add a file in the same folder as the page where you will use the partial to the 
 ### Using a partial
 
 Add the following to the markdown: `!partial <key>` 
+
 You need to include the `<>` around the key name
 
 ## Anchors

--- a/docs/deploying-applications/variables/system-variables.md
+++ b/docs/deploying-applications/variables/system-variables.md
@@ -88,7 +88,7 @@ Action-level variables are available during execution of an action. Indexer noti
 |**`Octopus.Action.Package.TreatConfigTransformationWarningsAsErrors`** <br/>If true, any warnings in configuration transformations will be treated as errors and will fail the deployment** ***(Boolean)* | *True*|
 |**`Octopus.Action.Package.IgnoreConfigTransformationErrors`** <br/>If true, any errors in configuration transformations will be treated as informational rather than errors that will fail the deployment** ***(Boolean)* | *False*|
 |**`Octopus.Action.Package.IgnoreVariableReplacementErrors`** <br/>If true, any errors in variable replacement will be treated as a warning rather than an error that will fail the deployment. (*Boolean*) | *False*|
-!partial packageVariables
+!partial <packageVariables>
 |**`Octopus.Action.Package.SkipIfAlreadyInstalled`** <br/>If true, and the version of the package being deployed is already present on the machine, its re-deployment will be skipped (use with caution) *(Boolean)* | *False*|
 |**`Octopus.Action.Package.Ssh.ApplicationsDirectoryPath`** <br/>The applications directory used for deployment on the target machine | */home/user/.tentacle/apps/*|
 |**`Octopus.Action.Package.Ssh.PackageFileName`** <br/>The package file being deployed on the target machine | */home/user/.tentacle/packages/OctoFx.RateService.1.2.3.nupkg.tar.gz*|

--- a/docs/deploying-applications/variables/system-variables.md
+++ b/docs/deploying-applications/variables/system-variables.md
@@ -88,9 +88,9 @@ Action-level variables are available during execution of an action. Indexer noti
 |**`Octopus.Action.Package.TreatConfigTransformationWarningsAsErrors`** <br/>If true, any warnings in configuration transformations will be treated as errors and will fail the deployment** ***(Boolean)* | *True*|
 |**`Octopus.Action.Package.IgnoreConfigTransformationErrors`** <br/>If true, any errors in configuration transformations will be treated as informational rather than errors that will fail the deployment** ***(Boolean)* | *False*|
 |**`Octopus.Action.Package.IgnoreVariableReplacementErrors`** <br/>If true, any errors in variable replacement will be treated as a warning rather than an error that will fail the deployment. (*Boolean*) | *False*|
-|**`Octopus.Action.Package.NuGetFeedId`** <br/>The ID of the NuGet feed from which the package being deployed was pulled | *feeds-123*|
-|**`Octopus.Action.Package.NuGetPackageId`** <br/>The ID of the NuGet package being deployed | *OctoFx.RateService*|
-|**`Octopus.Action.Package.NuGetPackageVersion`** <br/>The version of the NuGet package being deployed | *1.2.3*|
+|**`Octopus.Action.Package.FeedId`** <br/>The ID of the feed from which the package being deployed was pulled | *feeds-123*|
+|**`Octopus.Action.Package.PackageId`** <br/>The ID of the package being deployed | *OctoFx.RateService*|
+|**`Octopus.Action.Package.PackageVersion`** <br/>The version of the package being deployed | *1.2.3*|
 |**`Octopus.Action.Package.SkipIfAlreadyInstalled`** <br/>If true, and the version of the package being deployed is already present on the machine, its re-deployment will be skipped (use with caution) *(Boolean)* | *False*|
 |**`Octopus.Action.Package.Ssh.ApplicationsDirectoryPath`** <br/>The applications directory used for deployment on the target machine | */home/user/.tentacle/apps/*|
 |**`Octopus.Action.Package.Ssh.PackageFileName`** <br/>The package file being deployed on the target machine | */home/user/.tentacle/packages/OctoFx.RateService.1.2.3.nupkg.tar.gz*|

--- a/docs/deploying-applications/variables/system-variables.md
+++ b/docs/deploying-applications/variables/system-variables.md
@@ -88,9 +88,7 @@ Action-level variables are available during execution of an action. Indexer noti
 |**`Octopus.Action.Package.TreatConfigTransformationWarningsAsErrors`** <br/>If true, any warnings in configuration transformations will be treated as errors and will fail the deployment** ***(Boolean)* | *True*|
 |**`Octopus.Action.Package.IgnoreConfigTransformationErrors`** <br/>If true, any errors in configuration transformations will be treated as informational rather than errors that will fail the deployment** ***(Boolean)* | *False*|
 |**`Octopus.Action.Package.IgnoreVariableReplacementErrors`** <br/>If true, any errors in variable replacement will be treated as a warning rather than an error that will fail the deployment. (*Boolean*) | *False*|
-|**`Octopus.Action.Package.FeedId`** <br/>The ID of the feed from which the package being deployed was pulled | *feeds-123*|
-|**`Octopus.Action.Package.PackageId`** <br/>The ID of the package being deployed | *OctoFx.RateService*|
-|**`Octopus.Action.Package.PackageVersion`** <br/>The version of the package being deployed | *1.2.3*|
+!partial packageVariables
 |**`Octopus.Action.Package.SkipIfAlreadyInstalled`** <br/>If true, and the version of the package being deployed is already present on the machine, its re-deployment will be skipped (use with caution) *(Boolean)* | *False*|
 |**`Octopus.Action.Package.Ssh.ApplicationsDirectoryPath`** <br/>The applications directory used for deployment on the target machine | */home/user/.tentacle/apps/*|
 |**`Octopus.Action.Package.Ssh.PackageFileName`** <br/>The package file being deployed on the target machine | */home/user/.tentacle/packages/OctoFx.RateService.1.2.3.nupkg.tar.gz*|

--- a/docs/deploying-applications/variables/system-variables_packageVariables_(,3.4).partial.md
+++ b/docs/deploying-applications/variables/system-variables_packageVariables_(,3.4).partial.md
@@ -1,0 +1,3 @@
+|**`Octopus.Action.Package.NuGetFeedId`** <br/>The ID of the NuGet feed from which the package being deployed was pulled | *feeds-123*|
+|**`Octopus.Action.Package.NuGetPackageId`** <br/>The ID of the NuGet package being deployed | *OctoFx.RateService*|
+|**`Octopus.Action.Package.NuGetPackageVersion`** <br/>The version of the NuGet package being deployed | *1.2.3*|

--- a/docs/deploying-applications/variables/system-variables_packageVariables_[3.4,).partial.md
+++ b/docs/deploying-applications/variables/system-variables_packageVariables_[3.4,).partial.md
@@ -1,0 +1,3 @@
+|**`Octopus.Action.Package.FeedId`** <br/>The ID of the feed from which the package being deployed was pulled | *feeds-123*|
+|**`Octopus.Action.Package.PackageId`** <br/>The ID of the package being deployed | *OctoFx.RateService*|
+|**`Octopus.Action.Package.PackageVersion`** <br/>The version of the package being deployed | *1.2.3*|


### PR DESCRIPTION
No longer named `Octopus.Action.Package.NuGet*`