### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -130,7 +130,11 @@ Where [<options>] is any of:
                                IntegratedWindowsAuthentication, Negotiate,
                                Ntlm). You will need to restart all Octopus
                                Server nodes in your cluster for these changes
-                               to take effect.
+                               to take effect. Please note that using Negotiate
+                               or IntegratedWindowsAuthentication [may require
+                               additional server configuration](https://-
+                               g.octopushq.com/AuthAD) in order to work
+                               correctly.
       --allowFormsAuthenticationForDomainUsers=VALUE
                              When Domain authentication is used, specifies
                                whether the HTML-based username/password form


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2020.1.16.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 210