### PR TITLE
Fix migrator partial-export command options

### DIFF
--- a/docs/api-and-integration/migration-api/index.md
+++ b/docs/api-and-integration/migration-api/index.md
@@ -71,7 +71,7 @@ Import API parameters:
 | Password=VALUE | Password that was used during the export migration _(This is the shared key between partial-export and import migrations)_ |
 | PackageId=VALUE | Package Name/ID that we are importing |
 | PackageVersion=VALUE | SemVer package version that we are importing |
-| DestinationPackageFeedSpaceId=VALUE | [Optional] If not using the Spaces feature. The SpaceID of the Space where the package containing the data to migrate will be uploaded. This is only for the package the data in the package specifies the destination Space. |
+| DestinationPackageFeedSpaceId=VALUE | [Optional] If using the Spaces feature, the ID of the Space where the package containing the data to migrate will be uploaded. This is only for the package; the data in the package specifies its own destination Space. |
 | IsEncryptedPackage | [Optional] Tells us whether the package was encrypted _(E.g. if you set `EncryptPackage` on export, you need to set this to `True`)_ |
 | IsDryRun | [Optional] Do not commit changes, just print what would have happened _(This allows you to test an import without actually committing the transaction)_ |
 | OverwriteExisting | [Optional] If a document with the same name already exists, it will be skipped by default |
@@ -127,7 +127,7 @@ Request Body:
 
 ### Spaces
 
-If you using the Spaces feature of Octopus Deploy on the source server, you should supply the appropriate SpaceID values in the example below. The destination Space cannot be specified it will match the Source. There are two values to supply:
+If you using the Spaces feature of Octopus Deploy on the source server, you should supply the appropriate SpaceID values in the example below. The destination Space cannot be specified; it will match the Source. There are two values to supply:
 
  1. The location to look for the Projects in the source Space.
  2. The Space that has the feed we’ll be pushing the exported package to.

--- a/docs/api-and-integration/octopus.migrator.exe-command-line/partial-export.md
+++ b/docs/api-and-integration/octopus.migrator.exe-command-line/partial-export.md
@@ -26,7 +26,6 @@ Partial export:
                                export.
       --project=VALUE        Project to filter export for
 
-      --sourceSpaceId=VALUE   [Optional] If not using the Spaces feature. The Space which houses the project's being exported
       --releaseVersion=VALUE [Optional] Release of provided project to filter
                                export for
       --ignore-deployments   [Optional] Excludes deployments from partial


### PR DESCRIPTION
- Remove the `--sourceSpaceId` option from the doco for the migrator's `partial-export` command. This option doesn't exist.
- Raised [via support](https://help.octopus.com/t/partial-export-with-sourcespaceid/23182)
- Also tweaked a related option description
