### PR TITLE
Include tools and templates to auto-update credits.md

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "octopus.creditsfilegenerator.tool": {
+      "version": "1.0.187",
+      "commands": [
+        "octopus-creditsfilegenerator"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 *.iml
 .DS_Store
 **/*.dia~
+tmp

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet.org v3" value="https://api.nuget.org/v3/index.json" />
+    <add key="feedz.io" value="https://f.feedz.io/octopus-deploy/dependencies/nuget" />
+    <add key="nuget.packages.octopushq.com" value="https://nuget.packages.octopushq.com/" />    
+  </packageSources>
+</configuration>

--- a/docs/credits.template.md
+++ b/docs/credits.template.md
@@ -1,0 +1,20 @@
+﻿---
+title: Credits
+description: Octopus is made possible thanks to many great third-party products.
+position: 200
+---
+
+Octopus Deploy is made possible thanks to the following great third-party products.
+
+|                      Package                      |                         Authors and/or maintainers                        |                                                                                                        Find it at...                                                                                                        |                                                       License                                                       |
+| ------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+{{ for dependency in dependencies ~}}
+| {{ dependency.id | string.pad_right 49 }} | {{ dependency.authors | string.pad_right 73}} | {{ "[" + dependency.project_url + "]" + "(" + dependency.project_url + ")" | string.pad_right 219 }} | {{ for descriptor in dependency.licenses.descriptors }}{{ "[" + descriptor.name + "]" + "(" + descriptor.url + ")" | string.pad_right 115 }}{{ end }} |
+{{~ end }}
+
+Each project listed here is the property of its respective copyright owner.
+
+:::hint
+Have we missed something from this list? Typos or inaccuracies? Please let us know via our [support forum](https://octopus.com/support) so that we can fix it. Thanks!
+:::
+


### PR DESCRIPTION
# Background

We recently changed the way we generate licence/credits files and internally test for OSS licence compliance. This has necessitated a change to our `docs` repository with regard to how we generate our `credits.md` file.

# Results

This PR includes
- a .NET tool manifest
- a `dotnet` tool to generate the `credits.md` file
- a markdown template file for the credits file
- a `NuGet.config` file to allow downloading the .NET tool from our unauthenticated/public NuGet feed
- a `.gitignore` entry to ignore temporary directories created during generation of `credits.md` in case the cleanup fails.