### PR TITLE
Updating cli docs for octo.exe

### DIFF
--- a/docs/octopus-rest-api/octo.exe-command-line/clean-environment.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/clean-environment.md
@@ -94,6 +94,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/clean-workerpool.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/clean-workerpool.md
@@ -79,7 +79,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/create-autodeployoverride.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-autodeployoverride.md
@@ -79,6 +79,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/create-channel.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-channel.md
@@ -80,6 +80,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/create-environment.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-environment.md
@@ -68,6 +68,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/create-project.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-project.md
@@ -73,6 +73,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/create-release.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-release.md
@@ -177,6 +177,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/create-workerpool.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-workerpool.md
@@ -70,7 +70,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/delete-autodeployoverride.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/delete-autodeployoverride.md
@@ -77,6 +77,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/delete-releases.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/delete-releases.md
@@ -77,7 +77,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/deploy-release.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/deploy-release.md
@@ -138,6 +138,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/dump-deployments.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/dump-deployments.md
@@ -60,6 +60,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/export.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/export.md
@@ -74,6 +74,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/import.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/import.md
@@ -74,6 +74,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/index.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/index.md
@@ -29,8 +29,8 @@ We provide a number of ways to install Octo onto your machine:
 - **[delete-releases](/docs/octopus-rest-api/octo.exe-command-line/delete-releases.md)**:  Deletes a range of releases.
 - **[deploy-release](/docs/octopus-rest-api/octo.exe-command-line/deploy-release.md)**:  Deploys a release.
 - **[dump-deployments](/docs/octopus-rest-api/octo.exe-command-line/dump-deployments.md)**:  Writes deployments to an XML file that can be imported in Excel.
-- **[export](/docs/octopus-rest-api/octo.exe-command-line/export.md)**:  Exports an object to a JSON file.
-- **[import](/docs/octopus-rest-api/octo.exe-command-line/import.md)**:  Imports an Octopus object from an export file.
+- **[export](/docs/octopus-rest-api/octo.exe-command-line/export.md)**:  Exports an object to a JSON file. Deprecated. Please see [https://g.octopushq.com/DataMigration](https://g.octopushq.com/DataMigration) for alternative options.
+- **[import](/docs/octopus-rest-api/octo.exe-command-line/import.md)**:  Imports an Octopus object from an export file. Deprecated. Please see [https://g.octopushq.com/DataMigration](https://g.octopushq.com/DataMigration) for alternative options.
 - **[list-deployments](/docs/octopus-rest-api/octo.exe-command-line/list-deployments.md)**:  List a number of deployments by project, environment or by tenant.
 - **[list-environments](/docs/octopus-rest-api/octo.exe-command-line/list-environments.md)**:  List environments.
 - **[list-latestdeployments](/docs/octopus-rest-api/octo.exe-command-line/list-latestdeployments.md)**:  List the releases last-deployed in each environment.

--- a/docs/octopus-rest-api/octo.exe-command-line/list-deployments.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-deployments.md
@@ -69,6 +69,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/list-environments.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-environments.md
@@ -64,7 +64,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/list-latestdeployments.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-latestdeployments.md
@@ -65,6 +65,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/list-machines.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-machines.md
@@ -78,6 +78,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/list-projects.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-projects.md
@@ -64,7 +64,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/list-releases.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-releases.md
@@ -65,7 +65,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/list-tenants.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-tenants.md
@@ -62,6 +62,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/list-workerpools.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-workerpools.md
@@ -64,7 +64,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/list-workers.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/list-workers.md
@@ -84,7 +84,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/pack.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/pack.md
@@ -69,3 +69,4 @@ Common options:
       --outputFormat=VALUE   [Optional] Output format, only valid option is
                              json
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/promote-release.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/promote-release.md
@@ -137,6 +137,8 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.

--- a/docs/octopus-rest-api/octo.exe-command-line/push-metadata.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/push-metadata.md
@@ -81,7 +81,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+

--- a/docs/octopus-rest-api/octo.exe-command-line/push.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/push.md
@@ -86,7 +86,10 @@ Common options:
       --space=VALUE          [Optional] The name or ID of a space within
                              which this command will be executed. The default
                              space will be used if it is omitted.
+      --keepalive=VALUE      [Optional] How frequently (in seconds) to send a
+                             TCP keepalive packet.
       --logLevel=VALUE       [Optional] The log level. Valid options are
                              verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
+


### PR DESCRIPTION
An automated update of the command line docs for octo.exe.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 71