### PR TITLE
Add comma in simple variable transform example

### DIFF
--- a/docs/shared-content/json-configuration-variables.include.md
+++ b/docs/shared-content/json-configuration-variables.include.md
@@ -34,7 +34,7 @@ If you define the [variables](/docs/deployment-process/variables/index.md) `weat
    "weatherApiUrl": "test.weather.com",
    "weatherApiKey": "TEST7654321",
    "tempImageFolder": "C:\temp\img",
-   "port": 80
+   "port": 80,
    "debug": false
 }
 ```


### PR DESCRIPTION
There was a comma missing in the json example for the simple variable transform -- I added it here.