### PR TITLE
Update register-listening-tentacle powershell

### DIFF
--- a/docs/shared-content/scripts/register-listening-tentacle-scripts.include.md
+++ b/docs/shared-content/scripts/register-listening-tentacle-scripts.include.md
@@ -10,6 +10,7 @@ $hostName = "MyHost"
 $tentaclePort = "10933"
 $environmentNames = @("Development", "Production")
 $roles = @("MyRole")
+$environmentIds = @()
 
 # Get space
 $space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object {$_.Name -eq $spaceName}


### PR DESCRIPTION
Initial script didn't instantiate the $environmentIds var as an array, so it was making stringlists that did not work when registering the tentacle.