### PR TITLE
Added Structured Configuration Variable metrics to outbound requests

### DIFF
--- a/docs/security/outbound-requests.md
+++ b/docs/security/outbound-requests.md
@@ -75,6 +75,7 @@ In addition, when the "Include statistics" option is enabled, we'll send some sp
 | The usage of step configuration options | 2020.2.5 |
 | Aggregated type, result code and duration of database and api calls | 2020.2.14 |
 | Counts of specific kinds of events that occur internally, e.g. usage of deprecated code paths, errors | 2020.3.0 |
+| Structured Configuration Variable usage across projects including how many steps have Structured Configuration Variables enabled and what file extensions are being used | 2020.4.0
 
 The installation ID is a GUID that we generate when Octopus is installed. This GUID is simply a way for us to get a rough idea of the number of installations there are in the wild, and which versions people are using, so we can make decisions about backwards compatibility support.
 

--- a/docs/security/outbound-requests.md
+++ b/docs/security/outbound-requests.md
@@ -75,7 +75,7 @@ In addition, when the "Include statistics" option is enabled, we'll send some sp
 | The usage of step configuration options | 2020.2.5 |
 | Aggregated type, result code and duration of database and api calls | 2020.2.14 |
 | Counts of specific kinds of events that occur internally, e.g. usage of deprecated code paths, errors | 2020.3.0 |
-| Structured Configuration Variable usage across projects including how many steps have Structured Configuration Variables enabled and what file extensions are being used | 2020.4.0
+| Structured Configuration Variable usage across projects including how many steps have Structured Configuration Variables enabled and what file extensions are being used | 2020.4.0 |
 
 The installation ID is a GUID that we generate when Octopus is installed. This GUID is simply a way for us to get a rough idea of the number of installations there are in the wild, and which versions people are using, so we can make decisions about backwards compatibility support.
 


### PR DESCRIPTION
We're recording new metrics around Structured Configuration Variable usage in 2020.4 - updated the docs to reflect the new outbound metrics with check for update request. 

PR for Structured Config Metrics in Octopus Server: https://github.com/OctopusDeploy/OctopusDeploy/pull/6498
PR for Structured Config Metrics in Octofront: https://github.com/OctopusDeploy/Octofront/pull/2123