### PR TITLE
Remove support for Ubuntu 14.04 LTS targets

### DIFF
--- a/docs/infrastructure/deployment-targets/linux/index.md
+++ b/docs/infrastructure/deployment-targets/linux/index.md
@@ -18,7 +18,6 @@ The following platforms are explicitly supported (we run automated tests against
 
 - Ubuntu 18.04 LTS
 - Ubuntu 16.04 LTS
-- Ubuntu 14.04 LTS
 - Redhat (RHEL) 7.2
 - Centos 7.6
 - Amazon Linux 2


### PR DESCRIPTION
- We're [upgrading Calamari to netcore 2.2](https://github.com/OctopusDeploy/Calamari/pull/402) and this is [not supported](https://github.com/dotnet/core/blob/master/release-notes/2.2/2.2-supported-os.md) by Ubuntu 14.04. Ubuntu 14.04 reached its [End of Standard Support](https://wiki.ubuntu.com/Releases) last month.
- This PR removes Ubuntu 14.04 from our list of [Supported Distributions](https://octopus.com/docs/infrastructure/deployment-targets/linux)
