### PR TITLE
Tentacle-Permissions-Update

### DIFF
--- a/docs/infrastructure/machine-policies.md
+++ b/docs/infrastructure/machine-policies.md
@@ -129,7 +129,7 @@ By default, Calamari will be installed or updated when a machine is involved in 
 Tentacle can be toggled to manually or automatically update Tentacle.  If **Automatically update Tentacle** is selected, Octopus will start a task to update Tentacles whenever Octopus detects that there is a pending Tentacle upgrade (after health checks for example). Conversely, Octopus will not automatically start a task to update Tentacle but will prompt to begin a Tentacle update on the environments screen.
 
 ### Tentacle Update Account {#MachinePolicies-TentacleUpdateAccount}
-You can select a username/password account to perform automatic Tentacle updates.  When no account is selected, the account that the Tentacle service is running as will attempt to perform Tentacle updates. Sometimes that account does not have enough permission to perform Tentacle updates. Create a [username/password account](/docs/infrastructure/accounts/ssh-key-pair.md) for a user with enough permissions to install software on your machines (Administrator works great!) and select it from the drop down.
+You can select a username/password account to perform automatic Tentacle updates.  When no account is selected, the account that the Tentacle service is running as will attempt to perform Tentacle updates. If this account is not an Administrator it will not have enough permission to perform Tentacle updates. In that scenario you will need to create a [username/password account](/docs/infrastructure/accounts/ssh-key-pair.md) for a user with administrative rights to install software on your machines and select it from the drop down.
 
 **Note:** This option can not be used when Tentacle is running as Local System.
 


### PR DESCRIPTION
Wording change to clarify that administrative rights are required for Tentacle upgrades.