### PR TITLE
Update Powershell version requirement for Azure PS modules

### DIFF
--- a/docs/infrastructure/deployment-targets/windows-targets/requirements/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/requirements/index.md
@@ -24,7 +24,7 @@ The installation requirements for the latest version of Tentacle are:
 
 - Windows PowerShell 2.0. This is automatically installed on 2008 R2.
 - Windows PowerShell 3.0 or 4.0 is recommended, both of which are compatible with PowerShell 2.0, but execute against .NET 4.0+.
-- Windows PowerShell 5.0 is required to run Azure steps
+- Windows PowerShell 5.1 is required to run Azure steps
 
 ## Hardware Requirements
 


### PR DESCRIPTION
Azure PS 5.7.0 required Powershell 5+ but more recent versions require 5.1 or newer