### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -19,6 +19,8 @@ Where [<options>] is any of:
       --skipDatabaseSchemaUpgradeCheck
                              Skips the database schema upgrade checks. Use
                                with caution
+      --clusterShared=VALUE  Set the root path where shared files will be
+                               stored for Octopus clusters
       --cacheDirectory=VALUE Directory to use for temporary files and cachin-
                                g, e.g. downloaded packages. The data in this
                                directory can be removed when the Octopus Server
@@ -29,6 +31,7 @@ Where [<options>] is any of:
                                repository
       --artifacts=VALUE      Set the path where artifacts are stored
       --taskLogs=VALUE       Set the path where task logs are stored
+      --telemetry=VALUE      Set the path where telemetry is stored
 
 Or one of the common options:
 


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2020.2.16.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 218