### PR TITLE
Add warning that variable values are evaluated as strings

### DIFF
--- a/docs/projects/variables/variable-substitutions.md
+++ b/docs/projects/variables/variable-substitutions.md
@@ -114,7 +114,12 @@ You could achieve a similar result, with a different default/fallback behavior, 
 
 #### *Truthy* and *Falsy* Values {#VariableSubstitutionSyntax-TruthyandFalsyvalues}
 
-The `if`, `if-else` and `unless` statements consider a value to be *falsy* if it is undefined, empty, `False` or `0`. All other values are considered to be *truthy*.
+The `if`, `if-else` and `unless` statements consider a value to be *falsy* if it is undefined, an empty string, `False` or `0`. All other values are considered to be *truthy*.
+
+:::warning
+**All variables are strings**
+Note that when evaluating values, **all Octopus variables are strings** even if they look like numbers or other data types.
+:::
 
 ### Complex syntax
 Additional conditional statements are supported in **Octopus 3.5** and onwards, including `==` and `!=`.


### PR DESCRIPTION
A user in community slack raised that the docs were confusing when referring to `empty` being evaluated as `falsy`, so added a warning that variables are treated as Strings, and modified the wording to state an empty **string**. 