### PR TITLE
Re-wording Basic Examples

### DIFF
--- a/docs/octopus-rest-api/octo.exe-command-line/create-release.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-release.md
@@ -188,13 +188,13 @@ Common options:
 
 ## Basic Examples {#Creatingreleases-Basicexamples}
 
-This will create a new release of the *HelloWorld* project using the latest available NuGet packages for each step in the project. The version number of the release will be the highest version according to the Release Versioning project setting: 
+This will create a new release of the *HelloWorld* project using the latest available NuGet packages for each step in the project. The version number of the release will be the highest version according to the [Release Versioning](https://octopus.com/docs/deployment-process/releases/release-versioning) project setting: 
 
 ```bash
 octo create-release --project HelloWorld --server http://octopus/ --apiKey API-ABCDEF123456
 ```
 
-This will create a release with a specified release number, overriding the Release Versioning project setting:
+This will create a release with a specified release number, overriding the [Release Versioning](https://octopus.com/docs/deployment-process/releases/release-versioning) project setting:
 
 ```bash
 octo create-release --project HelloWorld --version 1.0.3 --server http://octopus/ --apiKey API-ABCDEF123456

--- a/docs/octopus-rest-api/octo.exe-command-line/create-release.md
+++ b/docs/octopus-rest-api/octo.exe-command-line/create-release.md
@@ -188,13 +188,13 @@ Common options:
 
 ## Basic Examples {#Creatingreleases-Basicexamples}
 
-This will create a new release of the *HelloWorld* project using the latest available NuGet packages for each step in the project. The version number of the release will be the highest NuGet package version. You can override this using:
+This will create a new release of the *HelloWorld* project using the latest available NuGet packages for each step in the project. The version number of the release will be the highest version according to the Release Versioning project setting: 
 
 ```bash
 octo create-release --project HelloWorld --server http://octopus/ --apiKey API-ABCDEF123456
 ```
 
-This will create a release with a specified release number (note that this is not the NuGet package version number):
+This will create a release with a specified release number, overriding the Release Versioning project setting:
 
 ```bash
 octo create-release --project HelloWorld --version 1.0.3 --server http://octopus/ --apiKey API-ABCDEF123456


### PR DESCRIPTION
Previous wording made it look like when using create-release without specifying --version, it would use whatever the highest NuGet package version was in the project.  As we know, the Release Versioning project setting specifies a specific step in the process and uses that steps package for the version number.  A customer contacted us about the confusion, they expected whatever NuGet package in the process had the highest number, that was the number that got used.

I'm not married to my wording, just trying to clarify the documentation 😄 