### PR TITLE
Add redirect for Configuration Features

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -641,3 +641,4 @@ docs/administration/managing-users-and-teams/service-accounts.md -> docs/securit
 docs/administration/managing-users-and-teams/system-and-space-permissions.md -> docs/security/users-and-teams/system-and-space-permissions.md
 docs/administration/managing-users-and-teams/user-roles.md -> docs/security/users-and-teams/user-roles.md
 docs/administration/managing-users-and-teams/external-groups-and-roles.md -> docs/security/users-and-teams/external-groups-and-roles.md
+docs/deploying-applications/deployment-process/configuration-features/index.md -> docs/deployment-process/configuration-features/index.md


### PR DESCRIPTION
Someone reported this URL was broken: https://octopus.com/docs/deploying-applications/deployment-process/configuration-features

I don't remember where it was linked from.

I think this redirect should fix it. The current url is https://octopus.com/docs/deployment-process/configuration-features