### PR TITLE
Document API key expiry

### DIFF
--- a/docs/administration/managing-infrastructure/subscriptions/index.md
+++ b/docs/administration/managing-infrastructure/subscriptions/index.md
@@ -127,9 +127,13 @@ The following is a list of all options for subscriptions including Event Groups,
 |Machine is no longer available for deployment|
 |Certificate expiry events|
 |Document events|
+|API key expiry events|
 
 |EVENTS|
 |---|
+|API key expired|
+|API key expiry 10-day warning|
+|API key expiry 20-day warning|
 |Auto-deploy trigger blocked|
 |Auto-deploy trigger succeeded|
 |Certificate expired|

--- a/docs/octopus-rest-api/how-to-create-an-api-key.md
+++ b/docs/octopus-rest-api/how-to-create-an-api-key.md
@@ -23,3 +23,30 @@ You can create API keys by performing the following steps:
 **Write Your Key Down**
 After you generate an API key, it cannot be retrieved from the Octopus Web Portal again, we store only a one-way hash of the API key. If you want to use the API key again, you need to store it in a secure place such as a password manager. Read about [why we hash API keys](https://octopus.com/blog/hashing-api-keys).
 :::
+
+## Setting an expiry date
+
+You can optionally set an expiry date on new API keys. By default, keys have no expiry date and are valid until they're revoked.
+
+When creating an API key in the Octopus Web Portal, you can choose from a preset list of offsets from the current date, or select a custom date. Keys will expire at the end of the selected day. When using the Octopus REST API to create a key, you can set the expiry date to your preferred  date and time, including time zone offset.
+
+There are two restrictions on the expiry date:
+
+- It cannot be in the past.
+- It cannot be beyond the expiry date of the key being used to create it (when using the REST API).
+
+## Configure API keys for expiry notifications
+
+[Octopus Subscriptions](/docs/administration/managing-infrastructure/subscriptions/index.md) can be used to configure notifications when API keys are close to expiry or have expired.
+
+There is a "API key expiry events" event-group, and three events:  
+
+- API key expiry 20-day warning.
+- API key expiry 10-day warning.
+- API key expired.
+
+:::info
+The background task which raises the api-key-expiry events runs:
+- 10 minutes after the Octopus Server service starts
+- Every 4 hours
+:::

--- a/docs/octopus-rest-api/how-to-create-an-api-key.md
+++ b/docs/octopus-rest-api/how-to-create-an-api-key.md
@@ -33,13 +33,13 @@ When creating an API key in the Octopus Web Portal, you can choose from a preset
 There are two restrictions on the expiry date:
 
 - It cannot be in the past.
-- It cannot be beyond the expiry date of the key being used to create it (when using the REST API).
+- It cannot be after the expiry date of the key being used to create it (when using the REST API).
 
 ## Configure API keys for expiry notifications
 
 [Octopus Subscriptions](/docs/administration/managing-infrastructure/subscriptions/index.md) can be used to configure notifications when API keys are close to expiry or have expired.
 
-There is a "API key expiry events" event-group, and three events:  
+There is an "API key expiry events" event-group and three events:
 
 - API key expiry 20-day warning.
 - API key expiry 10-day warning.


### PR DESCRIPTION
# Background

This PR is part of the [API Key Management](https://docs.google.com/document/d/1BwF_RjvOAX0Rc-6JEr3D1w88BJcyqxXuhYr8GPpV5Gc/edit#) pitch.

Add basic documentation around API key expiry. I think the functionality is fairly self-explanatory, so I haven't gone into much detail. Expiry events work pretty much identically to certificate expiry, so that section has largely be copy+pasted.

This feature will be shipping in **2020.6**.