### PR TITLE
Updating cli docs for octo.exe

### DIFF
--- a/docs/octopus-rest-api/octopus-cli/complete.md
+++ b/docs/octopus-rest-api/octopus-cli/complete.md
@@ -11,3 +11,4 @@ Supports command line auto completion.
 --help
 --helpOutputFormat
 ```
+

--- a/docs/octopus-rest-api/octopus-cli/index.md
+++ b/docs/octopus-rest-api/octopus-cli/index.md
@@ -27,7 +27,7 @@ hideInThisSection: true
 - **[deploy-release](/docs/octopus-rest-api/octopus-cli/deploy-release.md)**:  Deploys a release.
 - **[dump-deployments](/docs/octopus-rest-api/octopus-cli/dump-deployments.md)**:  Writes deployments to an XML file that can be imported in Excel.
 - **[export](/docs/octopus-rest-api/octopus-cli/export.md)**:  Exports an object to a JSON file. Deprecated. Please see [https://g.octopushq.com/DataMigration](https://g.octopushq.com/DataMigration) for alternative options.
-- **[import](/docs/octopus-rest-api/octopus-cli/import.md)**:  Imports an Octopus object from an export file. Deprecated. Please see [Data Migration](https://g.octopushq.com/DataMigration) for alternative options.
+- **[import](/docs/octopus-rest-api/octopus-cli/import.md)**:  Imports an Octopus object from an export file. Deprecated. Please see [https://g.octopushq.com/DataMigration](https://g.octopushq.com/DataMigration) for alternative options.
 - **[install-autocomplete](/docs/octopus-rest-api/octopus-cli/install-autocomplete.md)**:  Install a shell auto-complete script into your shell profile, if they aren't already there. Supports pwsh, zsh, bash & powershell.
 - **[list-deployments](/docs/octopus-rest-api/octopus-cli/list-deployments.md)**:  Lists a number of deployments by project, environment or by tenant.
 - **[list-environments](/docs/octopus-rest-api/octopus-cli/list-environments.md)**:  Lists environments.

--- a/docs/octopus-rest-api/octopus-cli/install-autocomplete.md
+++ b/docs/octopus-rest-api/octopus-cli/install-autocomplete.md
@@ -11,3 +11,4 @@ Install a shell auto-complete script into your shell profile, if they aren't alr
 Please specify the type of shell to install autocompletion for: --shell=XYZ. Valid values are Pwsh, Zsh, Bash and Powershell.
 Exit code: -1
 ```
+


### PR DESCRIPTION
An automated update of the command line docs for octo.exe version 7.3.1.0.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 197