### PR TITLE
Removed hint about PreservePaths regex

### DIFF
--- a/docs/guides/azure-deployments/web-apps/web-app-concepts.md
+++ b/docs/guides/azure-deployments/web-apps/web-app-concepts.md
@@ -140,20 +140,3 @@ For example, to preserve any paths beginning with `\Component` you could use:
 ```powershell
 \\Component.*(\\.*|$)
 ```
-
-:::hint
-Note: Because of the way the rules work for [WebDeploy](https://www.iis.net/downloads/microsoft/web-deploy) (which is used internally by Octopus when deploying Azure Websites), your pattern must also match any parent directories of the path you wish to preserve.
-
-For e.g. if you had the paths:
-
-```powershell
-\Components\ComponentA
-\Components\ComponentB
-```
-
-and you wanted to preserve `ComponentA` but *not* `ComponentB`, then you would have to set the variable to:
-
-```powershell
-\\Components;\\Components\\ComponentA(\\.*|$)
-```
-:::


### PR DESCRIPTION
WebDeploy no longer supports the regex we were using in this hint. It also no longer needs to, deployment of Web Apps into virtual directories no longer interfere with each other.

E.g. deploying ComponentA to a virtual directory of a site, and using the **Remove additional files** option, will not remove files from the root site or ComponentB.

Fixes OctopusDeploy/Issues#3384