### PR TITLE
User feedback re Accessing ARM Template Output

### DIFF
--- a/docs/deployment-examples/azure-deployments/resource-groups/index.md
+++ b/docs/deployment-examples/azure-deployments/resource-groups/index.md
@@ -144,6 +144,7 @@ Any [outputs](https://azure.microsoft.com/en-us/documentation/articles/resource-
 ```powershell
 Octopus.Action[Arm Template Step Name].Output.AzureRmOutputs[Foo]
 ```
+Note, you need to replace **Arm Template Step Name** with the name of your ARM step template. 
 
 ### Using Linked Templates {#DeployusinganAzureResourceGroupTemplate-Usinglinkedtemplates}
 

--- a/docs/deployment-examples/azure-deployments/resource-groups/index.md
+++ b/docs/deployment-examples/azure-deployments/resource-groups/index.md
@@ -142,7 +142,7 @@ The Parameter JSON file can be in one of two formats:
 Any [outputs](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authoring-templates/#outputs) from the ARM template step are made available as [Octopus output-variables](/docs/deployment-process/variables/output-variables.md) automatically. For example, an output `Foo` would be available as:
 
 ```powershell
-Octopus.Action[ArmTemplateStepName].Output.AzureRMOutputs[Foo]
+Octopus.Action[Arm Template Step Name].Output.AzureRmOutputs[Foo]
 ```
 
 ### Using Linked Templates {#DeployusinganAzureResourceGroupTemplate-Usinglinkedtemplates}


### PR DESCRIPTION
Octopus.Action[ArmTemplateStepName].Output.AzureRMOutputs[Foo]

Should be:

Octopus.Action[Arm Template Step Name].Output.AzureRmOutputs[Foo]

Two mistakes, the spaces in the step name, and the casing of the m in RM. 

@robpearson or @benPearce1, if either one of you could confirm this, that would be very helpful.