### PR TITLE
Updating cli docs for octopus.migrator.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md
+++ b/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md
@@ -14,7 +14,7 @@ Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
       --file=VALUE           Octopus 2.6 (.octobak) file
-      --master-key=VALUE     Master Key used to decrypt the file
+      --master-key=VALUE     Master key used to decrypt the file
       --dry-run              Do not commit changes, just print what would
                                have happened
       --maxage=VALUE         Ignore historical data older than x days


### PR DESCRIPTION
An automated update of the command line docs for octopus.migrator.exe version 2020.1.14.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 208