### PR TITLE
Update machine policy docs to reflect model changes

### DIFF
--- a/docs/infrastructure/machine-policies.md
+++ b/docs/infrastructure/machine-policies.md
@@ -51,11 +51,15 @@ You can set the "Time between checks" to control how frequently automatic health
 
 ![](/docs/images/5669423/5865585.png)
 
+### Health Check Type {#MachinePolicies-Healthchecktype}
+
+You can configure health checks to run scripts on deployment targets, or just check that a connection can be established with the deployment target. When the "Run health check scripts" option is selected you will also have the opportunity to customize the PowerShell and Bash scripts that will be executed during the health check. The "Only perform connection test" option is recommended if you are using the raw scripting feature.
+
 ### Custom Health Check Scripts {#MachinePolicies-Customhealthcheckscripts}
 
-Machine policies allow the configuration of custom health check scripts for Tentacle and SSH targets. While we do not expose the full underlying script that runs during health checks, we give you an entry point to inject your own custom scripts. For example, here is the default custom health check script for Tentacles that checks disk space:
+Machine policies allow the configuration of custom health check scripts for Tentacle and SSH deployment targets. While we do not expose the full underlying script that runs during health checks, we give you an entry point to inject your own custom scripts. For example, here is the default custom health check script for PowerShell that checks disk space:
 
-**Default Tentacle Health Check Script**
+**Default PowerShell Health Check Script**
 
 ```powershell
 $freeDiskSpaceThreshold = 5GB
@@ -67,13 +71,13 @@ Try {
 }
 ```
 
-The function *CheckDriveCapacity* informs you about how much space is available on your Tentacle's local hard disk and will write a warning if the free disk space is less than this threshold. You can add additional PowerShell to this script to customize your health checks as you wish, modify or remove the disk space checking altogether. It's entirely up to you! Just remember, you can copy and paste the original script above *back* into your machine policy if you run into any problems and wish to get back to the default behavior.
+The function *CheckDriveCapacity* informs you about how much space is available on your deployment target's local hard disk and will write a warning if the free disk space is less than this threshold. You can add additional PowerShell to this script to customize your health checks as you wish, modify or remove the disk space checking altogether. It's entirely up to you! Just remember, you can copy and paste the original script above *back* into your machine policy if you run into any problems and wish to get back to the default behavior.
 
 ## Setting the Status
 
-A health check script can set the status of a target by returning a non-zero exit code or by writing a service message during the health check. Tentacle deployment targets can use *Write-Warning*, *Write-Error* and *Fail-HealthCheck* to convey a healthy with warnings or unhealthy status:
+A health check script can set the status of a target by returning a non-zero exit code or by writing a service message during the health check. PowerShell based deployment targets can use *Write-Warning*, *Write-Error* and *Fail-HealthCheck* to convey a healthy with warnings or unhealthy status:
 
-**Tentacle Health Check Service Messages**
+**PowerShell Health Check Service Messages**
 
 ```powershell
 # For setting a health status of Healthy with Warnings:
@@ -83,11 +87,11 @@ Write-Error "This is an error"
 Fail-HealthCheck "This is an error"
 ```
 
-SSH targets do not include a disk space check by default like Tentacle targets do. As such, there is no default Bash script listed in your machine policy for SSH targets by default. However, you may write your own, or choose to add additional Bash script to run against your SSH targets during health checks. Again, it's entirely up to you. Unless you select the `Only perform connection test` option, there are some [system prerequisites](/docs/infrastructure/deployment-targets/linux/requirements.md) that are included as part of the standard health check.
+Bash targets do not include a disk space check by default like PowerShell targets do. As such, there is no default Bash script listed in your machine policy for Bash targets by default. However, you may write your own, or choose to add additional Bash script to run against your Bash targets during health checks. Again, it's entirely up to you. Unless you select the `Only perform connection test` option, there are some [system prerequisites](/docs/infrastructure/deployment-targets/linux/requirements.md) that are included as part of the standard health check.
 
-SSH deployment targets can use *echo\_warning*, *echo\_error* and *fail\_healthcheck* to convey a *healthy with warnings* or *unhealthy* status:
+Bash deployment targets can use *echo\_warning*, *echo\_error* and *fail\_healthcheck* to convey a *healthy with warnings* or *unhealthy* status:
 
-**SSH Health Check Service Messages**
+**Bash Health Check Service Messages**
 
 ```bash
 # For setting a health status of Healthy with Warnings:
@@ -100,7 +104,7 @@ fail_healthcheck "This is an error"
 :::hint
 **Agent-Level Variables**
 
-When using a custom health check script, the script execution through Calamari is bypassed. This results in some behavioral differences as compared with the normal scripting in Octopus that you would be accustomed to. You can still use the standard `#` variable substitution syntax, however since this is replaced on the server, environment variables from your target will not be available through Octopus variables.
+When using a custom health check script, the script execution through Calamari is bypassed. This results in some behavioral differences compared with the normal scripting in Octopus that you would be accustomed to. You can still use the standard `#` variable substitution syntax, however since this is replaced on the server, environment variables from your target will not be available through Octopus variables.
 :::
 
 ## Ignore Machines That are Unavailable During Health Checks {#MachinePolicies-Ignoremachinesthatareunavailableduringhealthchecks}


### PR DESCRIPTION
Machine policy health checks are now customisable for Bash and PowerShell instead of for Tentacle and SSH.