### PR TITLE
HA documentation update

### DIFF
--- a/docs/administration/high-availability/configuring-octopus-for-high-availability.md
+++ b/docs/administration/high-availability/configuring-octopus-for-high-availability.md
@@ -143,9 +143,39 @@ You may already have an existing Octopus Deploy server, that you wish to make hi
 
 ## Configuring High Availability Polling Tentacles {#ConfiguringOctopusforHighAvailability-ConfiguringHighAvailabilityPollingTentacles}
 
-Listening Tentacles require no special configuration for High Availability.  Polling Tentacles, however, poll a server at regular intervals to check if there are any tasks waiting for the Tentacle to perform. In a High Availability scenario Polling Tentacles must poll all of the Octopus Servers in your configuration. You could poll a load balancer but there is a risk, depending on your load balancer configuration, that the Tentacle will not poll all servers in a timely manner.  You could also configure the Tentacle to poll each server by registering it with one of your Octopus Servers and then adding each Octopus Server to the Tentacle.config file (this is interpreted as a JSON array of servers):
+Listening Tentacles require no special configuration for High Availability.  Polling Tentacles, however, poll a server at regular intervals to check if there are any tasks waiting for the Tentacle to perform. In a High Availability scenario Polling Tentacles must poll all of the Octopus Servers in your configuration. You could poll a load balancer but there is a risk, depending on your load balancer configuration, that the Tentacle will not poll all servers in a timely manner.  You could also configure the Tentacle to poll each server by registering it with one of your Octopus Servers and then adding each Octopus Server to the Tentacle.config file. There are two options to add Octopus servers, via the command line or via editing the Tentacle.config file directly:
 
 **Tentacle.config**
+
+Configuring the Tentacle via the command line is the preferred option; command and switches are described below:
+
+```
+Usage: Tentacle poll-server [<options>]
+
+Where [<options>] is any of:
+      --instance=VALUE       Name of the instance to use
+      --server=VALUE         The Octopus server - e.g., 'http://octopus'
+      --apiKey=VALUE         Your API key; you can get this from the Octopus
+                               web portal
+  -u, --username=VALUE       If not using API keys, your username
+  -p, --password=VALUE       In not using API keys, your password
+      --server-comms-port=VALUE
+                             The comms port on the Octopus server; the
+                               default is 10943
+Or one of the common options:
+      --console              Don't attempt to run as a service, even if the
+                               user is non-interactive
+      --nologo               Don't print title or version information
+      --noconsolelogging     Don't log to the console
+```
+
+This would be executed once per server, an example command to the default instance can be seen below:
+```
+C:\Program Files\Octopus Deploy\Tentacle>Tentacle poll-server --server=10.0.255.160 --apikey=77751F90F9EEDCEE0C0CD84F7A3CC726AD123FA6
+```
+
+
+Alternatively you can edit the Tentacle.config directly to add each Octopus server (this is interpreted as a JSON array of servers). This method is not recommended as the Octopus service may need to be restarted to accept incoming connections via this method.
 
 ```xml
 <set key="Tentacle.Communication.TrustedOctopusServers">

--- a/docs/administration/high-availability/configuring-octopus-for-high-availability.md
+++ b/docs/administration/high-availability/configuring-octopus-for-high-availability.md
@@ -147,35 +147,15 @@ Listening Tentacles require no special configuration for High Availability.  Po
 
 **Tentacle.config**
 
-Configuring the Tentacle via the command line is the preferred option; command and switches are described below:
+Configuring the Tentacle via the command line is the preferred option with the command exectured once per server; an example command using the default instance can be seen below:
 
-```
-Usage: Tentacle poll-server [<options>]
-
-Where [<options>] is any of:
-      --instance=VALUE       Name of the instance to use
-      --server=VALUE         The Octopus server - e.g., 'http://octopus'
-      --apiKey=VALUE         Your API key; you can get this from the Octopus
-                               web portal
-  -u, --username=VALUE       If not using API keys, your username
-  -p, --password=VALUE       In not using API keys, your password
-      --server-comms-port=VALUE
-                             The comms port on the Octopus server; the
-                               default is 10943
-Or one of the common options:
-      --console              Don't attempt to run as a service, even if the
-                               user is non-interactive
-      --nologo               Don't print title or version information
-      --noconsolelogging     Don't log to the console
-```
-
-This would be executed once per server, an example command to the default instance can be seen below:
 ```
 C:\Program Files\Octopus Deploy\Tentacle>Tentacle poll-server --server=10.0.255.160 --apikey=77751F90F9EEDCEE0C0CD84F7A3CC726AD123FA6
 ```
 
+For more information on this command please refer to the [Tentacle Poll Server options document](https://octopus.com/docs/api-and-integration/tentacle.exe-command-line/poll-server)
 
-Alternatively you can edit the Tentacle.config directly to add each Octopus server (this is interpreted as a JSON array of servers). This method is not recommended as the Octopus service may need to be restarted to accept incoming connections via this method.
+Alternatively you can edit Tentacle.config directly to add each Octopus server (this is interpreted as a JSON array of servers). This method is not recommended as the Octopus service for each server will need to be restarted to accept incoming connections via this method.
 
 ```xml
 <set key="Tentacle.Communication.TrustedOctopusServers">

--- a/docs/administration/high-availability/configuring-octopus-for-high-availability.md
+++ b/docs/administration/high-availability/configuring-octopus-for-high-availability.md
@@ -147,10 +147,10 @@ Listening Tentacles require no special configuration for High Availability.  Po
 
 **Tentacle.config**
 
-Configuring the Tentacle via the command line is the preferred option with the command exectured once per server; an example command using the default instance can be seen below:
+Configuring the Tentacle via the command line is the preferred option with the command executed once per server; an example command using the default instance can be seen below:
 
 ```
-C:\Program Files\Octopus Deploy\Tentacle>Tentacle poll-server --server=10.0.255.160 --apikey=77751F90F9EEDCEE0C0CD84F7A3CC726AD123FA6
+C:\Program Files\Octopus Deploy\Tentacle>Tentacle poll-server --server=http://my.Octopus.server --apikey=API-77751F90F9EEDCEE0C0CD84F7A3CC726AD123FA6
 ```
 
 For more information on this command please refer to the [Tentacle Poll Server options document](https://octopus.com/docs/api-and-integration/tentacle.exe-command-line/poll-server)


### PR DESCRIPTION
Updating HA documentation to clarify options when configuring Tentacles in polling configuration
- added cmd line option and switches 
- added clarification around implications of editing Tentacles.config file directly