### PR TITLE
Updating cli docs for octo.exe

### DIFF
--- a/docs/api-and-integration/octo.exe-command-line/clean-workerpool.md
+++ b/docs/api-and-integration/octo.exe-command-line/clean-workerpool.md
@@ -81,3 +81,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/create-workerpool.md
+++ b/docs/api-and-integration/octo.exe-command-line/create-workerpool.md
@@ -72,3 +72,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/delete-releases.md
+++ b/docs/api-and-integration/octo.exe-command-line/delete-releases.md
@@ -81,3 +81,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-projects.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-projects.md
@@ -66,3 +66,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-workerpools.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-workerpools.md
@@ -66,3 +66,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/list-workers.md
+++ b/docs/api-and-integration/octo.exe-command-line/list-workers.md
@@ -86,3 +86,4 @@ Common options:
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/api-and-integration/octo.exe-command-line/pack.md
+++ b/docs/api-and-integration/octo.exe-command-line/pack.md
@@ -67,3 +67,4 @@ Common options:
       --outputFormat=VALUE   [Optional] Output format, only valid option is
                              json
 ```
+


### PR DESCRIPTION
An automated update of the command line docs for octo.exe.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 35