### PR TITLE
Worker pool variable link

### DIFF
--- a/docs/infrastructure/workers/worker-pools.md
+++ b/docs/infrastructure/workers/worker-pools.md
@@ -8,7 +8,7 @@ Worker pools are groups of [workers](/docs/infrastructure/workers/index.md), whe
 
 ## Default Worker Pool
 
-There is always a default worker pool, and the default Pool can't be deleted, but you can swap which pool is the default. Worker pools are global resources which can't be scoped.  All users can see what pools are available and if there are workers in the pools. Only a user with the `ConfigureServer` permission can see the worker machines or edit workers or pools.
+There is always a default worker pool, and the default Pool can't be deleted, but you can swap which pool is the default. Worker pools are global resources which can be be scoped using [worker pool variables](/docs/projects/variables/worker-pool-variables.md).  All users can see what pools are available and if there are workers in the pools. Only a user with the `ConfigureServer` permission can see the worker machines or edit workers or pools.
 
 Using multiple workers pools allows you to configure the workers in your  pools for the tasks they will be assigned. For instance, depending on your teams needs you might configure worker pools in the following ways:
 

--- a/docs/infrastructure/workers/worker-pools.md
+++ b/docs/infrastructure/workers/worker-pools.md
@@ -8,7 +8,7 @@ Worker pools are groups of [workers](/docs/infrastructure/workers/index.md), whe
 
 ## Default Worker Pool
 
-There is always a default worker pool, and the default Pool can't be deleted, but you can swap which pool is the default. Worker pools are global resources which can be be scoped using [worker pool variables](/docs/projects/variables/worker-pool-variables.md).  All users can see what pools are available and if there are workers in the pools. Only a user with the `ConfigureServer` permission can see the worker machines or edit workers or pools.
+There is always a default worker pool, and the default Pool can't be deleted, but you can swap which pool is the default. Worker pools are global resources which can be scoped using [worker pool variables](/docs/projects/variables/worker-pool-variables.md).  All users can see what pools are available and if there are workers in the pools. Only a user with the `ConfigureServer` permission can see the worker machines or edit workers or pools.
 
 Using multiple workers pools allows you to configure the workers in your  pools for the tasks they will be assigned. For instance, depending on your teams needs you might configure worker pools in the following ways:
 


### PR DESCRIPTION
Remove the lies...

" Worker pools are global resources which can't be scoped" 