### PR TITLE
Update index.md

### DIFF
--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -18,7 +18,7 @@ Octopus supports the following scripts:
 
 ## How Your Scripts are Bootstrapped by Calamari
 
-Each of your scripts will be bootstrapped by the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to provide access to variables and helper functions. You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari.Shared/tree/master/source/Calamari/Integration/Scripting).
+Each of your scripts will be bootstrapped by the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to provide access to variables and helper functions. You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting).
 
 ## Working Directories {#Customscripts-Workingdirectories}
 


### PR DESCRIPTION
fix the link. The original link for custom scripts bootstrapping is broken. Update the link to https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting.