### PR TITLE
Expand info on where instance configuration is stored

### DIFF
--- a/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
+++ b/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
@@ -49,7 +49,7 @@ This will also remove your deployed applications if you have not configured Tent
 :::
 4. Find and delete the Octopus registry entries from **`HKLM\SOFTWARE\Octopus`**.
 5. Find and delete any Octopus folders from:
-    * **`%ProgramData%\Octopus`** - could be used for log files when a Home Directory cannot be discovered
+    * **`%ProgramData%\Octopus`** - used for storing instance configuration and can be used for log files when a Home Directory cannot be discovered
     * **`%LocalAppData%\Octopus`** - could be used for log files when a Home Directory cannot be discovered
 6. Find and delete any Octopus certificates from the following certificate stores:
     * **`Local Computer\Octopus`**


### PR DESCRIPTION
I'd originally thought that the docs on manual uninstalls weren't updated after the instance store was changed to be on the file system.

After looking closer, it did cover it, but I've expanded it a tiny bit to be clearer.