### PR TITLE
Updating cli docs for octo.exe

### DIFF
--- a/docs/api-and-integration/octo.exe-command-line/create-release.md
+++ b/docs/api-and-integration/octo.exe-command-line/create-release.md
@@ -117,9 +117,8 @@ Deployment:
                              build a query/filter with multiple tags, just
                              like you can in the user interface.
       --deployto=VALUE       [Optional] Environment to automatically deploy
-                             to, e.g., Production;
-                             specify this argument multiple times to deploy
-                             to multiple environments
+                             to, e.g., Production; specify this argument
+                             multiple times to deploy to multiple environments
 
 Common options:
 

--- a/docs/api-and-integration/octo.exe-command-line/dump-deployments.md
+++ b/docs/api-and-integration/octo.exe-command-line/dump-deployments.md
@@ -63,3 +63,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/import.md
+++ b/docs/api-and-integration/octo.exe-command-line/import.md
@@ -42,8 +42,6 @@ Common options:
                              enabled, a key of API-GUEST can be used. This
                              key can also be set in the OCTOPUS_CLI_API_KEY
                              environment variable.
-      --destinationPackageFeedSpaceId=VALUE
-                              [Optional] If not using the Spaces feature. The SpaceId of the Space where the package containing the data to migrate will be uploaded. This is only for the package the data in the package specifies the destination Space.
       --user=VALUE           [Optional] Username to use when authenticating
                              with the server. Your must provide an apiKey or
                              username and password. This Username can also be

--- a/docs/api-and-integration/octo.exe-command-line/list-deployments.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-deployments.md
@@ -72,3 +72,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-environments.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-environments.md
@@ -65,3 +65,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-latestdeployments.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-latestdeployments.md
@@ -68,3 +68,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-machines.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-machines.md
@@ -81,3 +81,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-releases.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-releases.md
@@ -66,3 +66,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-tenants.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-tenants.md
@@ -65,3 +65,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/push.md
+++ b/docs/api-and-integration/octo.exe-command-line/push.md
@@ -75,3 +75,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/version.md
+++ b/docs/api-and-integration/octo.exe-command-line/version.md
@@ -19,3 +19,4 @@ Common options:
                              [Optional] Output format for help, only valid
                              option is json
 ```
+


### PR DESCRIPTION
An automated update of the command line docs for octo.exe.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 34