### PR TITLE
Include escape sequences

### DIFF
--- a/docs/deploying-applications/custom-installation-directory.md
+++ b/docs/deploying-applications/custom-installation-directory.md
@@ -36,7 +36,7 @@ Octopus 3.13.8 introduced an enhancement to the *purge* option, which allows you
 Extended Wildcard syntax is supported in the same way as in [configuration transforms](https://octopus.com/docs/deploying-applications/configuration-files#Configurationfiles-Relativepath).
 :::
 
-Our Packages are extracted into a new directory each time (along the lines of C:\Octopus\Applications\[Environment name]\[Package name]\[Package version]\) , and this is no different for Custom Installation Directory.
+Our Packages are extracted into a new directory each time (along the lines of C:\Octopus\Applications\\[Environment name\]\\[Package name\]\\[Package version\]\) , and this is no different for Custom Installation Directory.
 
 ![](/docs/images/3048085/3277682.png "width=1140")
 


### PR DESCRIPTION
Include escape sequences so slashes & square brackets show correctly in paths