### PR TITLE
Update doco for static IPs in the Octopus Cloud

### DIFF
--- a/docs/octopus-cloud/static-ip.md
+++ b/docs/octopus-cloud/static-ip.md
@@ -1,21 +1,11 @@
 ---
 title: Static IP Address
 position: 20
-description: How to activate a static IP address with Octopus Cloud.
+description: How to find the list of static IP addresses for your Octopus Cloud instance
 ---
 
-You can purchase the option to have a static IP address assigned to your Octopus Cloud instance. This lets you:
+The Octopus Cloud is a multi-tenant service with several static IP addresses shared among customers in the same Azure region.
 
-- Connect to Listening Tentacles within your infrastructure from the Cloud.
-- Whitelist the static IP address of the Octopus server in your network configuration.
-- Allow connections to Linux or Unix SSH targets from the static IP address only.
+Each Azure region uses a pool of 10 static IP addresses, and the static IP for an Octopus Cloud instance will use one from the pool and may change to another static IP from the pool during certain situations.
 
-## Activate your Static IP address
-
-1. [Log in to your Octopus Account](https://account.octopus.com/).
-2. Select the instance that needs a Static IP
-3. Choose **Select Plan** and select the option to purchase a static IP address.
-
-Please allow a few minutes for the changes to be applied. There will be a short outage while the static IP address is provisioned. After this has been completed, you can find your IP address by performing a DNS lookup on the host name of your Octopus Cloud instance, where \<yoururl\> is the part of the URL you provided:
-
-https://\<yoururl\>.octopus.app
+A list of static IP addresses from the pool can be found within the settings section of your accounts organisation page.

--- a/docs/octopus-cloud/static-ip.md
+++ b/docs/octopus-cloud/static-ip.md
@@ -8,4 +8,4 @@ The Octopus Cloud is a multi-tenant service with several static IP addresses sha
 
 Each Azure region uses a pool of 10 static IP addresses, and the static IP for an Octopus Cloud instance will use one from the pool and may change to another static IP from the pool under certain situations.
 
-A list of static IP addresses from the pool can be found within the technical section of your accounts products page.
+A list of static IP addresses your instance could be using can be found within the technical section of the instance details page.

--- a/docs/octopus-cloud/static-ip.md
+++ b/docs/octopus-cloud/static-ip.md
@@ -6,6 +6,6 @@ description: How to find the list of static IP addresses for your Octopus Cloud 
 
 The Octopus Cloud is a multi-tenant service with several static IP addresses shared among customers in the same Azure region.
 
-Each Azure region uses a pool of 10 static IP addresses, and the static IP for an Octopus Cloud instance will use one from the pool and may change to another static IP from the pool during certain situations.
+Each Azure region uses a pool of 10 static IP addresses, and the static IP for an Octopus Cloud instance will use one from the pool and may change to another static IP from the pool under certain situations.
 
 A list of static IP addresses from the pool can be found within the settings section of your accounts organization page.

--- a/docs/octopus-cloud/static-ip.md
+++ b/docs/octopus-cloud/static-ip.md
@@ -8,4 +8,4 @@ The Octopus Cloud is a multi-tenant service with several static IP addresses sha
 
 Each Azure region uses a pool of 10 static IP addresses, and the static IP for an Octopus Cloud instance will use one from the pool and may change to another static IP from the pool during certain situations.
 
-A list of static IP addresses from the pool can be found within the settings section of your accounts organisation page.
+A list of static IP addresses from the pool can be found within the settings section of your accounts organization page.

--- a/docs/octopus-cloud/static-ip.md
+++ b/docs/octopus-cloud/static-ip.md
@@ -8,4 +8,4 @@ The Octopus Cloud is a multi-tenant service with several static IP addresses sha
 
 Each Azure region uses a pool of 10 static IP addresses, and the static IP for an Octopus Cloud instance will use one from the pool and may change to another static IP from the pool under certain situations.
 
-A list of static IP addresses from the pool can be found within the settings section of your accounts organization page.
+A list of static IP addresses from the pool can be found within the technical section of your accounts products page.


### PR DESCRIPTION
We're no longer charging customers for a static IP address. This PR explains that there's now a pool of static IPs for everybody and where to find them.