### PR TITLE
Clarify use of variable syntax in email subject and body

### DIFF
--- a/docs/deployment-examples/email-notifications.md
+++ b/docs/deployment-examples/email-notifications.md
@@ -34,8 +34,8 @@ Email steps are added to deployment processes in the same way as other steps.
 
 Octopus will build the resulting recipient list during the deployment, remove duplicate emails addresses, and send the email to each recipient.
 
-7. Provide a subject line for the emails.
-8. Add the body of the email. The email can be sent in plain text or HTML, and you can use Octopus [variable syntax](/docs/deployment-process/variables/variable-substitution-syntax.md) to include information about the deployment in the email. See the [Email Template Examples](/docs/deployment-examples/email-notifications.md#email-template-examples) below.
+7. Provide a subject line for the emails. The subject can contain Octopus [basic variable syntax](/docs/blob/master/docs/deployment-process/variables/variable-substitution-syntax.md#basic-syntax-variablesubstitutionsyntax-basicsyntax).
+8. Add the body of the email. The email can be sent in plain text or HTML, and you can use Octopus [extended variable syntax](/docs/deployment-process/variables/variable-substitution-syntax.md#extended-syntax-variablesubstitutionsyntax-extendedsyntax) to include information about the deployment in the email. See the [Email Template Examples](/docs/deployment-examples/email-notifications.md#email-template-examples) below.
 9. You can set conditions to determine when the step should run. For instance:
 
   - Send the email only for successful deployments to certain environments.


### PR DESCRIPTION
You can use basic variable substitution syntax in the email subject and the extended syntax in email body.
Provided some explicit clarification for this and provided link.