### PR TITLE
Add troubleshooting docs for invalid certificates

### DIFF
--- a/docs/deployment-examples/certificates/troubleshooting.md
+++ b/docs/deployment-examples/certificates/troubleshooting.md
@@ -1,0 +1,33 @@
+---
+title: Troubleshooting Invalid Certificate
+description: How to troubleshoot invalid certificates that wont load in Octopus Deploy
+position: 110
+---
+
+Some certificate generation libraries can generate certificates that are very slightly invalid. Some tools will allow you to work with them, and some wont.
+
+Octopus Deploy uses a common certificate library called [Bouncy Castle](https://github.com/bcgit/bc-csharp) to parse and work with certificates. Recent versions of this have improved validation of certificates, which unfortunately has limited the usability of some certificates that dont strictly comply with the specification.
+
+## Common errors:
+
+### `corrupted stream detected malformed integer`
+
+This error implies that a certificate violates the X.690 spec, section 8.3.2.
+
+If you receive this error when creating a deployment, please review the certificates variables on the project, and try to view each one in `Library -> Certificates`. One of them will either fail to load, or show a message `Invalid Certificate: This certificate was unable to be parsed and may be in an invalid format`. Please modify any references to use a new, valid certificate and use the REST API to delete the certificate in question.
+
+This error may also appear on the variables page: `An error occurred on the mapping CertificateResource.CertificateDataFomat = Certificate.CertificateDataFormat [attempted value was (unknown)]: corrupted stream detected malformed integer`. Please review the certificates in  `Library -> Certificates` to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.
+
+Please see [BC-CSharp issue #156](https://github.com/bcgit/bc-csharp/issues/156) for further information.
+
+If deleting the certificate is not an option, Bouncy Castle supports an environment variable that can be set to disable the strict validation. Set an environment variable `Org.BouncyCastle.Asn1.AllowUnsafeInteger` to 'true' for the Octopus Server process and a looser validation will be applied, allowing this certificate to be used. However, Bouncy Castle authors have noted that this is not ideal and may pave the way for an exploit based around a faulty encoding in the future.
+
+### `Unable to parse certificate 'cert name' (id: some-id): corrupted stream detected malformed integer`
+
+This is the same root cause as the message above, however it includes details about which certificate is in error. Please update any uses to a new valid certificate, and use the REST API to delete the certificate in question.
+
+### `problem parsing cert: Org.BouncyCastle.Security.Certificates.CertificateException: Failed to read certificate ---> System.ArgumentException: version 1 certificate contains extra data`
+
+This can happen when certificates include extension data without specifying the certificate format of v3. If the version is omitted, then v1 is implied. Since only v3 certificates are allowed to have this additional data, this leads to an invalid certificate. Please see [BC-CSharp issue #158](https://github.com/bcgit/bc-csharp/issues/158) for further information.
+
+Please review the certificates in  `Library -> Certificates` to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.

--- a/docs/deployment-examples/certificates/troubleshooting.md
+++ b/docs/deployment-examples/certificates/troubleshooting.md
@@ -1,22 +1,22 @@
 ---
-title: Troubleshooting Invalid Certificate
-description: How to troubleshoot invalid certificates that wont load in Octopus Deploy
+title: Troubleshooting Invalid Certificates
+description: How to troubleshoot invalid certificates that won't load in Octopus Deploy
 position: 110
 ---
 
-Some certificate generation libraries can generate certificates that are very slightly invalid. Some tools will allow you to work with them, and some wont.
+Some certificate generation libraries can generate certificates that are very slightly invalid. Some tools will allow you to work with them, and some won't.
 
-Octopus Deploy uses a common certificate library called [Bouncy Castle](https://github.com/bcgit/bc-csharp) to parse and work with certificates. Recent versions of this have improved validation of certificates, which unfortunately has limited the usability of some certificates that dont strictly comply with the specification.
+Octopus Deploy uses a common certificate library called [Bouncy Castle](https://github.com/bcgit/bc-csharp) to parse and work with certificates. Recent versions of this have improved validation of certificates, which unfortunately has limited the usability of some certificates that don't strictly comply with the specification.
 
-## Common errors:
+## Common Errors:
 
 ### `corrupted stream detected malformed integer`
 
 This error implies that a certificate violates the X.690 spec, section 8.3.2.
 
-If you receive this error when creating a deployment, please review the certificates variables on the project, and try to view each one in `Library -> Certificates`. One of them will either fail to load, or show a message `Invalid Certificate: This certificate was unable to be parsed and may be in an invalid format`. Please modify any references to use a new, valid certificate and use the REST API to delete the certificate in question.
+If you receive this error when creating a deployment, please review the certificates variables on the project, and try to view each one in {{Library,Certificates}}. One of them will either fail to load, or show a message `Invalid Certificate: This certificate was unable to be parsed and may be in an invalid format`. Please modify any references to use a new, valid certificate and use the REST API to delete the certificate in question.
 
-This error may also appear on the variables page: `An error occurred on the mapping CertificateResource.CertificateDataFomat = Certificate.CertificateDataFormat [attempted value was (unknown)]: corrupted stream detected malformed integer`. Please review the certificates in  `Library -> Certificates` to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.
+This error may also appear on the variables page: `An error occurred on the mapping CertificateResource.CertificateDataFomat = Certificate.CertificateDataFormat [attempted value was (unknown)]: corrupted stream detected malformed integer`. Please review the certificates in  {{Library,Certificates}} to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.
 
 Please see [BC-CSharp issue #156](https://github.com/bcgit/bc-csharp/issues/156) for further information.
 
@@ -30,4 +30,4 @@ This is the same root cause as the message above, however it includes details ab
 
 This can happen when certificates include extension data without specifying the certificate format of v3. If the version is omitted, then v1 is implied. Since only v3 certificates are allowed to have this additional data, this leads to an invalid certificate. Please see [BC-CSharp issue #158](https://github.com/bcgit/bc-csharp/issues/158) for further information.
 
-Please review the certificates in  `Library -> Certificates` to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.
+Please review the certificates in  {{Library,Certificates}} to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.

--- a/docs/deployment-examples/certificates/troubleshooting.md
+++ b/docs/deployment-examples/certificates/troubleshooting.md
@@ -4,9 +4,9 @@ description: How to troubleshoot invalid certificates that won't load in Octopus
 position: 110
 ---
 
-Some certificate generation libraries can generate certificates that are very slightly invalid. Some tools will allow you to work with them, and some won't.
+Some certificate generation libraries can generate certificates that are invalid. Some tools will allow you to work with them, and some won't.
 
-Octopus Deploy uses a common certificate library called [Bouncy Castle](https://github.com/bcgit/bc-csharp) to parse and work with certificates. Recent versions of this have improved validation of certificates, which unfortunately has limited the usability of some certificates that don't strictly comply with the specification.
+Octopus Deploy uses a common certificate library called [Bouncy Castle](https://github.com/bcgit/bc-csharp) to parse and work with certificates. Recent versions of this have improved validation of certificates, which has, unfortunately, limited the usability of some certificates that don't strictly comply with the specification.
 
 ## Common Errors:
 
@@ -14,9 +14,9 @@ Octopus Deploy uses a common certificate library called [Bouncy Castle](https://
 
 This error implies that a certificate violates the X.690 spec, section 8.3.2.
 
-If you receive this error when creating a deployment, please review the certificates variables on the project, and try to view each one in {{Library,Certificates}}. One of them will either fail to load, or show a message `Invalid Certificate: This certificate was unable to be parsed and may be in an invalid format`. Please modify any references to use a new, valid certificate and use the REST API to delete the certificate in question.
+If you receive this error when creating a deployment, please review the certificate's variables on the project, and try to view each one in {{Library,Certificates}}. One of them will either fail to load, or show the message: `Invalid Certificate: This certificate was unable to be parsed and may be in an invalid format`. Please modify any references to use a new, valid certificate, and use the REST API to delete the certificate in question.
 
-This error may also appear on the variables page: `An error occurred on the mapping CertificateResource.CertificateDataFomat = Certificate.CertificateDataFormat [attempted value was (unknown)]: corrupted stream detected malformed integer`. Please review the certificates in  {{Library,Certificates}} to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.
+This error may also appear on the variables page: `An error occurred on the mapping CertificateResource.CertificateDataFomat = Certificate.CertificateDataFormat [attempted value was (unknown)]: corrupted stream detected malformed integer`. Please review the certificates in  {{Library,Certificates}} to find the invalid one, update any usages to use a new valid certificate, and delete the old certificate via the REST API.
 
 Please see [BC-CSharp issue #156](https://github.com/bcgit/bc-csharp/issues/156) for further information.
 
@@ -24,10 +24,10 @@ If deleting the certificate is not an option, Bouncy Castle supports an environm
 
 ### `Unable to parse certificate 'cert name' (id: some-id): corrupted stream detected malformed integer`
 
-This is the same root cause as the message above, however it includes details about which certificate is in error. Please update any uses to a new valid certificate, and use the REST API to delete the certificate in question.
+This is the same root cause as the message above, however, it includes details about which certificate is in error. Please update any uses to a new valid certificate, and use the REST API to delete the certificate in question.
 
 ### `problem parsing cert: Org.BouncyCastle.Security.Certificates.CertificateException: Failed to read certificate ---> System.ArgumentException: version 1 certificate contains extra data`
 
 This can happen when certificates include extension data without specifying the certificate format of v3. If the version is omitted, then v1 is implied. Since only v3 certificates are allowed to have this additional data, this leads to an invalid certificate. Please see [BC-CSharp issue #158](https://github.com/bcgit/bc-csharp/issues/158) for further information.
 
-Please review the certificates in  {{Library,Certificates}} to find the invalid one, update any usages to use a new valid certificate, and delete via the REST API.
+Please review the certificates in  {{Library,Certificates}} to find the invalid one, update any usages to use a new valid certificate, and delete the old certificate via the REST API.


### PR DESCRIPTION
Add some troubleshooting docs for invalid certificates.

# reviewing

Adding @jburger as someone who's spent a fair bit of time investigating. Does it make sense? Do I have the details right?

Adding @wordlee for word-smithing. Does it read well, is it in the right voice, is it in the right spot?

Latest issue that prompted this:
Relates to https://github.com/OctopusDeploy/Issues/issues/5955

Older related issues:
Relates to https://github.com/OctopusDeploy/Issues/issues/5020
Relates to https://github.com/OctopusDeploy/Issues/issues/5359
Relates to https://github.com/OctopusDeploy/Issues/issues/5337