### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -69,9 +69,14 @@ Where [<options>] is any of:
                              Comma-separated whitelist of domains that are
                                allowed to retrieve data (empty turns CORS off,
                                * allows all).
+      --xFrameOptions=VALUE  A directive to provide in the X-Frame-Options
+                               header
       --xFrameOptionAllowFrom=VALUE
-                             A uri to provide in the X-Frame-Option http
-                               header in conjunction with the ALLOW-FROM value.
+                             (DEPRECATED) A uri to provide in the X-Frame-
+                               Options http header in conjunction with the
+                               ALLOW-FROM value. The directive allow-from uri
+                               for X-Frame-Options has been deprecated and no
+                               longer works in modern browsers.
       --hstsEnabled=VALUE    Enables or disables sending the Strict-Transport-
                                Security (HSTS) header. Defaults to false.
       --hstsMaxAge=VALUE     Sets the max-age value (in seconds) of the
@@ -123,7 +128,9 @@ Where [<options>] is any of:
                              When Domain authentication is used, specifies
                                the scheme (Basic, Digest,
                                IntegratedWindowsAuthentication, Negotiate,
-                               Ntlm).
+                               Ntlm). You will need to restart all Octopus
+                               Server nodes in your cluster for these changes
+                               to take effect.
       --allowFormsAuthenticationForDomainUsers=VALUE
                              When Domain authentication is used, specifies
                                whether the HTML-based username/password form
@@ -196,7 +203,7 @@ Where [<options>] is any of:
                              Set whether GitHub issue tracker integration is
                                enabled.
       --GitHubBaseUrl=VALUE  Set the base url for the Git repositories.
-      --jiraIsEnabled=VALUE  Set whether Jira Integration is
+      --jiraIsEnabled=VALUE  Set whether Jira issue tracker integration is
                                enabled.
       --jiraBaseUrl=VALUE    Enter the base url of your Jira instance. Once
                                set, work item references will render as links.

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/database.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/database.md
@@ -38,3 +38,4 @@ Or one of the common options:
 
       --help                 Show detailed help for this command
 ```
+

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/index.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/index.md
@@ -22,7 +22,7 @@ hideInThisSection: true
 - **[import-certificate](/docs/octopus-rest-api/octopus.server.exe-command-line/import-certificate.md)**:  Replace the certificate that Octopus Server uses to authenticate itself with its Tentacles.
 - **[license](/docs/octopus-rest-api/octopus.server.exe-command-line/license.md)**:  Import a license key.
 - **[list-instances](/docs/octopus-rest-api/octopus.server.exe-command-line/list-instances.md)**:  Lists all installed Octopus instances.
-- **[lost-master-key](/docs/octopus-rest-api/octopus.server.exe-command-line/lost-master-key.md)**:  Get your Octopus Server working again after losing your Master Key.
+- **[lost-master-key](/docs/octopus-rest-api/octopus.server.exe-command-line/lost-master-key.md)**:  Get your Octopus Server working again after losing your master key.
 - **[metrics](/docs/octopus-rest-api/octopus.server.exe-command-line/metrics.md)**:  Configure metrics logging.
 - **[new-certificate](/docs/octopus-rest-api/octopus.server.exe-command-line/new-certificate.md)**:  Creates a new certificate that Octopus Server can use to authenticate itself with its Tentacles.
 - **[node](/docs/octopus-rest-api/octopus.server.exe-command-line/node.md)**:  Configure settings related to this Octopus Server node.

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/license.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/license.md
@@ -23,3 +23,4 @@ Or one of the common options:
 
       --help                 Show detailed help for this command
 ```
+

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/lost-master-key.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/lost-master-key.md
@@ -40,3 +40,4 @@ Or one of the common options:
 
       --help                 Show detailed help for this command
 ```
+

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -34,3 +34,4 @@ Or one of the common options:
 
       --help                 Show detailed help for this command
 ```
+


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2020.1.14.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 208