### PR TITLE
Deleting Releases page

### DIFF
--- a/docs/deployment-process/releases/deleting-releases.md
+++ b/docs/deployment-process/releases/deleting-releases.md
@@ -1,0 +1,21 @@
+---
+title: Deleting Releases
+description: Deleting releases from your projects
+position: 18
+---
+
+Sometimes you may want to delete releases of your project. Maybe they're defective and you don't want them possibly deployed, or you just want to clean up old releases. This page outlines the methods to permanently delete these releases in Octopus.
+
+## Deleting releases
+
+Deleting individual releases can be done by entering the release page and selecting the `Edit` option in the overflow menu.
+
+![Edit release](edit-release.png "width=500")
+
+In the edit release page, click the overflow menu and select `Delete`.
+
+![Delete release](delete-release.png "width=500")
+
+You can also delete a batch of releases by specifying a release version range in Octo.exe. An example can be found in our [Octo.exe documentation](https://octopus.com/docs/api-and-integration/octo.exe-command-line/deleting-releases).
+
+Consider automating data clean up by configuring [retention policies](https://octopus.com/docs/administration/retention-policies).


### PR DESCRIPTION
Outlines how to delete releases via UI and refers to Octo.exe delete-releases command and retention policies