### PR TITLE
 Added documentation to clarify the speed limit for calamari upgrades 

### DIFF
--- a/docs/infrastructure/deployment-targets/machine-policies.md
+++ b/docs/infrastructure/deployment-targets/machine-policies.md
@@ -132,7 +132,7 @@ Tentacle can be toggled to manually or automatically update Tentacle.  If **Aut
 
 There is a limit to the number of concurrent upgrades possible when choosing `Always keep Calamari up to date`, this is to ensure that upgrades to do not adversely effect the performance of your Octopus Server.
 
-The maximum number of concurrent upgrades is no less than 2 and no greater than 32, calculated by doubling your Octopus Servers logical processor count. 
+The number of concurrent upgrades will be double the Octopus Servers logical processor count. It will be a minimum of 2 and will not exceed 32.
 
 ### Tentacle Update Account {#MachinePolicies-TentacleUpdateAccount}
 You can select a username/password account to perform automatic Tentacle updates.  When no account is selected, the account that the Tentacle service is running as will attempt to perform Tentacle updates. If this account is not an Administrator it will not have enough permission to perform Tentacle updates. In that scenario you will need to create a [username/password account](/docs/infrastructure/deployment-targets/username-and-password.md) for a user with administrative rights to install software on your machines and select it from the drop down.

--- a/docs/infrastructure/deployment-targets/machine-policies.md
+++ b/docs/infrastructure/deployment-targets/machine-policies.md
@@ -128,6 +128,12 @@ By default, Calamari will be installed or updated when a machine is involved in 
 
 Tentacle can be toggled to manually or automatically update Tentacle.  If **Automatically update Tentacle** is selected, Octopus will start a task to update Tentacles whenever Octopus detects that there is a pending Tentacle upgrade (after health checks for example). Conversely, Octopus will not automatically start a task to update Tentacle but will prompt to begin a Tentacle update on the environments screen.
 
+### Maximum number of concurrent upgrades {#MachinePolicies-MaxCalamariUpgrades}
+
+There is a limit to the number of concurrent upgrades possible when choosing `Always keep Calamari up to date`, this is to ensure that upgrades to do not adversely effect the performance of your Octopus Server.
+
+The maximum number of concurrent upgrades is no less than 2 and no greater than 32, calculated by doubling your Octopus Servers [logical processor count.](https://docs.microsoft.com/en-us/dotnet/api/system.environment.processorcount?view=netframework-4.8) 
+
 ### Tentacle Update Account {#MachinePolicies-TentacleUpdateAccount}
 You can select a username/password account to perform automatic Tentacle updates.  When no account is selected, the account that the Tentacle service is running as will attempt to perform Tentacle updates. If this account is not an Administrator it will not have enough permission to perform Tentacle updates. In that scenario you will need to create a [username/password account](/docs/infrastructure/deployment-targets/username-and-password.md) for a user with administrative rights to install software on your machines and select it from the drop down.
 

--- a/docs/infrastructure/deployment-targets/machine-policies.md
+++ b/docs/infrastructure/deployment-targets/machine-policies.md
@@ -130,7 +130,7 @@ Tentacle can be toggled to manually or automatically update Tentacle.  If **Aut
 
 ### Maximum number of concurrent upgrades {#MachinePolicies-MaxCalamariUpgrades}
 
-There is a limit to the number of concurrent upgrades possible when choosing `Always keep Calamari up to date`, this is to ensure that upgrades to do not adversely effect the performance of your Octopus Server.
+There is a limit to the number of concurrent upgrades possible when choosing `Always keep Calamari up to date`. This ensures that upgrades do not adversely effect the performance of your Octopus Server.
 
 The number of concurrent upgrades will be double the Octopus Servers logical processor count. It will be a minimum of 2 and will not exceed 32.
 

--- a/docs/infrastructure/deployment-targets/machine-policies.md
+++ b/docs/infrastructure/deployment-targets/machine-policies.md
@@ -132,7 +132,7 @@ Tentacle can be toggled to manually or automatically update Tentacle.  If **Aut
 
 There is a limit to the number of concurrent upgrades possible when choosing `Always keep Calamari up to date`. This ensures that upgrades do not adversely effect the performance of your Octopus Server.
 
-The number of concurrent upgrades will be double the Octopus Servers logical processor count. It will be a minimum of 2 and will not exceed 32.
+The number of concurrent upgrades will be double the Octopus Server's logical processor count which is a minimum of 2 and will not exceed 32.
 
 ### Tentacle Update Account {#MachinePolicies-TentacleUpdateAccount}
 You can select a username/password account to perform automatic Tentacle updates.  When no account is selected, the account that the Tentacle service is running as will attempt to perform Tentacle updates. If this account is not an Administrator it will not have enough permission to perform Tentacle updates. In that scenario you will need to create a [username/password account](/docs/infrastructure/deployment-targets/username-and-password.md) for a user with administrative rights to install software on your machines and select it from the drop down.

--- a/docs/infrastructure/deployment-targets/machine-policies.md
+++ b/docs/infrastructure/deployment-targets/machine-policies.md
@@ -132,7 +132,7 @@ Tentacle can be toggled to manually or automatically update Tentacle.  If **Aut
 
 There is a limit to the number of concurrent upgrades possible when choosing `Always keep Calamari up to date`, this is to ensure that upgrades to do not adversely effect the performance of your Octopus Server.
 
-The maximum number of concurrent upgrades is no less than 2 and no greater than 32, calculated by doubling your Octopus Servers [logical processor count.](https://docs.microsoft.com/en-us/dotnet/api/system.environment.processorcount?view=netframework-4.8) 
+The maximum number of concurrent upgrades is no less than 2 and no greater than 32, calculated by doubling your Octopus Servers logical processor count. 
 
 ### Tentacle Update Account {#MachinePolicies-TentacleUpdateAccount}
 You can select a username/password account to perform automatic Tentacle updates.  When no account is selected, the account that the Tentacle service is running as will attempt to perform Tentacle updates. If this account is not an Administrator it will not have enough permission to perform Tentacle updates. In that scenario you will need to create a [username/password account](/docs/infrastructure/deployment-targets/username-and-password.md) for a user with administrative rights to install software on your machines and select it from the drop down.


### PR DESCRIPTION
I've added this to aid a customers support query regarding tentacle upgrades. 

'Logical processor count' refers to this value given by the .NET framework https://docs.microsoft.com/en-us/dotnet/api/system.environment.processorcount?view=netframework-4.8