### PR TITLE
Updated Codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,9 +2,9 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
-# @wordlee will be requested for review when someone opens a pull request.
+# @harrisonmeister will be requested for review when someone opens a pull request.
 
-* @wordlee
+* @harrisonmeister
 
 # credits updates get reviewed by michaelnoonan and jburger for open source license compliance
 /docs/credits.md @michaelnoonan @jburger


### PR DESCRIPTION
Mark, as discussed, this updates the codeowners file to tag you as the primary codeowner, that way you'll be automatically added to review docs PRs as they come in.