### PR TITLE
move image version to include

### DIFF
--- a/docs/packaging-applications/build-servers/bitbucket-pipelines/index.md
+++ b/docs/packaging-applications/build-servers/bitbucket-pipelines/index.md
@@ -47,7 +47,7 @@ pipelines:
   default:
     - step:
         name: Deploy to Octopus
-        image: octopusdeploy/octo:6.17.3-alpine
+        image: !include <image-version-octo-alpine>
         script:
           - export VERSION=1.0.$BITBUCKET_BUILD_NUMBER
           - octo pack --id $BITBUCKET_REPO_SLUG --version $VERSION --outFolder ./out --format zip

--- a/docs/shared-content/versions/images/image-version-octo-alpine.include.md
+++ b/docs/shared-content/versions/images/image-version-octo-alpine.include.md
@@ -1,0 +1,1 @@
+octopusdeploy/octo:6.17.3-alpine


### PR DESCRIPTION
Relates to OctopusDeploy/Issues#4878 and #605

Moving the image version to an include so we can update it without needing to know about any specific usages.

TODO: modify the build/deploy process to update the version in this file when a new image is pushed to docker hub.