### PR TITLE
Add a short explanation and workaround warning alert for Azure Cloud Services Timeout issue

### DIFF
--- a/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-cloud-service/index.md
+++ b/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-cloud-service/index.md
@@ -99,6 +99,14 @@ To extract the Cloud Service Package, it is first converted to the CTP format (a
 
 Setting the `Octopus.Action.Azure.LogExtractedCspkg` variable to `true` will cause the layout of the extracted package to be written into the Task Log. This may assist with finding the path to a particular file.
 
+:::warning
+**Disable Package Extraction and Re-Packaging**
+
+Based on customer reports and Azure community discussions, we believe that Microsoft is no longer recommending Azure Cloud Services - https://docs.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree. Several customers have reported timeout issues with regards to Azure Cloud Services, and slow re-packing of CTP packages. Unfortunately we will not be able to fix this issue, [as noted here](https://github.com/OctopusDeploy/Issues/issues/6111).
+
+The issues around timeouts and slow re-repackaging can be mitigated by passing in a variable - `Octopus.Action.Azure.CloudServicePackageExtractionDisabled` and setting the value to `true`. However in doing so, variable substitution will no longer be available.
+:::
+
 ### Variable Substitutions in Cloud Service Configuration File {#DeployingapackagetoanAzureCloudService-VariablesubstitutionsinCloudServiceconfigurationfile}
 
 Octopus will attempt to modify your `.cscfg` file. For example, take the following configuration:


### PR DESCRIPTION
Related to https://github.com/OctopusDeploy/Issues/issues/6111 

We will not be able to fix that issue, as the change would need to happen on Azure Cloud Services. This docs update will inform customer who encounter Timeout Issues or slow re-packaging of a work around, however as this work around disables variable substitution, we're using a warning alert. 