### PR TITLE
Let's Encrypt update

### DIFF
--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -41,7 +41,7 @@ At this point, we recommend enabling [Force SSL](/docs/security/exposing-octopus
 ## Let's Encrypt for Containers
 For on-prem deployments of Octopus Deploy, there is a Let's Encrypt option that allows you to utilize open-source SSL/TLS certifications. The implementation for Let's Encrypt was originally built only for on-prem Octopus Deploy deployments that are running on Windows servers and at this time, that's where the implementation will stay.
 
-As Octopus Deploy grows into the Linux and container space, there needs to be several options that customers and users can utilize to ensure they can still use SSL/TLS certifications for the Octopus Deploy platform.
+From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt integration will no longer be available in the Octopus Portal or via the API. 
 
 For Linux and Windows containers moving forward. Let's Encrypt will not be an option in the UI or the API. Instead, you can use many of the standard ways we see today in containers and Kubernetes to enable HTTPS if you are running inside of a container.
 

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -39,7 +39,7 @@ The **{{Configuration,Let's Encrypt}}** page will now show when the SSL certific
 At this point, we recommend enabling [Force SSL](/docs/security/exposing-octopus/expose-the-octopus-web-portal-over-https.md#ForcingHTTPS) and [HSTS](/docs/security/exposing-octopus/expose-the-octopus-web-portal-over-https.md#HSTS).
 
 ## Let's Encrypt for Containers
-For on-prem deployments of Octopus Deploy, there is a Let's Encrypt option that allows you to utilize open-source SSL/TLS certifications. The implementation for Let's Encrypt was originally built only for on-prem Octopus Deploy deployments that are running on Windows servers and at this time, that's where the implementation will stay.
+The integration for Let's Encrypt was designed for self-hosted Octopus Server installations running on a Windows server. There are currently no plans to support Let's Encrypt when running [Octopus in a container](docs/installation/octopus-in-container/index.md).
 
 From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt integration will no longer be available in the Octopus Portal or via the API. 
 

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -46,7 +46,7 @@ From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt 
 Customers running Octopus in a container that wish to secure the Octopus Portal to be accessible over HTTPS can do so in a number of standard ways, which are discussed in more detail below.
 
 ### NGINX proxy {#nginx-proxy}
-If you are running an Octopus Deploy container on Docker without an orchestration platform like Kubernetes, you can set up an Nginx reverse proxy with TLS termination. 
+If you are running an Octopus in a Docker container without an orchestration platform like Kubernetes, you can set up an NGINX reverse proxy with TLS termination.
 
 There is a great piece of documentation on the Nginx website for setting up TLS/SSL termination, which you can find [here](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/)
 

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -45,7 +45,7 @@ In **Octopus 2020.5** and earlier, when attempting to configure the Let's Encryp
 
 From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt integration will no longer be available in the Octopus Portal or via the API. 
 
-Customers running Octopus in a container that wish to secure the Octopus Portal to be accessible over HTTPS can do so in a number of standard ways, which are discussed in more detail below.
+Customers running Octopus in a container that wish to secure the Octopus Portal to be accessible over HTTPS can do so in a number of standard ways, which are discussed in more detail here.
 
 ### NGINX proxy {#nginx-proxy}
 If you are running an Octopus in a Docker container without an orchestration platform like Kubernetes, you can set up an NGINX reverse proxy with TLS termination.

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -43,7 +43,7 @@ The integration for Let's Encrypt was designed for self-hosted Octopus Server in
 
 From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt integration will no longer be available in the Octopus Portal or via the API. 
 
-For Linux and Windows containers moving forward. Let's Encrypt will not be an option in the UI or the API. Instead, you can use many of the standard ways we see today in containers and Kubernetes to enable HTTPS if you are running inside of a container.
+Customers running Octopus in a container that wish to secure the Octopus Portal to be accessible over HTTPS can do so in a number of standard ways, which are discussed in more detail below.
 
 ### Nginx Proxy
 If you are running an Octopus Deploy container on Docker without an orchestration platform like Kubernetes, you can set up an Nginx reverse proxy with TLS termination. 

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -41,6 +41,8 @@ At this point, we recommend enabling [Force SSL](/docs/security/exposing-octopus
 ## Let's Encrypt for Containers
 The integration for Let's Encrypt was designed for self-hosted Octopus Server installations running on a Windows server. There are currently no plans to support Let's Encrypt when running [Octopus in a container](docs/installation/octopus-in-container/index.md).
 
+In **Octopus 2020.5** and earlier, when attempting to configure the Let's Encrypt integration on an Octopus Server Linux container, it would fail with a message similar to `We received an error 'Unix LocalMachine X509Stores are read-only for all users`.
+
 From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt integration will no longer be available in the Octopus Portal or via the API. 
 
 Customers running Octopus in a container that wish to secure the Octopus Portal to be accessible over HTTPS can do so in a number of standard ways, which are discussed in more detail below.

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -45,7 +45,7 @@ From **Octopus 2020.6**, when running Octopus in a container, the Let's Encrypt 
 
 Customers running Octopus in a container that wish to secure the Octopus Portal to be accessible over HTTPS can do so in a number of standard ways, which are discussed in more detail below.
 
-### Nginx Proxy
+### NGINX proxy {#nginx-proxy}
 If you are running an Octopus Deploy container on Docker without an orchestration platform like Kubernetes, you can set up an Nginx reverse proxy with TLS termination. 
 
 There is a great piece of documentation on the Nginx website for setting up TLS/SSL termination, which you can find [here](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/)

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -54,7 +54,7 @@ For more information on configuring TLS/SSL termination in NGINX, refer to the [
 Another popular and cloud-native HTTP reverse proxy and load balancer is [Traefik](https://traefik.io/traefik/). You can combine this with Let's Encrypt to support TLS/SSL termination with your Octopus container. To find out more, refer to  the [Traefik documentation](https://doc.traefik.io/traefik/v1.7/user-guide/.docker-and-lets-encrypt/).
 
 ### Kubernetes and Octopus Deploy
-If you're going the orchestration and containerization route with say, Kubernetes and Docker, there are a plethora of ingress controllers that can be used. There is an extensive list that you can find [here](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) that goes over many open-source, extremely popular platforms that include Traefik, HAProxy Ingress, Istio, and many others.
+If you plan to use an orchestrator with your container say, Kubernetes and Docker, an ingress controller can be used to secure the Octopus Portal. You can find an extensive list in the  [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). It includes multiple open-source, popular platforms such as Traefik, HAProxy Ingress, Istio, and many others.
 
 
 ## Availability

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -48,7 +48,7 @@ Customers running Octopus in a container that wish to secure the Octopus Portal 
 ### NGINX proxy {#nginx-proxy}
 If you are running an Octopus in a Docker container without an orchestration platform like Kubernetes, you can set up an NGINX reverse proxy with TLS termination.
 
-There is a great piece of documentation on the Nginx website for setting up TLS/SSL termination, which you can find [here](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/)
+For more information on configuring TLS/SSL termination in NGINX, refer to the [documentation](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/).
 
 ### Let's Encrypt and Traefik
 If you'd still like to use Let's Encrypt with Docker and you aren't using an orchestration platform, you can combine Let's Encrypt with Traefik, a popular and cloud native HTTP reverse proxy and load balancer. You can find the documentation for setting up Let's Encrypt and Traefik [here](https://doc.traefik.io/traefik/v1.7/user-guide/docker-and-lets-encrypt/)

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -50,7 +50,7 @@ If you are running an Octopus in a Docker container without an orchestration pla
 
 For more information on configuring TLS/SSL termination in NGINX, refer to the [documentation](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/).
 
-### Let's Encrypt and Traefik
+### Let's Encrypt and Traefik {#lets-encrypt-traefik}
 If you'd still like to use Let's Encrypt with Docker and you aren't using an orchestration platform, you can combine Let's Encrypt with Traefik, a popular and cloud native HTTP reverse proxy and load balancer. You can find the documentation for setting up Let's Encrypt and Traefik [here](https://doc.traefik.io/traefik/v1.7/user-guide/docker-and-lets-encrypt/)
 
 ### Kubernetes and Octopus Deploy

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -51,7 +51,7 @@ If you are running an Octopus in a Docker container without an orchestration pla
 For more information on configuring TLS/SSL termination in NGINX, refer to the [documentation](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/).
 
 ### Let's Encrypt and Traefik {#lets-encrypt-traefik}
-If you'd still like to use Let's Encrypt with Docker and you aren't using an orchestration platform, you can combine Let's Encrypt with Traefik, a popular and cloud native HTTP reverse proxy and load balancer. You can find the documentation for setting up Let's Encrypt and Traefik [here](https://doc.traefik.io/traefik/v1.7/user-guide/docker-and-lets-encrypt/)
+Another popular and cloud-native HTTP reverse proxy and load balancer is [Traefik](https://traefik.io/traefik/). You can combine this with Let's Encrypt to support TLS/SSL termination with your Octopus container. To find out more, refer to  the [Traefik documentation](https://doc.traefik.io/traefik/v1.7/user-guide/.docker-and-lets-encrypt/).
 
 ### Kubernetes and Octopus Deploy
 If you're going the orchestration and containerization route with say, Kubernetes and Docker, there are a plethora of ingress controllers that can be used. There is an extensive list that you can find [here](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) that goes over many open-source, extremely popular platforms that include Traefik, HAProxy Ingress, Istio, and many others.

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -53,7 +53,7 @@ For more information on configuring TLS/SSL termination in NGINX, refer to the [
 ### Let's Encrypt and Traefik {#lets-encrypt-traefik}
 Another popular and cloud-native HTTP reverse proxy and load balancer is [Traefik](https://traefik.io/traefik/). You can combine this with Let's Encrypt to support TLS/SSL termination with your Octopus container. To find out more, refer to  the [Traefik documentation](https://doc.traefik.io/traefik/v1.7/user-guide/.docker-and-lets-encrypt/).
 
-### Kubernetes and Octopus Deploy
+### Kubernetes and Octopus Deploy {#kubernetes-and-octopus}
 If you plan to use an orchestrator with your container say, Kubernetes and Docker, an ingress controller can be used to secure the Octopus Portal. You can find an extensive list in the  [Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/). It includes multiple open-source, popular platforms such as Traefik, HAProxy Ingress, Istio, and many others.
 
 

--- a/docs/security/exposing-octopus/lets-encrypt-integration.md
+++ b/docs/security/exposing-octopus/lets-encrypt-integration.md
@@ -38,6 +38,25 @@ The **{{Configuration,Let's Encrypt}}** page will now show when the SSL certific
 
 At this point, we recommend enabling [Force SSL](/docs/security/exposing-octopus/expose-the-octopus-web-portal-over-https.md#ForcingHTTPS) and [HSTS](/docs/security/exposing-octopus/expose-the-octopus-web-portal-over-https.md#HSTS).
 
+## Let's Encrypt for Containers
+For on-prem deployments of Octopus Deploy, there is a Let's Encrypt option that allows you to utilize open-source SSL/TLS certifications. The implementation for Let's Encrypt was originally built only for on-prem Octopus Deploy deployments that are running on Windows servers and at this time, that's where the implementation will stay.
+
+As Octopus Deploy grows into the Linux and container space, there needs to be several options that customers and users can utilize to ensure they can still use SSL/TLS certifications for the Octopus Deploy platform.
+
+For Linux and Windows containers moving forward. Let's Encrypt will not be an option in the UI or the API. Instead, you can use many of the standard ways we see today in containers and Kubernetes to enable HTTPS if you are running inside of a container.
+
+### Nginx Proxy
+If you are running an Octopus Deploy container on Docker without an orchestration platform like Kubernetes, you can set up an Nginx reverse proxy with TLS termination. 
+
+There is a great piece of documentation on the Nginx website for setting up TLS/SSL termination, which you can find [here](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/)
+
+### Let's Encrypt and Traefik
+If you'd still like to use Let's Encrypt with Docker and you aren't using an orchestration platform, you can combine Let's Encrypt with Traefik, a popular and cloud native HTTP reverse proxy and load balancer. You can find the documentation for setting up Let's Encrypt and Traefik [here](https://doc.traefik.io/traefik/v1.7/user-guide/docker-and-lets-encrypt/)
+
+### Kubernetes and Octopus Deploy
+If you're going the orchestration and containerization route with say, Kubernetes and Docker, there are a plethora of ingress controllers that can be used. There is an extensive list that you can find [here](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) that goes over many open-source, extremely popular platforms that include Traefik, HAProxy Ingress, Istio, and many others.
+
+
 ## Availability
 
 ### ACME v1 retirement


### PR DESCRIPTION
The updates found in this PR contain documentation updates for the work that has been done to get the Linux Container out of EAP with the removal of Let's Encrypt.