### PR TITLE
Update to unit file

### DIFF
--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -78,7 +78,7 @@ Start the Tentacle interactively by running:
     [Service]
     Type=simple
     User=root
-    WorkingDirectory=/etc/octopus/default/
+    WorkingDirectory=/etc/octopus/tentacle/
     ExecStart=/opt/octopus/tentacle/Tentacle run --instance <instance name> --noninteractive
     Restart=always
 


### PR DESCRIPTION
Following the doco to set up the Linux tentacle as a service, I found that the service would not start because of the working directory didn't exist.  Changing the working directory from default to tentacle allowed my Linux tentacle to start correctly as a service.  Being a Linux noob, it is entirely possible that I did something incorrect during the installation process, which is why I'm requesting a review of the change.