### PR TITLE
Update compability of Octopus.Client/octo.exe for versions upto and including 2018.12

### DIFF
--- a/docs/api-and-integration/compatibility.md
+++ b/docs/api-and-integration/compatibility.md
@@ -12,7 +12,7 @@ The table below outlines the backward compatibility between Octopus Server and r
 | 3.3               | 3.3 ➜ latest           | 3.3              | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 3.4               | 3.3 ➜ latest           | 3.4              | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 3.5 ➜ 2018.2     | 3.3 ➜ latest           | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
-| 2018.2 ➜ 2018.12 | 4.30.7 ➜ latest        | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
+| 2018.2 ➜ 2018.12 | 4.30.7 ➜ 4.47.0        | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 2019.1* ➜ latest | 5.0.0 ➜ latest         | 3.5 ➜ latest    | 4.0 ➜ latest | coming soon      |
 
 ## &ast; Partial forwards compatibility

--- a/docs/api-and-integration/compatibility.md
+++ b/docs/api-and-integration/compatibility.md
@@ -9,11 +9,12 @@ The table below outlines the backward compatibility between Octopus Server and r
 | Octopus Server    | Octopus.Client Octo.exe | Calamari         | Tentacle      | TeamCity Plugin  |
 | --------------    | ----------------------- | ------------     | ------------  | ---------------  |
 | 3.2               | 3.2                     | 3.0 ➜ latest    | 3.2           |                  |
-| 3.3               | 3.3 ➜ latest           | 3.3              | 3.0 ➜ latest | 3.3 ➜ latest    |
-| 3.4               | 3.3 ➜ latest           | 3.4              | 3.0 ➜ latest | 3.3 ➜ latest    |
-| 3.5 ➜ 2018.2     | 3.3 ➜ latest           | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
+| 3.3               | 3.3 ➜ 4.30.3           | 3.3              | 3.0 ➜ latest | 3.3 ➜ latest    |
+| 3.4               | 3.3 ➜ 4.30.3           | 3.4              | 3.0 ➜ latest | 3.3 ➜ latest    |
+| 3.5 ➜ 2018.2     | 3.3 ➜ 4.30.3           | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 2018.2 ➜ 2018.12 | 4.30.7 ➜ 4.47.0        | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
-| 2019.1* ➜ latest | 5.0.0 ➜ latest         | 3.5 ➜ latest    | 4.0 ➜ latest | coming soon      |
+| 2019.1*           | 5.0.0 ➜ 5.2.7          | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
+| 2019.2* ➜ latest | 6.0.0 ➜ latest         | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
 
 ## &ast; Partial forwards compatibility
 


### PR DESCRIPTION
https://trello.com/c/jBuW0lx6/282-compatibility-matrix-in-docs-is-incorrect