### PR TITLE
Update pictures and add warning about Subversion

### DIFF
--- a/docs/packaging-applications/build-servers/index.md
+++ b/docs/packaging-applications/build-servers/index.md
@@ -53,15 +53,15 @@ The Verbose logging option can be used to include more detail in the build logs.
 
 As of `2019.10.0`, the build information for a package can be viewed by navigating to **{{Library,Build Information}}**
 
-![Library Build information](images/Capture.png "width=500")
+![Library Build information](images/Capture.PNG "width=500")
 
 The build information for a package can be viewed on any release which contains the package.
 
-![Build information on release page](images/Capture2.png "width=500")
+![Build information on release page](images/Capture2.PNG "width=500")
 
 For packages pushed to the Octopus built-in repository, the build information can also be viewed in the package version details by navigating to **{{Library, Packages}}** and selecting the package.
 
-![Build information on package version page](images/Capture3.png "width=500")
+![Build information on package version page](images/Capture3.PNG "width=500")
 
 :::warning 
 

--- a/docs/packaging-applications/build-servers/index.md
+++ b/docs/packaging-applications/build-servers/index.md
@@ -53,15 +53,15 @@ The Verbose logging option can be used to include more detail in the build logs.
 
 As of `2019.10.0`, the build information for a package can be viewed by navigating to **{{Library,Build Information}}**
 
-![Library Build information](images/Capture.PNG "width=500")
+![Library Build information](images/library-build-information-2.png "width=500")
 
 The build information for a package can be viewed on any release which contains the package.
 
-![Build information on release page](images/Capture2.PNG "width=500")
+![Build information on release page](images/build-information-release-2.png "width=500")
 
 For packages pushed to the Octopus built-in repository, the build information can also be viewed in the package version details by navigating to **{{Library, Packages}}** and selecting the package.
 
-![Build information on package version page](images/Capture3.PNG "width=500")
+![Build information on package version page](images/build-information-package-version-2.png "width=500")
 
 :::warning 
 

--- a/docs/packaging-applications/build-servers/index.md
+++ b/docs/packaging-applications/build-servers/index.md
@@ -53,15 +53,21 @@ The Verbose logging option can be used to include more detail in the build logs.
 
 As of `2019.10.0`, the build information for a package can be viewed by navigating to **{{Library,Build Information}}**
 
-![Library Build information](images/library-build-information.png "width=500")
+![Library Build information](images/Capture.png "width=500")
 
 The build information for a package can be viewed on any release which contains the package.
 
-![Build information on release page](images/build-information-release.png "width=500")
+![Build information on release page](images/Capture2.png "width=500")
 
 For packages pushed to the Octopus built-in repository, the build information can also be viewed in the package version details by navigating to **{{Library, Packages}}** and selecting the package.
 
-![Build information on package version page](images/build-information-package-version.png "width=500")
+![Build information on package version page](images/Capture3.png "width=500")
+
+:::warning 
+
+Commit messages will only be shown in the build information if you are using GitHub. Subversion does not have this functionality. 
+
+:::
 
 :::hint
 


### PR DESCRIPTION
The pictures needed to be updated as one of them contains "Metadata" which isnt what our current version shows. A user got concerned that they had setup build info correctly since theirs didnt say Metadata. I've taken 3 new screenshots for consistency. I also added a warning that subversion doesnt work for commit messages, only github.