### PR TITLE
ServerNodeName arg has moved to create-instance

### DIFF
--- a/docs/installation/automating-installation.md
+++ b/docs/installation/automating-installation.md
@@ -25,9 +25,9 @@ Save the script into a new file.
 
 Here is an example of what the script might look like:
 ```bash
-"[INSTALLLOCATION]\Octopus.Server.exe" create-instance --instance "<instance name>" --config "<new instance config path>"
+"[INSTALLLOCATION]\Octopus.Server.exe" create-instance --instance "<instance name>" --config "<new instance config path>" --serverNodeName "<machine name>"
 "[INSTALLLOCATION]\Octopus.Server.exe" database --instance "<instance name>" --connectionString "<database connection string>" --create
-"[INSTALLLOCATION]\Octopus.Server.exe" configure --instance "<instance name>" --upgradeCheck "True" --upgradeCheckWithStatistics "True" --usernamePasswordIsEnabled "True" --webForceSSL "False" --webListenPrefixes "<url to expose>" --commsListenPort "10943" --serverNodeName "<machine name>"
+"[INSTALLLOCATION]\Octopus.Server.exe" configure --instance "<instance name>" --upgradeCheck "True" --upgradeCheckWithStatistics "True" --usernamePasswordIsEnabled "True" --webForceSSL "False" --webListenPrefixes "<url to expose>" --commsListenPort "10943"
 "[INSTALLLOCATION]\Octopus.Server.exe" service --instance "<instance name>" --stop
 "[INSTALLLOCATION]\Octopus.Server.exe" admin --instance "<instance name>" --username "<admin username>" --email "<admin email>" --password "<admin password>"
 "[INSTALLLOCATION]\Octopus.Server.exe" license --instance "<instance name>" --licenseBase64 "<a very long license string>"

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -19,8 +19,9 @@ Where [<options>] is any of:
       --skipDatabaseSchemaUpgradeCheck
                              Skips the database schema upgrade checks. Use
                                with caution
-      --serverNodeName=VALUE Unique Server Node name for a clustered
-                               environment
+      --serverNodeName=VALUE Deprecated: set the node name via the create-
+                               instance command instead. Unique Server Node
+                               name for a clustered environment.
       --cachePackages=VALUE  Days to cache packages for. Default: 20
       --maxConcurrentTasks=VALUE
                              Deprecated: may be removed in a future release

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/create-instance.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/create-instance.md
@@ -16,6 +16,9 @@ Where [<options>] is any of:
       --config=VALUE         Path to configuration file to create
       --home=VALUE           [Optional] Path to the home directory - defaults
                                to the same directory as the config file
+      --serverNodeName=VALUE [Optional] Unique Server Node name for a
+                               clustered environment - defaults to the machine
+                               name
 
 Or one of the common options:
 


### PR DESCRIPTION
Updates the automated install instructions, and also the `create-instance` and `configure` command docs.

Relates to https://github.com/OctopusDeploy/Issues/issues/5793

Pulls in some of the changes from https://github.com/OctopusDeploy/docs/pull/510, which is currently blocked.