### PR TITLE
fix small typo's in Multi-tenant deployments

### DIFF
--- a/docs/guides/multi-tenant-deployments/index.md
+++ b/docs/guides/multi-tenant-deployments/index.md
@@ -41,7 +41,7 @@ The multi-tenant features in Octopus Deploy will simplify your deployments in al
 - you want to provide each tester with an isolated test deployment so they can work on test data, and choose when to upgrade
 - you want to provide isolated, time-limited, deployments for work on feature branches
 - you want to manage deployments to individual targets across environments, like managing a fleet of embedded devices, or a fleet of laptops/workstations
-- you deploy your application to multiple geographic regions - this way you can avoid creating mutliple environments instead modeling each region as a tenant in the same environment - [example](/docs/patterns/multi-region-deployment-pattern.md)
+- you deploy your application to multiple geographic regions - this way you can avoid creating multiple environments instead modeling each region as a tenant in the same environment - [example](/docs/patterns/multi-region-deployment-pattern.md)
 - you deploy unique instances of your application for each end-customer - keep reading!
 
 ### You want to deploy a multi-tenant application {#Multi-tenantdeployments-Youwanttodeployamulti-tenantapplication}
@@ -53,7 +53,7 @@ We built the multi-tenant features in Octopus Deploy for this kind of scenario:
 
 Consider the following example:
 
-> NameBadge make HR software for large corporate customers. They provide the software as a SaaS offering to their customers, and host the web site and associated services for them. Due to the application architecture, for each customer, they deploy:
+> NameBadge makes HR software for large corporate customers. They provide the software as a SaaS offering to their customers, and host the web site and associated services for them. Due to the application architecture, for each customer, they deploy:
 >
 > - A different SQL database
 > - A copy of an ASP.NET website


### PR DESCRIPTION
Just some small typo fixes in the page `Multi-tenant deployments`