### PR TITLE
Add telemetry and clusterShared path commands

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -9,7 +9,7 @@ Set the file paths that Octopus will use for storage
 **path options**
 
 ```text
-Usage: octopus.server path [<options>]
+Usage: Octopus.Server path [<options>]
 
 Where [<options>] is any of:
 
@@ -19,6 +19,8 @@ Where [<options>] is any of:
       --skipDatabaseSchemaUpgradeCheck
                              Skips the database schema upgrade checks. Use
                                with caution
+      --clusterShared=VALUE  Set the root path where shared files will be
+                               stored for Octopus clusters
       --cacheDirectory=VALUE Directory to use for temporary files and cachin-
                                g, e.g. downloaded packages. The data in this
                                directory can be removed when the Octopus Server
@@ -29,6 +31,7 @@ Where [<options>] is any of:
                                repository
       --artifacts=VALUE      Set the path where artifacts are stored
       --taskLogs=VALUE       Set the path where task logs are stored
+      --telemetry=VALUE      Set the path where telemetry is stored
 
 Or one of the common options:
 


### PR DESCRIPTION
Added two new path commands.

`telemetry` sets the storage location of temporary files used when collecting telemetry. This should be path shared by all nodes in a cluster.
`clusterShared` sets the root path shared by nodes in a cluster. This is a shorthand way to configure a cluster instead of setting each path individually, previously each of artifacts, built-in repository and task logs would need to be configured. 