### PR TITLE
Add azure web app callout about WEBSITE_WEBDEPLOY_USE_SCM setting for…

### DIFF
--- a/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-web-app/index.md
+++ b/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-web-app/index.md
@@ -91,4 +91,4 @@ The example we've discussed here is the most common scenario for deploying Azure
 ### Deploying to a Linux Azure Web App
 
 Octopus currently uses web deploy for azure web app deployments, which requires you to disable the SCM endpoint in order for deployments to work for linux web apps. In order to achieve this the `WEBSITE_WEBDEPLOY_USE_SCM` app setting should be
-added to the Azure portal with a value of `false`. If you have multiple slots, this setting will have to be applied for each slot. If you do not add this setting web deploy will be unable to find the appropriate endpoint for deployment.
+to the Azure portal with a value of `false`. If you have multiple slots, this setting needs to be applied for each slot. If you do not add this setting, web deploy will be unable to find the appropriate endpoint for deployment.

--- a/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-web-app/index.md
+++ b/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-web-app/index.md
@@ -79,7 +79,7 @@ When the `Deploy an Azure Web App` step gets executed, the below actions will ha
 ## Simple and Advanced Deployment Scenarios {#DeployingapackagetoanAzureWebApp-Simpleandadvanceddeploymentscenarios}
 
 
-## Deploying to Multiple Geographic Regions {#DeployingapackagetoanAzureWebApp-Deployingtomultiplegeographicregions}
+### Deploying to Multiple Geographic Regions {#DeployingapackagetoanAzureWebApp-Deployingtomultiplegeographicregions}
 
 When your application is deployed to more than one geographic region, you are likely to need per-region configuration settings. You can achieve this result in many different ways, but the two most popular methods we have seen are:
 
@@ -87,3 +87,8 @@ When your application is deployed to more than one geographic region, you are li
 2. Environment-per-region: by creating an environment per region you can leverage [lifecycles](/docs/deployment-process/lifecycles/index.md) to create a strict release promotion process.
 
 The example we've discussed here is the most common scenario for deploying Azure Web Apps: a single package that contains an ASP.NET Web Application and some Web Jobs in the same release cadence. It is possible to implement more complex deployment scenarios where the ASP.NET Web Application and each Web Job follow independent release cadences. In this case you would build multiple packages using the folder structure expected by the Azure Web App hosting framework discussed earlier. Once you've done that you can simply reuse the same Azure Web App Deployment Target to deploy each package when they are released.
+
+### Deploying to a Linux Azure Web App
+
+Octopus currently uses web deploy for azure web app deployments, which requires you to disable the SCM endpoint in order for deployments to work for linux web apps. In order to achieve this the `WEBSITE_WEBDEPLOY_USE_SCM` app setting should be
+added to the Azure portal with a value of `false`. If you have multiple slots, this setting will have to be applied for each slot. If you do not add this setting web deploy will be unable to find the appropriate endpoint for deployment.


### PR DESCRIPTION
Our Azure web app docs doesn't contain any information about deploying to a Azure Linux web app using web deploy which requires some special handling. This PR adds some basic information in case anybody misses the obscure setting buried deep in the [microsoft documeation](https://docs.microsoft.com/en-us/azure/app-service/containers/app-service-linux-faq#continuous-integration-and-deployment) 