### PR TITLE
Telling the customer why the should care about custom scripts

### DIFF
--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -24,7 +24,7 @@ If an activity can be scripted, Octopus can run that script as a standalone acti
 
 In the context of Octopus, your custom scripts get the following extra benefits:
 
- - Your script can use [variables](/docs/deployment-process/variables/index.md) managed by Octopus, including [secrets](/docs/deployment-process/variables/sensitive-variables.md), [complex variable expressions](docs/deployment-process/variables/variable-substitutions.md), and [filters](/docs/deployment-process/variables/variable-filters.md). Learn about [using variables in scripts](using-variables-in-scripts.md).
+ - Your scripts can use [variables](/docs/deployment-process/variables/index.md) managed by Octopus, including [secrets](/docs/deployment-process/variables/sensitive-variables.md), [complex variable expressions](docs/deployment-process/variables/variable-substitutions.md), and [filters](/docs/deployment-process/variables/variable-filters.md). Learn about [using variables in scripts](using-variables-in-scripts.md).
  - Your script can be executed across your entire fleet of servers, or a selection of servers, in a controlled fashion. Learn about [deployment targets](/docs/infrastructure/deployment-targets/index.md) and [workers](/docs/infrastructure/workers/index.md).
  - Your script can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -57,7 +57,7 @@ Octopus can execute scripts from a variety of locations, all with different bene
 
 The precise details depend on the context within which your script is running, however, Octopus follows this general process:
 
- 1. Octopus transfers the script to the execution environment along with variables, packages, script modules, and anything else required to run the script. This is done via the Tentacle agent or SSH session into a temporary work directory.
+ 1. Octopus transfers the script to the execution environment along with the variables, packages, script modules, and anything else required to run the script. This is done via the Tentacle agent or SSH session into a temporary work directory.
  2. The Tentacle agent or SSH session invokes the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to bootstrap your script providing access to variables and helper functions. _You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting)._
  3. Calamari invokes your script, streaming log messages back to the Octopus Server.
  4. Any artifacts published by your script are transferred back to the Octopus Server.

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -60,7 +60,7 @@ The precise details depend on the context within which your script is running, h
  1. Octopus transfers the script to the execution environment along with the variables, packages, script modules, and anything else required to run the script. This is done via the Tentacle agent or SSH session into a temporary work directory.
  2. The Tentacle agent or SSH session invokes the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to bootstrap your script providing access to variables and helper functions. _You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting)._
  3. Calamari invokes your script, streaming log messages back to the Octopus Server.
- 4. Any artifacts published by your script are transferred back to the Octopus Server.
+ 4. Any artifacts published by your scripts are transferred back to the Octopus Server.
  5. The temporary work directory is cleaned up.
 
 ### Working Directories {#Customscripts-Workingdirectories}

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -4,7 +4,7 @@ description: Custom scripts allows you to script anything you want using PowerSh
 position: 50
 ---
 
-As a convention-oriented deployment tool, Octopus can perform a number of actions automatically, such as deploying and configuring common types of applications to popular hosting environments. In these situations, we have built everything you need into Octopus. Sometimes however you’ll need to do more than the built-in conventions support, and that’s where custom scripts come in.
+As a convention-oriented deployment tool, Octopus can perform a number of actions automatically, such as configuring common types of applications and deploying them to popular hosting environments. For these situations, we have built everything you need into Octopus. Sometimes, however, you need to do more than the built-in conventions support, and that’s where custom scripts come in.
 
 ## Supported Script Types
 
@@ -58,7 +58,7 @@ Octopus can execute scripts from a variety of locations, all with different bene
 The precise details depend on the context within which your script is running, however, Octopus follows this general process:
 
  1. Octopus transfers the script to the execution environment along with the variables, packages, script modules, and anything else required to run the script. This is done via the Tentacle agent or SSH session into a temporary work directory.
- 2. The Tentacle agent or SSH session invokes the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to bootstrap your script providing access to variables and helper functions. _You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting)._
+ 2. The Tentacle agent or SSH session invokes the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to bootstrap your script and provide access to variables and helper functions. _You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting)._
  3. Calamari invokes your script, streaming log messages back to the Octopus Server.
  4. Any artifacts published by your scripts are transferred back to the Octopus Server.
  5. The temporary work directory is cleaned up.
@@ -71,7 +71,7 @@ If you're executing a script contained within a package, the package contents wi
 
 ### Security and Permissions {#Customscripts-Securityandpermissions}
 
-Keep in mind that scripts are executed in the context of the account that the Tentacle agent or SSH session runs as. Learn about [running Tentacle as a different user account](/docs/infrastructure/deployment-targets/windows-targets/running-tentacle-under-a-specific-user-account.md).
+When scripts are executed, it is in the context of the account that the Tentacle agent or SSH session is running as. Learn about [running Tentacle as a different user account](/docs/infrastructure/deployment-targets/windows-targets/running-tentacle-under-a-specific-user-account.md).
 
 :::hint
 On Windows, the Tentacle agent runs as **Local System** by default, which has extensive local privileges, but usually cannot access file shares, remote SQL databases, or other external resources. If you need wider permissions, you’ll need to configure Tentacle to [run under a custom user account](/docs/infrastructure/deployment-targets/windows-targets/running-tentacle-under-a-specific-user-account.md).
@@ -90,7 +90,7 @@ Learn about [script integrity](/docs/administration/security/script-integrity.md
 We recommend the following approaches for developing and testing your scripts, in order of preference:
 
  1. Build your script to use script arguments as inputs so it can be invoked with equal fidelity from Octopus or directly in your development environment. You can test your scripts by invoking them directly in a development environment with a very fast feedback cycle. Learn about [passing parameters to scripts](passing-parameters-to-scripts.md). The only difference in this approach may be the user context the script runs in.
- 2. Build your script as a reusable step template and test it using the `Run Now` feature. [Learn about step templates](/docs/deployment-process/steps/custom-step-templates.md). The only difference to this approach is the absence of some deployment-specific variables provided by Octopus when actually running a deployment.
+ 2. Build your script as a reusable step template and test it using the `Run Now` feature. [Learn about step templates](/docs/deployment-process/steps/custom-step-templates.md). The only difference to this approach is the absence of deployment-specific variables provided by Octopus when actually running a deployment.
  3. Put your script in a test process and run that process in a test environment.
  4. Put your script in a real process and run that process in a test environment.
 

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -32,7 +32,7 @@ In the context of Octopus, your custom scripts get the following extra benefits:
  - Your script can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).
  - Your script can be pre-authenticated and bootstrapped into a cloud provider. Learn about [AWS CLI scripts](aws-cli-scripts.md) and [Azure CLI scripts](azure-powershell-scripts.md).
  - Your script can be pre-authenticated and bootstrapped into an external service or server cluster. Learn about [Kubernetes deployments](/docs/deployment-examples/kubernetes-deployments/index.md) and [Service Fabric deployments](/docs/deployment-examples/azure-deployments/service-fabric/index.md).
- - Your can define reusable functions for your scripts to use. Learn about [script modules](docs/deployment-examples/custom-scripts/script-modules.md).
+ - You can define reusable functions for your scripts to use. Learn about [script modules](docs/deployment-examples/custom-scripts/script-modules.md).
 
 ## How To Use Custom Scripts
 

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -55,7 +55,7 @@ Octopus can execute scripts from a variety of locations, all with different bene
 
 ## How Your Scripts are Executed by Octopus
 
-The precise details depend on the context within which your script is running, however Octopus follows this general process:
+The precise details depend on the context within which your script is running, however, Octopus follows this general process:
 
  1. Octopus transfers the script to the execution environment along with variables, packages, script modules, and anything else required to run the script. This is done via the Tentacle agent or SSH session into a temporary work directory.
  2. The Tentacle agent or SSH session invokes the [open-source Calamari project](https://github.com/OctopusDeploy/Calamari) to bootstrap your script providing access to variables and helper functions. _You can see how your scripts are bootstrapped in the [Calamari source code](https://github.com/OctopusDeploy/Calamari/blob/master/source/Calamari.Shared/Integration/Scripting)._

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -31,7 +31,7 @@ In the context of Octopus, your custom scripts get the following extra benefits:
  - Your scripts can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).
  - Your scripts can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).
  - Your scripts can be pre-authenticated and bootstrapped into a cloud provider. Learn about [AWS CLI scripts](aws-cli-scripts.md) and [Azure CLI scripts](azure-powershell-scripts.md).
- - Your script can be pre-authenticated and bootstrapped into an external service or server cluster. Learn about [Kubernetes deployments](/docs/deployment-examples/kubernetes-deployments/index.md) and [Service Fabric deployments](/docs/deployment-examples/azure-deployments/service-fabric/index.md).
+ - Your scripts can be pre-authenticated and bootstrapped into an external service or server cluster. Learn about [Kubernetes deployments](/docs/deployment-examples/kubernetes-deployments/index.md) and [Service Fabric deployments](/docs/deployment-examples/azure-deployments/service-fabric/index.md).
  - You can define reusable functions for your scripts to use. Learn about [script modules](docs/deployment-examples/custom-scripts/script-modules.md).
 
 ## How To Use Custom Scripts

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -29,7 +29,7 @@ In the context of Octopus, your custom scripts get the following extra benefits:
  - Your scripts can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).
  - Your scripts can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).
- - Your script can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).
+ - Your scripts can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).
  - Your script can be pre-authenticated and bootstrapped into a cloud provider. Learn about [AWS CLI scripts](aws-cli-scripts.md) and [Azure CLI scripts](azure-powershell-scripts.md).
  - Your script can be pre-authenticated and bootstrapped into an external service or server cluster. Learn about [Kubernetes deployments](/docs/deployment-examples/kubernetes-deployments/index.md) and [Service Fabric deployments](/docs/deployment-examples/azure-deployments/service-fabric/index.md).
  - You can define reusable functions for your scripts to use. Learn about [script modules](docs/deployment-examples/custom-scripts/script-modules.md).

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -26,7 +26,7 @@ In the context of Octopus, your custom scripts get the following extra benefits:
 
  - Your scripts can use [variables](/docs/deployment-process/variables/index.md) managed by Octopus, including [secrets](/docs/deployment-process/variables/sensitive-variables.md), [complex variable expressions](docs/deployment-process/variables/variable-substitutions.md), and [filters](/docs/deployment-process/variables/variable-filters.md). Learn about [using variables in scripts](using-variables-in-scripts.md).
  - Your scripts can be executed across your entire fleet of servers, or a selection of servers, in a controlled fashion. Learn about [deployment targets](/docs/infrastructure/deployment-targets/index.md) and [workers](/docs/infrastructure/workers/index.md).
- - Your script can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
+ - Your scripts can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).
  - Your script can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).
  - Your script can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -28,7 +28,7 @@ In the context of Octopus, your custom scripts get the following extra benefits:
  - Your scripts can be executed across your entire fleet of servers, or a selection of servers, in a controlled fashion. Learn about [deployment targets](/docs/infrastructure/deployment-targets/index.md) and [workers](/docs/infrastructure/workers/index.md).
  - Your scripts can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).
- - Your script can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).
+ - Your scripts can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).
  - Your script can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).
  - Your script can be pre-authenticated and bootstrapped into a cloud provider. Learn about [AWS CLI scripts](aws-cli-scripts.md) and [Azure CLI scripts](azure-powershell-scripts.md).
  - Your script can be pre-authenticated and bootstrapped into an external service or server cluster. Learn about [Kubernetes deployments](/docs/deployment-examples/kubernetes-deployments/index.md) and [Service Fabric deployments](/docs/deployment-examples/azure-deployments/service-fabric/index.md).

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -24,7 +24,7 @@ If an activity can be scripted, Octopus can run that script as a standalone acti
 
 In the context of Octopus, your custom scripts get the following extra benefits:
 
- - Your script can use [variables](/docs/deployment-process/variables/index.md) managed by Octopus including [secrets](/docs/deployment-process/variables/sensitive-variables.md), [complex variable expressions](docs/deployment-process/variables/variable-substitutions.md), and [filters](/docs/deployment-process/variables/variable-filters.md). Learn about [using variables in scripts](using-variables-in-scripts.md).
+ - Your script can use [variables](/docs/deployment-process/variables/index.md) managed by Octopus, including [secrets](/docs/deployment-process/variables/sensitive-variables.md), [complex variable expressions](docs/deployment-process/variables/variable-substitutions.md), and [filters](/docs/deployment-process/variables/variable-filters.md). Learn about [using variables in scripts](using-variables-in-scripts.md).
  - Your script can be executed across your entire fleet of servers, or a selection of servers, in a controlled fashion. Learn about [deployment targets](/docs/infrastructure/deployment-targets/index.md) and [workers](/docs/infrastructure/workers/index.md).
  - Your script can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -30,7 +30,7 @@ In the context of Octopus, your custom scripts get the following extra benefits:
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).
  - Your scripts can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).
  - Your scripts can collect files and store them in Octopus. Learn about [publishing artifacts](/docs/deployment-process/artifacts.md).
- - Your script can be pre-authenticated and bootstrapped into a cloud provider. Learn about [AWS CLI scripts](aws-cli-scripts.md) and [Azure CLI scripts](azure-powershell-scripts.md).
+ - Your scripts can be pre-authenticated and bootstrapped into a cloud provider. Learn about [AWS CLI scripts](aws-cli-scripts.md) and [Azure CLI scripts](azure-powershell-scripts.md).
  - Your script can be pre-authenticated and bootstrapped into an external service or server cluster. Learn about [Kubernetes deployments](/docs/deployment-examples/kubernetes-deployments/index.md) and [Service Fabric deployments](/docs/deployment-examples/azure-deployments/service-fabric/index.md).
  - You can define reusable functions for your scripts to use. Learn about [script modules](docs/deployment-examples/custom-scripts/script-modules.md).
 

--- a/docs/deployment-examples/custom-scripts/index.md
+++ b/docs/deployment-examples/custom-scripts/index.md
@@ -25,7 +25,7 @@ If an activity can be scripted, Octopus can run that script as a standalone acti
 In the context of Octopus, your custom scripts get the following extra benefits:
 
  - Your scripts can use [variables](/docs/deployment-process/variables/index.md) managed by Octopus, including [secrets](/docs/deployment-process/variables/sensitive-variables.md), [complex variable expressions](docs/deployment-process/variables/variable-substitutions.md), and [filters](/docs/deployment-process/variables/variable-filters.md). Learn about [using variables in scripts](using-variables-in-scripts.md).
- - Your script can be executed across your entire fleet of servers, or a selection of servers, in a controlled fashion. Learn about [deployment targets](/docs/infrastructure/deployment-targets/index.md) and [workers](/docs/infrastructure/workers/index.md).
+ - Your scripts can be executed across your entire fleet of servers, or a selection of servers, in a controlled fashion. Learn about [deployment targets](/docs/infrastructure/deployment-targets/index.md) and [workers](/docs/infrastructure/workers/index.md).
  - Your script can use the contents of a package. Learn about [using files from packages in scripts](scripts-in-packages/reference-files-within-a-package.md).
  - Your script can log special messages to control the format or report progress. Learn about [logging messages in scripts](logging-messages-in-scripts.md).
  - Your script can set output variables making these values available to other steps in your process. Learn about [output variables](/docs/deployment-process/variables/output-variables.md).


### PR DESCRIPTION
When I was helping a customer, I realised this is the landing page for custom scripts. Instead of telling the customer all the amazing super powers they get with scripts in Octopus, we told them about the security context and how to debug scripts in an antiquated way.

I've re-authored the page trying to put myself in the shoes of a customer arriving at Octopus for the first time.

![](https://www.useronboard.com/imgs/posts/mario-water.png)