### PR TITLE
Added some documentation around debugging failed or hanging tasks

### DIFF
--- a/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -4,17 +4,17 @@ description: A guide for troubleshooting tasks that fail unexpectedly or are unr
 position: 8
 ---
 
-Sometimes your deployments, health checks, or other tasks may unexpectedly fail, or can even appear unresponsive. This page describes some common issues along with strategies to help you overcome them.
+Sometimes your deployments, health checks, or other tasks may unexpectedly fail, or can even appear unresponsive. This page describes some common issues and strategies to help you overcome these issues.
 
 ## Check the Logs
 
 The first step to debug your failed tasks is to check the [Task Log](docs/support/get-the-raw-output-from-a-task.md). This will usually contain detailed information about the failure. For deployments, this includes the step, and information about the deployment targets that the step was running on.
 
-If a deployment failed unexpectedly within a built-in step, you may have misconfigured the step. Double check the configuration of your step in your deployment process. If your step is relying on variables, then you may have also misconfigured your variables. There are [some methods](docs/support/debug-problems-with-octopus-variables.md) available that can help you debug your variables.
+If a deployment failed unexpectedly within a built-in step, you may have misconfigured the step. Double check the configuration of your [step](/docs/deployment-process/steps/index.md) in your [deployment process](/docs/deployment-process/index.md). If your step is relying on [variables](/docs/deployment-process/variables/index.md), then you may have also misconfigured your variables. There are [some methods](docs/support/debug-problems-with-octopus-variables.md) available that can help you debug your variables.
 
 If a task fails while executing a PowerShell script, you may be able to get more information by debugging the PowerShell script. You can easily [debug PowerShell scripts](docs/deployment-examples/custom-scripts/debugging-powershell-scripts/index.md) as they are executed by Tentacle.
 
-Manually running the failed script on the same target may often be a helpful step towards getting more useful error information, and helping to isolate the problem. Remember to run the script under the same user account as the Tentacle Service. This user is often the **Local System** account, but this may have been changed so that [Tentacle runs under a specific user account](docs/infrastructure/deployment-targets/windows-targets/running-tentacle-under-a-specific-user-account.md).
+Manually running the failed script on the same target may often be a helpful step towards getting more useful error information, and helping to isolate the problem. Remember to run the script under the same user account as the Tentacle service. This user is often the **Local System** account, but this may have been changed so that [Tentacle runs under a specific user account](docs/infrastructure/deployment-targets/windows-targets/running-tentacle-under-a-specific-user-account.md).
 
 If none of the above steps help, then you may have encountered a bug in a built-in step, in which case you can contact support for further assistance.
 
@@ -22,40 +22,40 @@ If none of the above steps help, then you may have encountered a bug in a built-
 
 If your task logs contain errors that indicate a networking issue, there could be a few possible causes.
 
-### Connections between Octopus Server and Tentacles
+### Connections Between Octopus Server and Tentacles
 
-Octopus Server communicates with Tentacles in either Listening mode or Polling mode. Both modes require different configuration. 
+The Octopus Server communicates with Tentacles in either Listening mode or Polling mode. Both modes require different configuration. 
 
 A common problem is that traffic on the appropriate ports (10933 by default for Listening Tentacles) is not allowed by your firewall. If you are encountering problems with your connections, then your Task log might show messages that indicate a connection timing out, or a connection that was rejected by the remote host.
 
-A utility called [TentaclePing](https://github.com/OctopusDeploy/TentaclePing) can be used to test and diagnose connections between the machine hosting Octopus Server and the machines hosting Tentacles. This allows you to quickly test connections in isolation, without involving the complexity of Octopus Server, Tentacles or tasks.
+A utility called [TentaclePing](https://github.com/OctopusDeploy/TentaclePing) can be used to test and diagnose connections between the machine hosting Octopus Server and the machines hosting Tentacles. This allows you to quickly test connections in isolation, without involving the complexity of Octopus Server, Tentacles, or tasks.
 
 See [Tentacle Communication Modes](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md) for more information on configuring your Tentacles.
 
 #### Halibut
 
-The tool that manages connections between Octopus Server and your Tentacles is called [Halibut](https://github.com/OctopusDeploy/Halibut/). In order to discover more detailed information about the connections, it may be useful to [increase the log level for Halibut](docs/support/log-files.md#Logfiles-Changingloglevelshalibut). The same change to increase the log level for Halibut can also be made on [Tentacle](docs/support/log-files.md#Logfiles-Changingloglevelstentacle).
+The tool that manages connections between the Octopus Server and your Tentacles is called [Halibut](https://github.com/OctopusDeploy/Halibut/). In order to discover more detailed information about the connections, it may be useful to [increase the log level for Halibut](docs/support/log-files.md#Logfiles-Changingloglevelshalibut). The same change to increase the log level for Halibut can also be made on [Tentacle](docs/support/log-files.md#Logfiles-Changingloglevelstentacle).
 
 ### Connections to External Services
 
-Steps that execute on Deployment Targets or Workers may need to reach out to contact other external services. In these cases, a useful first step to help diagnose the problem is to attempt to manually perform the same connection - this can help to isolate the problem to a networking issue rather than a problem with Octopus Deploy.
+Steps that execute on Deployment Targets or Workers may need to reach out to contact other external services. In these cases, a useful first step to help diagnose the problem is to attempt to manually perform the same connection, this can help to isolate the problem to a networking issue rather than a problem with Octopus Deploy.
 
-Remember that these connections are usually initiated by your Deployment Targets or Workers, and not by Octopus Server. You may need to remotely connect to these remote machines, and then initiate a connection from those machines. This is distinct from attempting to establish the connection on the machine that hosts Octopus Server itself.
+Remember these connections are usually initiated by your Deployment Targets or Workers, and not by the Octopus Server. You may need to remotely connect to these remote machines, and then initiate a connection from those machines. This is distinct from attempting to establish the connection on the machine that hosts Octopus Server itself.
 
 ## Hanging Tasks
 
-Sometimes tasks appear to be unresponsive or "hanging". In most cases, this ends up being anti-virus or anti-malware software interfering with the task, and the first step in diagnosing the problem is to eliminate this source of interference (see below). 
+Sometimes tasks appear to be unresponsive or "hanging". In most cases, this ends up being anti-virus or anti-malware software interfering with the task, and the first step in diagnosing the problem is to eliminate this source of interference, [see below](#anti-virus-software). 
 
-If you can completely rule out anti-virus software as a source of interference, then the problem may lie in your custom scripts. The next step to diagnosing these problems is to examine your logs and determine the exact location that the task became unresponsive. If this occurs within the logs output by a custom script, then the bug is likely to originate from your script.
+If you can completely rule out anti-virus software as a source of interference, then the problem may lie in your [custom scripts](/docs/deployment-examples/custom-scripts/index.md). The next step to diagnosing these problems is to examine your logs and determine the exact location that the task became unresponsive. If this occurs within the logs output by a custom script, then the bug likely originates from your script.
 
 If you are still unable to determine the cause of your hanging tasks, please contact support for further assistance.
 
-### Anti-virus Software
+### Anti-virus Software {#anti-virus-software}
 
-If the task appears to hang after a log message output by Octopus Server or Tentacle, then in most cases the cause is anti-virus or anti-malware software interfering with the task. The first step is to determine if your anti-virus software is actually affecting your Tasks, and this can easily be done by removing your anti-virus protection and confirming whether the tasks continue to be unresponsive.
+If the task appears to hang after a log message output by the Octopus Server or Tentacle, then in most cases the cause is anti-virus or anti-malware software interfering with the task. The first step is to determine if your anti-virus software is actually affecting your Tasks, and this can easily be done by removing your anti-virus protection and confirming whether the tasks continue to be unresponsive.
 
 If this test shows that anti-virus is interfering with your tasks, you may need to configure your anti-virus software with the appropriate exclusions to ensure that it does not lock any files owned by Octopus, or affect any running processes initiated by Octopus. Consult your anti-virus provider's documentation for more information.
 
 ## Steps Are Slow to Start
 
-If you notice that your PowerShell script or built in steps take a while to begin execution, and the time is consistent across your steps, then you may have something in your Tentacle user's PowerShell profile which is causing PowerShell to take a long time to initialize. Add the `Octopus.Action.PowerShell.ExecuteWithoutProfile` variable to your deployment to help diagnose this problem. See [System Variables](docs/deployment-process/variables/system-variables.md#Systemvariables-User-modifiablesettings) for more information.
+If you notice that your PowerShell script or built-in steps take a while to begin execution, and the time is consistent across your steps, then you may have something in your Tentacle user's PowerShell profile which is causing PowerShell to take a long time to initialize. Add the `Octopus.Action.PowerShell.ExecuteWithoutProfile` variable to your deployment to help diagnose this problem. See [System Variables](docs/deployment-process/variables/system-variables.md#Systemvariables-User-modifiablesettings) for more information.

--- a/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -58,4 +58,4 @@ If this test shows that anti-virus is interfering with your tasks, you may need 
 
 ## Steps Are Slow to Start
 
-If you notice that your PowerShell script or built in steps take a while to begin execution, and the time is consistent across your steps, then you may have something in your Tentacle user's PowerShell profile which is causing PowerShell to take a long time to initialize. Add the `Octopus.Action.PowerShell.ExecuteWithoutProfile` variable to your deployment to help diagnose this problem. See [System Variables](docs/deployment-process/variables/system-variables#Systemvariables-User-modifiablesettings) for more information.
+If you notice that your PowerShell script or built in steps take a while to begin execution, and the time is consistent across your steps, then you may have something in your Tentacle user's PowerShell profile which is causing PowerShell to take a long time to initialize. Add the `Octopus.Action.PowerShell.ExecuteWithoutProfile` variable to your deployment to help diagnose this problem. See [System Variables](docs/deployment-process/variables/system-variables.md#Systemvariables-User-modifiablesettings) for more information.

--- a/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -12,6 +12,10 @@ The first step to debug your failed tasks is to check the [Task Log](docs/suppor
 
 If a deployment failed unexpectedly within a built-in step, you may have misconfigured the step. Double check the configuration of your step in your deployment process. If your step is relying on variables, then you may have also misconfigured your variables. There are [some methods](docs/support/debug-problems-with-octopus-variables.md) available that can help you debug your variables.
 
+If a task fails while executing a PowerShell script, you may be able to get more information by debugging the PowerShell script. You can easily [debug PowerShell scripts](docs/deployment-examples/custom-scripts/debugging-powershell-scripts/index.md) as they are executed by Tentacle.
+
+Manually running the failed script on the same target may often be a helpful step towards getting more useful error information, and helping to isolate the problem. Remember to run the script under the same user account as the Tentacle Service. This user is often the **Local System** account, but this may have been changed so that [Tentacle runs under a specific user account](docs/infrastructure/deployment-targets/windows-targets/running-tentacle-under-a-specific-user-account.md).
+
 If none of the above steps help, then you may have encountered a bug in a built-in step, in which case you can contact support for further assistance.
 
 ## Networking Errors
@@ -23,6 +27,8 @@ If your task logs contain errors that indicate a networking issue, there could b
 Octopus Server communicates with Tentacles in either Listening mode or Polling mode. Both modes require different configuration. 
 
 A common problem is that traffic on the appropriate ports (10933 by default for Listening Tentacles) is not allowed by your firewall. If you are encountering problems with your connections, then your Task log might show messages that indicate a connection timing out, or a connection that was rejected by the remote host.
+
+A utility called [TentaclePing](https://github.com/OctopusDeploy/TentaclePing) can be used to test and diagnose connections between the machine hosting Octopus Server and the machines hosting Tentacles. This allows you to quickly test connections in isolation, without involving the complexity of Octopus Server, Tentacles or tasks.
 
 See [Tentacle Communication Modes](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md) for more information on configuring your Tentacles.
 

--- a/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -36,7 +36,7 @@ See [Tentacle Communication Modes](docs/infrastructure/deployment-targets/window
 
 The tool that manages connections between Octopus Server and your Tentacles is called [Halibut](https://github.com/OctopusDeploy/Halibut/). In order to discover more detailed information about the connections, it may be useful to [increase the log level for Halibut](docs/support/log-files.md#Logfiles-Changingloglevelshalibut). The same change to increase the log level for Halibut can also be made on [Tentacle](docs/support/log-files.md#Logfiles-Changingloglevelstentacle).
 
-### Connections to external services
+### Connections to External Services
 
 Steps that execute on Deployment Targets or Workers may need to reach out to contact other external services. In these cases, a useful first step to help diagnose the problem is to attempt to manually perform the same connection - this can help to isolate the problem to a networking issue rather than a problem with Octopus Deploy.
 
@@ -50,8 +50,12 @@ If you can completely rule out anti-virus software as a source of interference, 
 
 If you are still unable to determine the cause of your hanging tasks, please contact support for further assistance.
 
-### Anti-virus software
+### Anti-virus Software
 
 If the task appears to hang after a log message output by Octopus Server or Tentacle, then in most cases the cause is anti-virus or anti-malware software interfering with the task. The first step is to determine if your anti-virus software is actually affecting your Tasks, and this can easily be done by removing your anti-virus protection and confirming whether the tasks continue to be unresponsive.
 
 If this test shows that anti-virus is interfering with your tasks, you may need to configure your anti-virus software with the appropriate exclusions to ensure that it does not lock any files owned by Octopus, or affect any running processes initiated by Octopus. Consult your anti-virus provider's documentation for more information.
+
+## Steps Are Slow to Start
+
+If you notice that your PowerShell script or built in steps take a while to begin execution, and the time is consistent across your steps, then you may have something in your Tentacle user's PowerShell profile which is causing PowerShell to take a long time to initialize. Add the `Octopus.Action.PowerShell.ExecuteWithoutProfile` variable to your deployment to help diagnose this problem. See [System Variables](docs/deployment-process/variables/system-variables#Systemvariables-User-modifiablesettings) for more information.

--- a/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -28,7 +28,7 @@ See [Tentacle Communication Modes](docs/infrastructure/deployment-targets/window
 
 #### Halibut
 
-The tool that manages connections between Octopus Server and your Tentacles is called Halibut. In order to discover more detailed information about the connections, it may be useful to [increase the log level for Halibut](docs/support/log-files.md#Logfiles-Changingloglevelshalibut). The same change to increase the log level for Halibut can also be made on [Tentacle](docs/support/log-files.md#Logfiles-Changingloglevelstentacle).
+The tool that manages connections between Octopus Server and your Tentacles is called [Halibut](https://github.com/OctopusDeploy/Halibut/). In order to discover more detailed information about the connections, it may be useful to [increase the log level for Halibut](docs/support/log-files.md#Logfiles-Changingloglevelshalibut). The same change to increase the log level for Halibut can also be made on [Tentacle](docs/support/log-files.md#Logfiles-Changingloglevelstentacle).
 
 ### Connections to external services
 
@@ -38,7 +38,7 @@ Remember that these connections are usually initiated by your Deployment Targets
 
 ## Hanging Tasks
 
-Sometimes tasks appear to be unresponsive or "hanging". The first step to diagnosing these problems is to examine your logs and determine the exact location that the task become unresponsive. If this occurs within the logs output by a custom script, then the bug is likely to originate from your script.
+Sometimes tasks appear to be unresponsive or "hanging". The first step to diagnosing these problems is to examine your logs and determine the exact location that the task became unresponsive. If this occurs within the logs output by a custom script, then the bug is likely to originate from your script.
 
 ### Anti-virus software
 

--- a/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -44,12 +44,14 @@ Remember that these connections are usually initiated by your Deployment Targets
 
 ## Hanging Tasks
 
-Sometimes tasks appear to be unresponsive or "hanging". The first step to diagnosing these problems is to examine your logs and determine the exact location that the task became unresponsive. If this occurs within the logs output by a custom script, then the bug is likely to originate from your script.
+Sometimes tasks appear to be unresponsive or "hanging". In most cases, this ends up being anti-virus or anti-malware software interfering with the task, and the first step in diagnosing the problem is to eliminate this source of interference (see below). 
+
+If you can completely rule out anti-virus software as a source of interference, then the problem may lie in your custom scripts. The next step to diagnosing these problems is to examine your logs and determine the exact location that the task became unresponsive. If this occurs within the logs output by a custom script, then the bug is likely to originate from your script.
+
+If you are still unable to determine the cause of your hanging tasks, please contact support for further assistance.
 
 ### Anti-virus software
 
-If the task appears to hang after a log message output by Octopus Server or Tentacle, then the cause may be anti-virus software interfering with the task.
-
-The first step is to determine if your anti-virus software is actually affecting your Tasks, and this can easily be done by disabling your anti-virus protection and confirming whether the tasks continue to be unresponsive.
+If the task appears to hang after a log message output by Octopus Server or Tentacle, then in most cases the cause is anti-virus or anti-malware software interfering with the task. The first step is to determine if your anti-virus software is actually affecting your Tasks, and this can easily be done by removing your anti-virus protection and confirming whether the tasks continue to be unresponsive.
 
 If this test shows that anti-virus is interfering with your tasks, you may need to configure your anti-virus software with the appropriate exclusions to ensure that it does not lock any files owned by Octopus, or affect any running processes initiated by Octopus. Consult your anti-virus provider's documentation for more information.

--- a/docs/support/troubleshooting-hanging-tasks.md
+++ b/docs/support/troubleshooting-hanging-tasks.md
@@ -1,0 +1,49 @@
+---
+title: Troubleshooting Failed or Hanging Tasks
+description: A guide for troubleshooting tasks that fail unexpectedly or are unresponsive
+position: 8
+---
+
+Sometimes your deployments, health checks, or other tasks may unexpectedly fail, or can even appear unresponsive. This page describes some common issues along with strategies to help you overcome them.
+
+## Check the Logs
+
+The first step to debug your failed tasks is to check the [Task Log](docs/support/get-the-raw-output-from-a-task.md). This will usually contain detailed information about the failure. For deployments, this includes the step, and information about the deployment targets that the step was running on.
+
+If a deployment failed unexpectedly within a built-in step, you may have misconfigured the step. Double check the configuration of your step in your deployment process. If your step is relying on variables, then you may have also misconfigured your variables. There are [some methods](docs/support/debug-problems-with-octopus-variables.md) available that can help you debug your variables.
+
+If none of the above steps help, then you may have encountered a bug in a built-in step, in which case you can contact support for further assistance.
+
+## Networking Errors
+
+If your task logs contain errors that indicate a networking issue, there could be a few possible causes.
+
+### Connections between Octopus Server and Tentacles
+
+Octopus Server communicates with Tentacles in either Listening mode or Polling mode. Both modes require different configuration. 
+
+A common problem is that traffic on the appropriate ports (10933 by default) is not allowed by your firewall. If you are encountering problems with your connections, then your Task log might show messages that indicate a connection timing out, or a connection that was rejected by the remote host.
+
+See [Tentacle Communication Modes](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md) for more information on configuring your Tentacles.
+
+#### Halibut
+
+The tool that manages connections between Octopus Server and your Tentacles is called Halibut. In order to discover more detailed information about the connections, it may be useful to [increase the log level for Halibut](docs/support/log-files.md#Logfiles-Changingloglevelshalibut). The same change to increase the log level for Halibut can also be made on [Tentacle](docs/support/log-files.md#Logfiles-Changingloglevelstentacle).
+
+### Connections to external services
+
+Steps that execute on Deployment Targets or Workers may need to reach out to contact other external services. In these cases, a useful first step to help diagnose the problem is to attempt to manually perform the same connection - this can help to isolate the problem to a networking issue rather than a problem with Octopus Deploy.
+
+Remember that these connections are usually initiated by your Deployment Targets or Workers, and not by Octopus Server. You may need to remotely connect to these remote machines, and then initiate a connection from those machines. This is distinct from attempting to establish the connection on the machine that hosts Octopus Server itself.
+
+## Hanging Tasks
+
+Sometimes tasks appear to be unresponsive or "hanging". The first step to diagnosing these problems is to examine your logs and determine the exact location that the task become unresponsive. If this occurs within the logs output by a custom script, then the bug is likely to originate from your script.
+
+### Anti-virus software
+
+If the task appears to hang after a log message output by Octopus Server or Tentacle, then the cause may be anti-virus software interfering with the task.
+
+The first step is to determine if your anti-virus software is actually affecting your Tasks, and this can easily be done by disabling your anti-virus protection and confirming whether the tasks continue to be unresponsive.
+
+If this test shows that anti-virus is interfering with your tasks, you may need to configure your anti-virus software with the appropriate exclusions to ensure that it does not lock any files owned by Octopus, or affect any running processes initiated by Octopus. Consult your anti-virus provider's documentation for more information.

--- a/docs/support/troubleshooting-hanging-tasks.md
+++ b/docs/support/troubleshooting-hanging-tasks.md
@@ -22,7 +22,7 @@ If your task logs contain errors that indicate a networking issue, there could b
 
 Octopus Server communicates with Tentacles in either Listening mode or Polling mode. Both modes require different configuration. 
 
-A common problem is that traffic on the appropriate ports (10933 by default) is not allowed by your firewall. If you are encountering problems with your connections, then your Task log might show messages that indicate a connection timing out, or a connection that was rejected by the remote host.
+A common problem is that traffic on the appropriate ports (10933 by default for Listening Tentacles) is not allowed by your firewall. If you are encountering problems with your connections, then your Task log might show messages that indicate a connection timing out, or a connection that was rejected by the remote host.
 
 See [Tentacle Communication Modes](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md) for more information on configuring your Tentacles.
 


### PR DESCRIPTION
A recent theme in support is around hanging tasks. Often this is anti-virus. A docs page explaining some common debugging steps could go a long way to deflecting these kinds of support issues, and this PR is an attempt at adding that page. At the same time, common debugging techniques for failed tasks feels like a cohesive addition to this page.