### PR TITLE
Added and moved some information for clarity

### DIFF
--- a/docs/packaging-applications/build-servers/index.md
+++ b/docs/packaging-applications/build-servers/index.md
@@ -59,7 +59,7 @@ The Build Information step is currently available in the official Octopus [TeamC
 Check our [downloads page](https://octopus.com/downloads) for our latest build server plugins.
 :::
 
-Build information is independent from the packages that it relates to. You can pass build information to Octopus **before** the packages have been pushed to either the built-in repository or an external feed. You can also [push build information manually](/blog/manually-push-build-information-to-octopus) using calls to the API when you are not utilising a Build Server.
+Build information is independent of the packages that it relates to. You can pass build information to Octopus **before** the packages have been pushed to either the built-in repository or an external feed. You can also [push build information manually](https://octopus.com/blog/manually-push-build-information-to-octopus) using the Octopus REST API when you aren't utilizing a Build Server.
 
 :::warning 
 

--- a/docs/packaging-applications/build-servers/index.md
+++ b/docs/packaging-applications/build-servers/index.md
@@ -59,7 +59,13 @@ The Build Information step is currently available in the official Octopus [TeamC
 Check our [downloads page](https://octopus.com/downloads) for our latest build server plugins.
 :::
 
-Build information is independent from the packages that it relates to. You can pass build information to Octopus **before** the packages have been pushed to either the built-in repository or an external feed.
+Build information is independent from the packages that it relates to. You can pass build information to Octopus **before** the packages have been pushed to either the built-in repository or an external feed. You can also [push build information manually](/blog/manually-push-build-information-to-octopus) using calls to the API when you are not utilising a Build Server.
+
+:::warning 
+
+Commit messages and deep links may not be shown if an unsupported `VcsType` is passed to Octopus as part of the build information call. Currently we support values of `Git` and `TFVC` (TFS / Azure DevOps). `SVN` (Subversion) is **not supported**.
+
+:::
 
 ## Build information step {#build-information-step}
 
@@ -86,12 +92,6 @@ The build information for a package can be viewed on any release which contains 
 For packages pushed to the Octopus built-in repository, the build information can also be viewed in the package version details by navigating to **{{Library, Packages}}** and selecting the package.
 
 ![Build information on package version page](images/build-information-package-version-2.png "width=500")
-
-:::warning 
-
-Commit messages and deep links may not be shown if an unsupported `VcsType` is passed to Octopus as part of the build information call. Currently we support values of `Git` and `TFVC` (TFS / Azure DevOps). `SVN` (Subversion) is **not supported**.
-
-:::
 
 ## Using build information in release notes #{release-notes}
 


### PR DESCRIPTION
I've moved the warning for the VCS types to a more promienent position as many people miss this information which can waste the customer and support team a lot of time.

I've also added a link a short lead up to a blog discussing Manually Pushing Build Information.