### PR TITLE
Adding information about OctoPack's incompatibility with .NET Core

### DIFF
--- a/docs/api-and-integration/teamcity.md
+++ b/docs/api-and-integration/teamcity.md
@@ -131,5 +131,5 @@ The video below is from a webinar hosted by JetBrains in which we demonstrated t
 
 Traditionally the Octopus TeamCity plugin required a Windows build agent to work. As of version 4.2.1 will run on Linux build agents if they meet either **one** of the following requirements:
 
-1. Have [.NET Core](https://www.microsoft.com/net/core) installed on the build agent and in the PATH such that the `dotnet` command runs successfully. To install, follow the linked guide to install the .NET Core SDK for your distribution. Ensure that the `dotnet` command runs successfully.
+1. Have [.NET Core](https://www.microsoft.com/net/core) installed on the build agent and in the PATH such that the `dotnet` command runs successfully. To install, follow the linked guide to install the .NET Core SDK for your distribution. Ensure that the `dotnet` command runs successfully. From version 4.15.10 of the plugin .NET Core v2 is required.
 2. Have the Octo command line tool installed and in the PATH such that the `Octo` command runs successfully. To install, download the .tar.gz for you system from the [Octopus download page](https://octopus.com/downloads), extract somewhere appropriate and symlink `Octo` into your PATH. Again, ensure that `Octo` runs successfully. On Ubuntu you may need to install `libunwind8` using your package manager`.`

--- a/docs/deploying-applications/deploying-asp.net-core-web-applications/index.md
+++ b/docs/deploying-applications/deploying-asp.net-core-web-applications/index.md
@@ -1,6 +1,6 @@
 ---
 title: Deploying ASP.NET Core Web Applications
-description: This guide covers everything you need to perfor your first ASP.NET Core webapp deployment.
+description: This guide covers everything you need to perform your first ASP.NET Core webapp deployment.
 position: 51
 ---
 

--- a/docs/deploying-applications/deploying-asp.net-core-web-applications/index.md
+++ b/docs/deploying-applications/deploying-asp.net-core-web-applications/index.md
@@ -1,8 +1,10 @@
 ---
 title: Deploying ASP.NET Core Web Applications
-description: This guide covers everything you need to perfor your first ASP.NET Core webapp deployment. 
+description: This guide covers everything you need to perfor your first ASP.NET Core webapp deployment.
 position: 51
 ---
+
+!toc
 
 ASP.NET Core is the future of ASP.NET, and it contains many changes to how applications are built, and how they are run.
 
@@ -15,12 +17,17 @@ Once you have a project up and running (see the [getting started guide](https://
 dotnet publish source/MyApp.Web --output published-app --configuration Release
 
 # Package the folder into a ZIP
-octo pack --id MyApp.Web --version 1.0.0 --basePath published-app 
+octo pack --id MyApp.Web --version 1.0.0 --basePath published-app
 ```
 
 If you are using the built-in repository, you can create a [zip file](/docs/packaging-applications/creating-packages/creating-zip-packages.md) instead. The generated nupkg or zip file should then be then be [pushed to a repository](/docs/packaging-applications/package-repositories/index.md).
 
 If you are using TeamCity, you can use the [new TeamCity plugin for dotnet commands](https://github.com/JetBrains/teamcity-dnx-plugin).
+
+:::warning
+** Why not OctoPack?**
+OctoPack is not compatible with ASP.NET Core applications. Please see [the OctoPack documentation](/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md#UsingOctoPack-UsingNETCore) for more details.
+:::
 
 ## Deployment {#DeployingASP.NETCoreWebApplications-Deployment}
 
@@ -37,7 +44,7 @@ When running under IIS, ensure the .NET CLR Version is set to `No Managed Code`
 The `.AspNetCore.Antiforgery` cookie created by ASP.NET Core uses the application path to generate it's hash. By default Octopus will deploy to a new path every time, which causes a new cookie to be set every deploy. This results in many unneeded cookies in the browser. See this [blog post](http://blog.novanet.no/a-pile-of-anti-forgery-cookies/) for more details. To change this behavior, set the Antiforgery token in your `startup.cs` like this:
 
 ```
-public void ConfigureServices(IServiceCollection services)  
+public void ConfigureServices(IServiceCollection services)
 {
     services.AddAntiforgery(opts => opts.CookieName = "AntiForgery.MyAppName");
 }

--- a/docs/packaging-applications/creating-packages/nuget-packages/using-octo.exe.md
+++ b/docs/packaging-applications/creating-packages/nuget-packages/using-octo.exe.md
@@ -3,6 +3,8 @@ title: Using Octo.exe
 description: Packaging applications using the octo.exe command line tool for use in your deployments.
 ---
 
+!toc
+
 If you don't want to (or can't) add [OctoPack](/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md) to your Visual Studio project, or you have a project that doesn't use Visual Studio then packaging your applications into a NuGet package would involve using NuGet.exe, together with a manifest file (.nuspec file), to create your packages.
 
 There is, however, another way that you can create a NuGet package from just a folder of files and subdirectories. **Octo.exe** is our API command line tool that allows you to interact with your Octopus Deploy server using different **commands**, but, it also has a, not so known command, the **pack** command. The [Octo.exe Command Line](/docs/api-and-integration/octo.exe-command-line/index.md) page will show you how to get the API command line tool installed and ready to use.
@@ -129,3 +131,8 @@ Advanced options:
       --overwrite            [Optional] Allow an existing package file of the
                              same ID/version to be overwritten
 ```
+## Using .NET Core?
+
+If you are using .NET Core for class libraries, we recommend using [dotnet pack from Microsoft](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack).
+
+If you are using .NET Core for web applications, we recommend publishing to a folder and then using [Octo.exe pack](/docs/packaging-applications/creating-packages/nuget-packages/using-octo.exe), as described in the "Publishing and Packing the Website" section of the [Deploying ASP.NET Core Web Applications documentation](/docs/deploying-applications/deploying-asp.net-core-web-applications#DeployingASP.NETCoreWebApplications-PublishingandPackingtheWebsite).

--- a/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md
+++ b/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md
@@ -8,7 +8,7 @@ description: Using OctoPack is the easiest way to package .NET applications for 
 The easiest way to package .NET applications from your continuous integration/automated build process is to use OctoPack. OctoPack adds a custom MSBuild target that hooks into the build process of your solution. When enabled, OctoPack will package your Windows Service and ASP.NET applications when MSBuild runs. This makes it easy to integrate OctoPack with your build server - as long as you can pass properties to MSBuild, you can use OctoPack.
 
 :::warning
-##OctoPack is not compatible with ASP.NET Core applications
+**OctoPack is not compatible with ASP.NET Core applications**
 Please see [this section](#UsingOctoPack-UsingNETCore) for more details.
 :::
 

--- a/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md
+++ b/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md
@@ -7,6 +7,11 @@ description: Using OctoPack is the easiest way to package .NET applications for 
 
 The easiest way to package .NET applications from your continuous integration/automated build process is to use OctoPack. OctoPack adds a custom MSBuild target that hooks into the build process of your solution. When enabled, OctoPack will package your Windows Service and ASP.NET applications when MSBuild runs. This makes it easy to integrate OctoPack with your build server - as long as you can pass properties to MSBuild, you can use OctoPack.
 
+:::warning
+##OctoPack is not compatible with ASP.NET Core applications
+Please see [this section](#UsingOctoPack-UsingNETCore) for more details.
+:::
+
 :::hint
 **OctoPack is Open-Source**
 OctoPack is built and maintained by the Octopus Deploy team, but it is also open source. You can [view the OctoPack project on GitHub](https://github.com/OctopusDeploy/OctoPack).
@@ -144,8 +149,8 @@ NuGet packages have version numbers. When you use OctoPack, the NuGet package ve
 
 1. The command line, if you pass `/p:OctoPackPackageVersion=<version>` as an MSBuild parameter when building your project.
 2. If the assembly contains a `GitVersionInformation` type, the field `GitVersionInformation.NuGetVersion` is used
-3. If you pass `/p:OctoPackUseProductVersion=true` as an MSBuild parameter, `[assembly: AssemblyInformationalVersion]` (AKA Assembly's product version) is used 
-4. If you pass `/p:OctoPackUseFileVersion=true` as an MSBuild parameter, `[assembly: AssemblyFileVersion]` (AKA Assembly's file version) is used 
+3. If you pass `/p:OctoPackUseProductVersion=true` as an MSBuild parameter, `[assembly: AssemblyInformationalVersion]` (AKA Assembly's product version) is used
+4. If you pass `/p:OctoPackUseFileVersion=true` as an MSBuild parameter, `[assembly: AssemblyFileVersion]` (AKA Assembly's file version) is used
 5. If the `[assembly: AssemblyInformationalVersion]` value is not valid, the `[assembly: AssemblyFileVersion]` is used
 6. If the `[assembly: AssemblyFileVersion]` is the same as the `[assembly: AssemblyInformationalVersion]` (AKA ProductVersion), then we'll use the `[assembly: AssemblyVersion]` attribute in your `AssemblyInfo.cs` file
 7. Otherwise we take the `[assembly: AssemblyInformationalVersion]`.
@@ -257,6 +262,7 @@ In addition to the common arguments above, OctoPack has a number of other parame
 | `OctoPackUseFileVersion`               | `true`                                  | Use this parameter to use `[assembly: AssemblyFileVersion]` (Assembly File Version) as the package version (see [version numbers](#UsingOctoPack-Versionnumbers)) |
 | `OctoPackUseProductVersion`            | `true`                                  | Use this parameter to use `[assembly: AssemblyInformationalVersion]` (Assembly Product Version) as the package version (see [version numbers](#UsingOctoPack-Versionnumbers)). Introduced in OctoPack `3.5.0` |
 | `OctoPackAppendProjectToFeed`          | `true`                                  | Append the project name onto the feed so you can nest packages under folders on publish |
+
 ## Troubleshooting OctoPack {#UsingOctoPack-TroubleshootingOctoPack}
 
 Sometimes OctoPack doesn't work the way you expected it to, or perhaps you are having trouble configuring your `.nuspec` file. Here are some steps to help you diagnose what is going wrong, and fix the problem.
@@ -268,7 +274,7 @@ Sometimes OctoPack doesn't work the way you expected it to, or perhaps you are h
   ```
   The `/p:RunOctoPack=true` argument configures OctoPack to run as part of the build process
   The `/fl` argument configures `msbuild.exe` to write the output to a log file which will usually look like `msbuild.log`.   Refer to the [MSBuild documentation](https://msdn.microsoft.com/en-us/library/ms171470.aspx) for more details.
-  Note: You may need to change some of these parameters to match the process you are using on your build server. Take a look   at the build server logs and try to emulate the process as closely as possible.  
+  Note: You may need to change some of these parameters to match the process you are using on your build server. Take a look   at the build server logs and try to emulate the process as closely as possible.
 
 2. Inspect the [MSBuild output log file](https://msdn.microsoft.com/en-us/library/ms171470.aspx). If OctoPack has executed successfully you should see log entries like the ones shown below generated using OctoPack 3.0.42:
 
@@ -290,8 +296,8 @@ Task "CreateOctoPackPackage"
   OctoPack: PackageVersion: 0.0.0.0
   OctoPack: ProjectName: MyApplication.Web
   OctoPack: PrimaryOutputAssembly: c:\dev\MyApplication\source\MyApplication.Web\bin\MyApplication.Web.dll
-  OctoPack: NugetArguments: 
-  OctoPack: NugetProperties: 
+  OctoPack: NugetArguments:
+  OctoPack: NugetProperties:
   OctoPack: ---------------
   OctoPack: Written files: 299
   OctoPack: Create directory: c:\dev\MyApplication\source\MyApplication.Web\obj\octopacking
@@ -333,7 +339,7 @@ Done executing task "Copy".
 Task "Message" skipped, due to false condition; ('$(OctoPackPublishPackageToHttp)' != '') was evaluated as ('' != '').
 Task "Exec" skipped, due to false condition; ('$(OctoPackPublishPackageToHttp)' != '') was evaluated as ('' != '').
 Done building target "OctoPack" in project "MyApplication.Web.csproj".
-```  
+```
 
  * If you cannot see any OctoPack-related log messages, perhaps OctoPack isn't installed into your project(s) correctly?
    * Try completely uninstalling OctoPack and installing it again
@@ -347,3 +353,11 @@ Done building target "OctoPack" in project "MyApplication.Web.csproj".
    * For web applications, files that are configured with the Visual Studio property **Build Action: Content** will be included in the package
    * If you have specified the `<files>` element in a custom `.nuspec` file, perhaps you need to add the `/p:OctoPackEnforceAddingFiles=true` MSBuild argument as discussed above?
    * If you have specified the `<files>` element in a custom `.nuspec` file, perhaps you need to experiment with some different combinations of include and exclude?
+
+## Using .NET Core? {#UsingOctoPack-UsingNETCore}
+
+OctoPack does not support .NET Core projects.
+
+If you are using .NET Core for class libraries, we recommend using [dotnet pack from Microsoft](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack).
+
+If you are using .NET Core for web applications, we recommend publishing to a folder and then using [Octo.exe pack](/docs/packaging-applications/creating-packages/nuget-packages/using-octo.exe), as described in the "Publishing and Packing the Website" section of the [Deploying ASP.NET Core Web Applications documentation](/docs/deploying-applications/deploying-asp.net-core-web-applications#DeployingASP.NETCoreWebApplications-PublishingandPackingtheWebsite).


### PR DESCRIPTION
This PR updates various doco to warn users about OctoPack's incompatibility with .NET Core. Used warnings in places where I think it should stand out, and new sections where it needed to be more informative (in the hope that this will put downwards pressure on support).