### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -28,6 +28,10 @@ Where [<options>] is any of:
                              Threshold of free disk space (in gigabytes)
                                where packages are cleaned up from cache
                                regardless of age. Default: 1
+      --cacheDirectoryFullThreshold=VALUE
+                             Threshold of the size of the cache folder(in
+                               gigabytes) where packages are cleaned up from
+                               cache regardless of age. Default: 0 (no limit)
       --maxConcurrentTasks=VALUE
                              Deprecated: may be removed in a future release
                                (currently has no effect; set Task Cap instead).


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2020.2.13.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 215