### PR TITLE
remove spaces around = in bash example

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -159,7 +159,7 @@ Steps in the deployment process can reference the variables.
 Write-Host $OctopusParameters["Helloworld.Greeting"]
 ```
 ```bash Bash
-greeting = $(get_octopusvariable "Helloworld.Greeting")
+greeting=$(get_octopusvariable "Helloworld.Greeting")
 echo $greeting
 ```
 


### PR DESCRIPTION
While working through the getting started guide I noticed that the bash variable substitution example was failing. This is because the variable declaration is not quite right (see [this explanation](https://stackoverflow.com/questions/2268104/command-not-found-error-in-bash-variable-assignment) )