### PR TITLE
Updated links to Microsoft PAT documentation

### DIFF
--- a/docs/packaging-applications/package-repositories/index.md
+++ b/docs/packaging-applications/package-repositories/index.md
@@ -45,8 +45,8 @@ Earlier releases of Octopus Deploy only support external NuGet v2 feeds:
 **Azure DevOps Package Feeds**
 If you are using Azure DevOps Package Management, Octopus can consume either the v2 or v3 NuGet feeds.
 
-- To connect to the v3 URL, you must use [a Personal Access Token](https://www.visualstudio.com/en-us/docs/integrate/get-started/auth/overview) in the password field. The username field is not checked, so you can put anything in here as long as it is not blank. Ensure that the PAT has (at least) the *Packaging (read)* scope.
-- To connect to the v2 URL, you can use either [alternate credentials or a Personal Access Token](https://www.visualstudio.com/en-us/docs/integrate/get-started/auth/overview) in the password field.
+- To connect to the v3 URL, you must use [a Personal Access Token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) in the password field. The username field is not checked, so you can put anything in here as long as it is not blank. Ensure that the PAT has (at least) the *Packaging (read)* scope.
+- To connect to the v2 URL, you can use either [alternate credentials or a Personal Access Token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) in the password field.
 :::
 
 :::warning


### PR DESCRIPTION
I updated the links in the Azure DevOps Package Feeds section. I couldn't find a good page for alternate credentials so I linked back to the PAT page.