### PR TITLE
Removed Octopus Server section

### DIFF
--- a/docs/octopus-cloud/index.md
+++ b/docs/octopus-cloud/index.md
@@ -5,11 +5,13 @@ description: How to work with Octopus Cloud.
 hideInThisSectionHeader: true
 ---
 
-!include <octopus-cloud>
+Octopus Cloud is the hosted version of Octopus Deploy.
 
-## Octopus Server
+We designed Octopus Cloud and self-hosted Octopus to provide the same functionality. Octopus Cloud uses the same deployment automation server to define your deployment processes and runbooks and manage the releases of your software.
 
-!include <octopus-server>
+![Octopus Dashboard](/docs/shared-content/concepts/images/dashboard.png "width=500")
+
+You can sign up for Octopus Cloud at [octopus.com/free](https://octopus.com/free).
 
 ## Create an Octopus account
 

--- a/docs/shared-content/octopus-cloud/octopus-cloud.include.md
+++ b/docs/shared-content/octopus-cloud/octopus-cloud.include.md
@@ -1,6 +1,0 @@
-Octopus Cloud is the hosted version of Octopus Deploy.
-
-We designed Octopus Cloud and self-hosted Octopus to provide the same functionality; however, with Octopus Cloud we're responsible for backups, automatically upgrading the service, and maintaining and monitoring the underlying systems. 
-
-You can sign up for Octopus Cloud at [octopus.com/free](https://octopus.com/free).
- 


### PR DESCRIPTION
No longer references the octopus-server.include file that added the octopus server content.

I removed the shared octopus-cloud content (it was only used in this one place), simplified and rewrote the introduction.