### PR TITLE
Update apt + repo urls

### DIFF
--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -10,7 +10,7 @@ Welcome to Linux Tentacle early access. This page provides information about get
 
 - Octopus Server 2019.5.7 or newer
 
-Linux Tentacle is a .NET Core application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd). On most linux distributions it will "just work", but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md) that may need to be installed.
+Linux Tentacle is a .NET Core application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd). On most Linux distributions it will "just work", but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md) that may need to be installed.
 
 ## Known limitations
 

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -9,13 +9,11 @@ Welcome to Linux Tentacle early access. This page provides information about get
 ## Requirements
 
 - Octopus Server 2019.5.7 or newer
-- [.NET Core 2.x](https://docs.microsoft.com/en-us/dotnet/core/linux-prerequisites?tabs=netcore2x) installed on the Linux machine
 
 ## Known limitations
 
 Linux Tentacle is intended to provide feature parity with Windows Tentacle. The currently known limitations of Linux Tentacle are:
 
-- The Octopus portal does not have a Linux specific way to add Linux Tentacles. As a workaround, add the Tentacle using the Windows > Tentacle deployment target type.
 - PowerShell, C# and F# script types are not supported. The alternatives are Bash and Python scripts.
 - Automatic Tentacle upgrade is not currently supported for Linux Tentacle.
 

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -15,7 +15,7 @@ Welcome to Linux Tentacle early access. This page provides information about get
 Linux Tentacle is intended to provide feature parity with Windows Tentacle. The currently known limitations of Linux Tentacle are:
 
 - PowerShell, C# and F# script types are not supported. The alternatives are Bash and Python scripts.
-- Automatic Tentacle upgrade is not currently supported for Linux Tentacle.
+- Automatic Tentacle upgrade from the Octopus Server is not currently supported for Linux Tentacle.
 
 ## Downloads
 

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -10,6 +10,8 @@ Welcome to Linux Tentacle early access. This page provides information about get
 
 - Octopus Server 2019.5.7 or newer
 
+Linux Tentacle is a .NET Core application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#self-contained-deployments-scd). On most linux distributions it will "just work", but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md) that may need to be installed.
+
 ## Known limitations
 
 Linux Tentacle is intended to provide feature parity with Windows Tentacle. The currently known limitations of Linux Tentacle are:

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -28,21 +28,21 @@ Note that many of the steps described below must be run as a super user using `s
 
 ### Installing Tentacle
 ```bash Debian/Ubuntu repository
-apt-key adv --fetch-keys https://s3.amazonaws.com/octopus-apt-repo/public.key
-add-apt-repository "deb https://s3.amazonaws.com/octopus-apt-repo/ stretch main"
+apt-key adv --fetch-keys https://apt.octopus.com/public.key
+add-apt-repository "deb https://apt.octopus.com/ stretch main"
 apt-get update
 apt-get install tentacle
 ```
 
 ```bash CentOS/Fedora repository
-wget https://s3.amazonaws.com/octopus-rpm-repo/tentacle.repo -O /etc/yum.repos.d/tentacle.repo
+wget https://rpm.octopus.com/tentacle.repo -O /etc/yum.repos.d/tentacle.repo
 yum install tentacle
 ```
 
 ```bash Archive
 wget https://download.octopusdeploy.com/linux-tentacle/tentacle-5.0.0-beta14-linux_x64.tar.gz
 #or
-curl https://download.octopusdeploy.com/linux-tentacle/tentacle-5.0.0-beta14-linux_x64.tar.gz --output tentacle-5.0.0-beta1-linux_x64.tar.gz
+curl https://download.octopusdeploy.com/linux-tentacle/tentacle-5.0.0-beta14-linux_x64.tar.gz --output tentacle-5.0.0-beta14-linux_x64.tar.gz
 
 mkdir /opt/octopus
 tar xvzf tentacle-5.0.0-beta1-linux_x64.tar.gz -C /opt/octopus
@@ -101,8 +101,8 @@ Start the Tentacle interactively by running:
     ```
 
 
-## Quick start scripts
-The following bash scripts install, configure and register Linux Tentacle:
+## Automation scripts
+The following bash scripts install, configure and register Linux Tentacle for use in automated environments:
 
 !include <quickstart-debian>
 

--- a/docs/infrastructure/deployment-targets/linux/tentacle/quickstart-debian.include.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/quickstart-debian.include.md
@@ -10,8 +10,8 @@ role="web server"   # The role to assign to the Tentacle
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-apt-key adv --fetch-keys https://s3.amazonaws.com/octopus-apt-repo/public.key
-add-apt-repository "deb https://s3.amazonaws.com/octopus-apt-repo/ stretch main"
+apt-key adv --fetch-keys https://apt.octopus.com/public.key
+add-apt-repository "deb https://apt.octopus.com/ stretch main"
 apt-get update
 apt-get install tentacle
 
@@ -34,8 +34,8 @@ role="web server"   # The role to assign to the Tentacle
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-apt-key adv --fetch-keys https://s3.amazonaws.com/octopus-apt-repo/public.key
-add-apt-repository "deb https://s3.amazonaws.com/octopus-apt-repo/ stretch main"
+apt-key adv --fetch-keys https://apt.octopus.com/public.key
+add-apt-repository "deb https://apt.octopus.com/ stretch main"
 apt-get update
 apt-get install tentacle
 
@@ -56,8 +56,8 @@ workerPool="Default Worker Pool"    # The worker pool to register the Tentacle i
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-apt-key adv --fetch-keys https://s3.amazonaws.com/octopus-apt-repo/public.key
-add-apt-repository "deb https://s3.amazonaws.com/octopus-apt-repo/ stretch main"
+apt-key adv --fetch-keys https://apt.octopus.com/public.key
+add-apt-repository "deb https://apt.octopus.com/ stretch main"
 apt-get update
 apt-get install tentacle
 
@@ -79,8 +79,8 @@ workerPool="Default Worker Pool"    # The worker pool to register the Tentacle i
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-apt-key adv --fetch-keys https://s3.amazonaws.com/octopus-apt-repo/public.key
-add-apt-repository "deb https://s3.amazonaws.com/octopus-apt-repo/ stretch main"
+apt-key adv --fetch-keys https://apt.octopus.com/public.key
+add-apt-repository "deb https://apt.octopus.com/ stretch main"
 apt-get update
 apt-get install tentacle
 

--- a/docs/infrastructure/deployment-targets/linux/tentacle/quickstart-fedora.include.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/quickstart-fedora.include.md
@@ -10,7 +10,7 @@ role="web server"   # The role to assign to the Tentacle
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-curl https://s3.amazonaws.com/octopus-rpm-repo/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
+curl https://rpm.octopus.com/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
 yum install tentacle
 
 /opt/octopus/tentacle/Tentacle create-instance --config "$configFilePath"
@@ -32,7 +32,7 @@ role="web server"   # The role to assign to the Tentacle
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-curl https://s3.amazonaws.com/octopus-rpm-repo/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
+curl https://rpm.octopus.com/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
 yum install tentacle
 
 /opt/octopus/tentacle/Tentacle create-instance --config "$configFilePath"
@@ -52,7 +52,7 @@ workerPool="Default Worker Pool"    # The worker pool to register the Tentacle i
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-curl https://s3.amazonaws.com/octopus-rpm-repo/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
+curl https://rpm.octopus.com/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
 yum install tentacle
 
 /opt/octopus/tentacle/Tentacle create-instance --config "$configFilePath"
@@ -73,7 +73,7 @@ workerPool="Default Worker Pool"    # The worker pool to register the Tentacle i
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-curl https://s3.amazonaws.com/octopus-rpm-repo/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
+curl https://rpm.octopus.com/tentacle.repo -o /etc/yum.repos.d/tentacle.repo
 yum install tentacle
 
 /opt/octopus/tentacle/Tentacle create-instance --config "$configFilePath"


### PR DESCRIPTION
- Did a rename of "Quick start scripts" -> "Automation scripts"
- Removed net core instructions, I don't think it's actually a pre-req because we bundle
- Removed blurb about the portal not having a way to add linux Tentacle