### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -59,8 +59,6 @@ Where [<options>] is any of:
                                get redirected to HTTPS)
       --requestLoggingEnabled=VALUE
                              Whether to enable logging of web requests
-      --azurePowerShellModule=VALUE
-                             Path to Azure PowerShell module to be used
       --customBundledPackageDirectory=VALUE
                              A custom folder for getting packages (like
                                Calamari) that are normally bundled with Octopus

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -19,13 +19,13 @@ Where [<options>] is any of:
       --skipDatabaseSchemaUpgradeCheck
                              Skips the database schema upgrade checks. Use
                                with caution
-      --clusterShared=VALUE  Set the root path where shared files will be
-                               stored for Octopus clusters
       --cacheDirectory=VALUE Directory to use for temporary files and cachin-
                                g, e.g. downloaded packages. The data in this
                                directory can be removed when the Octopus Server
                                is not running. This directory should not be
                                shared between nodes.
+      --clusterShared=VALUE  Set the root path where shared files will be
+                               stored for Octopus clusters
       --nugetRepository=VALUE
                              Set the package path for the built-in package
                                repository


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2020.4.2.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 231