### PR TITLE
Authentication providers compatibility enhancements

### DIFF
--- a/docs/security/authentication/active-directory/index.md
+++ b/docs/security/authentication/active-directory/index.md
@@ -1,19 +1,17 @@
 ---
 title: Active Directory authentication
 description: Octopus Deploy can use Windows credentials to identify users.
-position: 0
+position: 5
 ---
 
 :::hint
-Active Directory authentication only works with Octopus Server and does not work with [Octopus Cloud](/docs/octopus-cloud/index.md).
+Active Directory authentication can only be configured for Octopus Server and not for [Octopus Cloud](/docs/octopus-cloud/index.md). See our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information.
 :::
 
 Octopus Deploy can authenticate users using Windows credentials. Windows AD authentication can be chosen during installation of the Octopus Server, or later through the configuration.
 
-:::hint
 **Domain user required during setup**
 When setting AD Authentication, either via the Octopus setup wizard or running the commands outlined below to switch to AD authentication mode, make sure you are signed in to Windows as a domain user. If you are signed in as a local user account on the machine (a non-domain user) you won't be able to query Active Directory, so setup will fail.
-:::
 
 ## Active Directory Sign-In options {#ActiveDirectoryauthentication-ActiveDirectorysigninoptions}
 If you are using Active Directory Authentication with Octopus, there are two ways to sign in.
@@ -116,7 +114,7 @@ setspn.exe -S HTTP/od octoserver1
 setspn.exe -S HTTP/od.mydomain.local octoserver1 
 ```
 
-:::note
+:::hint
 **HA Clusters**
 If you are running a HA Octopus Deploy environment, Kerberos authentication is not currently supported. Please refer to our section on [Supported Setups for Active Directory Authentication](#ActiveDirectoryAuthentication-SupportedAuthentication)
 :::

--- a/docs/security/authentication/active-directory/index.md
+++ b/docs/security/authentication/active-directory/index.md
@@ -5,7 +5,7 @@ position: 5
 ---
 
 :::hint
-Active Directory authentication can only be configured for Octopus Server and not for [Octopus Cloud](/docs/octopus-cloud/index.md). See our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information.
+Active Directory authentication can only be configured for Octopus Server and not for [Octopus Cloud](/docs/octopus-cloud/index.md). See our [authentication provider compatibility](/docs/security/authentication/auth-provider-compatibility.md) section for further information.
 :::
 
 Octopus Deploy can authenticate users using Windows credentials. Windows AD authentication can be chosen during installation of the Octopus Server, or later through the configuration.

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -13,12 +13,12 @@ The following table highlights login support for each authentication provider in
 |                                       | Octopus Server     | Octopus Cloud   |
 |---------------------------------------|:------------------:|:---------------:|
 | Username and Password                 | :white_check_mark: | :white_check_mark: **\*** |
-| Active Directory Authentication       | :white_check_mark: | :x:&nbsp; |
+| Active Directory Authentication       | :white_check_mark: | :x:&nbsp;&nbsp; |
 | Azure Active Directory Authentication | :white_check_mark: | :white_check_mark: **\*** |
 | GoogleApps Authentication             | :white_check_mark: | :white_check_mark: **\*** |
-| Okta Authentication                   | :white_check_mark: | :x:&nbsp; |
+| Okta Authentication                   | :white_check_mark: | :x:&nbsp;&nbsp; |
 | Octopus ID                            | :x: | :white_check_mark: |
 | Guest Login                           | :white_check_mark: | :white_check_mark: |
 | GitHub                                | :x: | :white_check_mark: **\*** |
 
-**Note:** Entries marked with a **\*** are supported via [Octopus ID](octopusid-authentication.md).
+**Note:** Entries marked with **\*** are supported via [Octopus ID](octopusid-authentication.md).

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -23,7 +23,7 @@ The following table shows login support for each authentication provider in Octo
 
 **Note:** Entries marked with **\*** are supported via [Octopus ID](octopusid-authentication.md).
 
-## External group and roles support {#external-groups-and-roles}
+## External groups and roles support {#external-groups-and-roles}
 
 Octopus allows [external groups and roles](/docs/security/users-and-teams/external-groups-and-roles.md) to be added as members of Teams in Octopus. The following table shows which authentication providers support this in Octopus Server and Octopus Cloud:
 

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -33,10 +33,11 @@ Octopus allows [external groups and roles](/docs/security/users-and-teams/extern
 | Active Directory Authentication       | :white_check_mark:&nbsp;&nbsp; | :x: |
 | Azure Active Directory Authentication | :white_check_mark: **\*** | :x: |
 | GoogleApps Authentication             | :x:&nbsp;&nbsp; | :x: |
-| Okta Authentication                   | :x:&nbsp;&nbsp; | :x: |
+| Okta Authentication                   | :white_check_mark: **†**| :x: |
 | Octopus ID                            | :x:&nbsp;&nbsp; | :x: |
 | Guest Login                           | :x:&nbsp;&nbsp; | :x: |
 | GitHub                                | :x:&nbsp;&nbsp; | :x: |
 
-**\*** For Azure Active Directory (AAD) users and groups, these must also be mapped in the Azure App Registration. Please read the [Mapping AAD users into Octopus teams](/docs/security/authentication/azure-ad-authentication.md#mapping-aad-users-into-octopus-teams-optional) section for further information.
+**\*** For Azure Active Directory (AAD) users and groups, these must also be mapped in the Azure App Registration. Please read the [Mapping AAD users into Octopus teams](/docs/security/authentication/azure-ad-authentication.md#mapping-aad-users-into-octopus-teams-optional) section for more details.
 
+**†** For Okta groups to flow through to Octopus, you'll need to change the _Groups claim_ fields. Please read the [Okta group integration](/docs/security/authentication/okta-authentication.md#Oktaauthentication-OpenIDConnectSettings-OktaGroups) section for more details.

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -17,7 +17,6 @@ The following table shows login support for each authentication provider in Octo
 | Azure Active Directory Authentication | :white_check_mark: | :white_check_mark: **\*** |
 | GoogleApps Authentication             | :white_check_mark: | :white_check_mark: **\*** |
 | Okta Authentication                   | :white_check_mark: | :x:&nbsp;&nbsp; |
-| Octopus ID                            | :x: | :white_check_mark:&nbsp;&nbsp; |
 | Guest Login                           | :white_check_mark: | :white_check_mark:&nbsp;&nbsp; |
 | GitHub                                | :x: | :white_check_mark: **\*** |
 
@@ -34,7 +33,6 @@ Octopus allows [external groups and roles](/docs/security/users-and-teams/extern
 | Azure Active Directory Authentication | :white_check_mark: **\*** | :x: |
 | GoogleApps Authentication             | :x:&nbsp;&nbsp; | :x: |
 | Okta Authentication                   | :white_check_mark: **†**| :x: |
-| Octopus ID                            | :x:&nbsp;&nbsp; | :x: |
 | Guest Login                           | :x:&nbsp;&nbsp; | :x: |
 | GitHub                                | :x:&nbsp;&nbsp; | :x: |
 

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -17,8 +17,8 @@ The following table highlights login support for each authentication provider in
 | Azure Active Directory Authentication | :white_check_mark: | :white_check_mark: **\*** |
 | GoogleApps Authentication             | :white_check_mark: | :white_check_mark: **\*** |
 | Okta Authentication                   | :white_check_mark: | :x:&nbsp;&nbsp; |
-| Octopus ID                            | :x: | :white_check_mark: |
-| Guest Login                           | :white_check_mark: | :white_check_mark: |
+| Octopus ID                            | :x: | :white_check_mark:&nbsp;&nbsp; |
+| Guest Login                           | :white_check_mark: | :white_check_mark:&nbsp;&nbsp; |
 | GitHub                                | :x: | :white_check_mark: **\*** |
 
 **Note:** Entries marked with **\*** are supported via [Octopus ID](octopusid-authentication.md).

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -1,0 +1,24 @@
+---
+title: Authentication provider compatibility
+description: Compatibility of authentication providers differ between Octopus Server and Octopus Cloud.
+position: 0
+---
+
+Octopus ships with a number of authentication providers. The support for these providers differ between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). Some only support authentication with Octopus Server, and others only support Octopus Cloud.
+
+## Authentication provider login support {#authentication-provider-login-support}
+
+The following table highlights login support for each authentication provider in Octopus Server and Octopus Cloud:
+
+|                                       | Octopus Server     | Octopus Cloud   |
+|---------------------------------------|:------------------:|:---------------:|
+| Username and Password                 | :white_check_mark: | :white_check_mark: **\*** |
+| Active Directory Authentication       | :white_check_mark: | :x:&nbsp; |
+| Azure Active Directory Authentication | :white_check_mark: | :white_check_mark: **\*** |
+| GoogleApps Authentication             | :white_check_mark: | :white_check_mark: **\*** |
+| Okta Authentication                   | :white_check_mark: | :x:&nbsp; |
+| Octopus ID                            | :x: | :white_check_mark: |
+| Guest Login                           | :white_check_mark: | :white_check_mark: |
+| GitHub                                | :x: | :white_check_mark: **\*** |
+
+**Note:** Entries marked with a **\*** are supported via [Octopus ID](octopusid-authentication.md).

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -25,7 +25,7 @@ The following table shows login support for each authentication provider in Octo
 
 ## External group and roles support {#external-groups-and-roles}
 
-Octopus allows [external groups and roles](/docs/security/users-and-teams/external-groups-and-roles.md) to be added as Members of Teams in Octopus. The following table shows which authentication providers support this in Octopus Server and Octopus Cloud:
+Octopus allows [external groups and roles](/docs/security/users-and-teams/external-groups-and-roles.md) to be added as members of Teams in Octopus. The following table shows which authentication providers support this in Octopus Server and Octopus Cloud:
 
 |                                       | Octopus Server     | Octopus Cloud   |
 |---------------------------------------|:------------------:|:---------------:|

--- a/docs/security/authentication/auth-provider-compatibility.md
+++ b/docs/security/authentication/auth-provider-compatibility.md
@@ -4,11 +4,11 @@ description: Compatibility of authentication providers differ between Octopus Se
 position: 0
 ---
 
-Octopus ships with a number of authentication providers. The support for these providers differ between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). Some only support authentication with Octopus Server, and others only support Octopus Cloud.
+Octopus ships with a number of authentication providers. The support for these providers differ between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). Some authentication providers only work with Octopus Server, whilst others only work with Octopus Cloud. This page describes the compatibility of these providers in Octopus.
 
-## Authentication provider login support {#authentication-provider-login-support}
+## Login support {#login-support}
 
-The following table highlights login support for each authentication provider in Octopus Server and Octopus Cloud:
+The following table shows login support for each authentication provider in Octopus Server and Octopus Cloud:
 
 |                                       | Octopus Server     | Octopus Cloud   |
 |---------------------------------------|:------------------:|:---------------:|
@@ -22,3 +22,21 @@ The following table highlights login support for each authentication provider in
 | GitHub                                | :x: | :white_check_mark: **\*** |
 
 **Note:** Entries marked with **\*** are supported via [Octopus ID](octopusid-authentication.md).
+
+## External group and roles support {#external-groups-and-roles}
+
+Octopus allows [external groups and roles](/docs/security/users-and-teams/external-groups-and-roles.md) to be added as Members of Teams in Octopus. The following table shows which authentication providers support this in Octopus Server and Octopus Cloud:
+
+|                                       | Octopus Server     | Octopus Cloud   |
+|---------------------------------------|:------------------:|:---------------:|
+| Username and Password                 | :x:&nbsp;&nbsp; | :x: |
+| Active Directory Authentication       | :white_check_mark:&nbsp;&nbsp; | :x: |
+| Azure Active Directory Authentication | :white_check_mark: **\*** | :x: |
+| GoogleApps Authentication             | :x:&nbsp;&nbsp; | :x: |
+| Okta Authentication                   | :x:&nbsp;&nbsp; | :x: |
+| Octopus ID                            | :x:&nbsp;&nbsp; | :x: |
+| Guest Login                           | :x:&nbsp;&nbsp; | :x: |
+| GitHub                                | :x:&nbsp;&nbsp; | :x: |
+
+**\*** For Azure Active Directory (AAD) users and groups, these must also be mapped in the Azure App Registration. Please read the [Mapping AAD users into Octopus teams](/docs/security/authentication/azure-ad-authentication.md#mapping-aad-users-into-octopus-teams-optional) section for further information.
+

--- a/docs/security/authentication/authentication-automation-with-octopusdsc.md
+++ b/docs/security/authentication/authentication-automation-with-octopusdsc.md
@@ -1,7 +1,7 @@
 ---
 title: Authentication automation with OctopusDSC
 description: Authentication automation resources with OctopusDSC.
-position: 20
+position: 40
 ---
 
 OctopusDSC is an in-house open-source PowerShell module with DSC resource designed to reduce the overhead when automating the installation and configuration of your Octopus infrastructure.

--- a/docs/security/authentication/auto-user-creation.md
+++ b/docs/security/authentication/auto-user-creation.md
@@ -1,7 +1,7 @@
 ---
 title: Automatic user creation
 description: User can be automatically created using some providers.
-position: 7
+position: 35
 ---
 
 The Active Directory and OpenID connect providers will, by default, automatically create a new user record for any user who can successfully authenticate but is not currently recognized (based on the checks and fallbacks described [here](index.md#AuthenticationProviders-Usernames,emailaddresses,UPNsandExternalIds)).

--- a/docs/security/authentication/azure-ad-authentication.md
+++ b/docs/security/authentication/azure-ad-authentication.md
@@ -5,7 +5,7 @@ position: 10
 ---
 
 :::hint
-Azure Active Directory (AAD) authentication support differs between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). In Octopus Server, you can login with your AAD credentials, and have your AAD user and groups mapped into Octopus teams. For Octopus Cloud, you can only login with AAD using [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/authentication/authentication-provider-compatibility.md) section for further information. 
+Azure Active Directory (AAD) authentication support differs between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). In Octopus Server, you can login with your AAD credentials, and have your AAD user and groups mapped into Octopus teams. For Octopus Cloud, you can only login with AAD using [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/security/authentication/authentication-provider-compatibility.md) section for further information. 
 :::
 
 To use Azure Active Directory (AAD) authentication with Octopus Server, you will need to do the following:

--- a/docs/security/authentication/azure-ad-authentication.md
+++ b/docs/security/authentication/azure-ad-authentication.md
@@ -1,14 +1,14 @@
 ---
 title: Azure Active Directory authentication
 description: Octopus Deploy can use Azure AD authentication to identify users.
-position: 1
+position: 10
 ---
 
 :::hint
-Azure Active Directory (AAD) authentication only works with Octopus Server and does not work with [Octopus Cloud](/docs/octopus-cloud/index.md).
+Azure Active Directory (AAD) authentication support differs between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). In Octopus Server, you can login with your AAD credentials, and have your AAD user and groups mapped into Octopus teams. For Octopus Cloud, you can only login with AAD using [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/authentication/authentication-provider-compatibility.md) section for further information. 
 :::
 
-To use Azure Active Directory (AAD) authentication with Octopus, you will need to do the following:
+To use Azure Active Directory (AAD) authentication with Octopus Server, you will need to do the following:
 
 1. Configure AAD to trust your Octopus Deploy instance by setting it up as an App in AAD.
 2. Optionally map AAD Users into Roles so you the users can be automatically connected to Octopus Teams.
@@ -189,11 +189,9 @@ If you followed the optional steps to modify the App registration's manifest to 
 
 Even if you are using an external identity provider, Octopus still requires a [user account](/docs/security/users-and-teams/index.md), so that you can assign those people to Octopus teams and subsequently grant permissions to Octopus resources. Octopus will automatically create a [user account](/docs/security/users-and-teams/index.md) based on the profile information returned in the security token, which includes an **Identifier**, **Name**, and **Email Address**.
 
-:::hint
 **How Octopus matches external identities to user accounts**
 
 When the security token is returned from the external identity provider, Octopus looks for a user account with a **matching Identifier**. If there is no match, Octopus looks for a user account with a **matching Email Address**. If a user account is found, the external identifier will be added to the user account for next time. If a user account is not found, Octopus will create one using the profile information in the security token.
-:::
 
 :::success
 **Existing Octopus user accounts**

--- a/docs/security/authentication/azure-ad-authentication.md
+++ b/docs/security/authentication/azure-ad-authentication.md
@@ -5,7 +5,7 @@ position: 10
 ---
 
 :::hint
-Azure Active Directory (AAD) authentication support differs between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). In Octopus Server, you can login with your AAD credentials, and have your AAD user and groups mapped into Octopus teams. For Octopus Cloud, you can only login with AAD using [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/security/authentication/authentication-provider-compatibility.md) section for further information. 
+Azure Active Directory (AAD) authentication support differs between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). In Octopus Server, you can login with your AAD credentials, and have your AAD user and groups mapped into Octopus teams. For Octopus Cloud, you can only login with AAD using [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/security/authentication/auth-provider-compatibility.md) section for further information. 
 :::
 
 To use Azure Active Directory (AAD) authentication with Octopus Server, you will need to do the following:

--- a/docs/security/authentication/googleapps-authentication.md
+++ b/docs/security/authentication/googleapps-authentication.md
@@ -5,10 +5,10 @@ position: 2
 ---
 
 :::hint
-GoogleApps authentication only works with Octopus Server and does not work with [Octopus Cloud](/docs/octopus-cloud/index.md).
+GoogleApps authentication can only be configured for Octopus Server. For [Octopus Cloud](/docs/octopus-cloud/index.md), authentication using GoogleApps is supported with [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information. 
 :::
 
-To use GoogleApps authentication with Octopus, GoogleApps must be configured to trust Octopus (by setting it up as an app).  Below are the details for how to configure the app.
+To use GoogleApps authentication with Octopus Server, GoogleApps must be configured to trust Octopus - by setting it up as an app. This section covers the details on how to configure the app.
 
 ## Configure GoogleApps {#GoogleAppsauthentication-ConfiguringGoogleApps}
 
@@ -27,13 +27,9 @@ Once you have an account, log in to [https://console.developers.google.com](htt
 7. Add `https://octopus.example.com/api/users/authenticatedToken/GoogleApps` (replacing `https://octopus.example.com` with the url of your Octopus Server) to the **Authorized Redirect URIs**.
 
 :::hint
-**Reply URLs are case-sensitive**
-Be aware that the path in this URL after the domain name was **case sensitive** during our testing.
-:::
-
-:::hint
-**Not using SSL?**
-That's OK, you can use `http` if you do not have SSL enabled on your Octopus Server. Please beware of the security implications in accepting a security token over an insecure channel.
+**Common issues:**
+- **Reply URLs are case-sensitive** - Be aware that the path in this URL after the domain name was **case sensitive** during our testing.
+- **Not using SSL?** - You can use `http` if you do not have SSL enabled on your Octopus Server. Please beware of the security implications in accepting a security token over an insecure channel.
 :::
 
 ## Configure Octopus Server {#GoogleAppsauthentication-ConfiguringOctopusDeployServer}
@@ -54,10 +50,8 @@ Alternatively these settings can be defined through the user interface by select
 
 Even if you are using an external identity provider, Octopus still requires a [user account](/docs/security/users-and-teams/index.md) so you can assign those people to Octopus teams and subsequently grant permissions to Octopus resources. Octopus will automatically create a [user account](/docs/security/users-and-teams/index.md) based on the profile information returned in the security token, which includes an **Identifier**, **Name**, and **Email Address**.
 
-:::hint
 **How Octopus matches external identities to user accounts**
 When the security token is returned from the external identity provider, Octopus looks for a user account with a **matching Identifier**. If there is no match, Octopus looks for a user account with a **matching Email Address**. If a user account is found, the External Identifier will be added to the user account for next time. If a user account is not found, Octopus will create one using the profile information in the security token.
-:::
 
 :::success
 **Already have Octopus user accounts?**

--- a/docs/security/authentication/googleapps-authentication.md
+++ b/docs/security/authentication/googleapps-authentication.md
@@ -5,7 +5,7 @@ position: 2
 ---
 
 :::hint
-GoogleApps authentication can only be configured for Octopus Server. For [Octopus Cloud](/docs/octopus-cloud/index.md), authentication using GoogleApps is supported with [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information. 
+GoogleApps authentication can only be configured for Octopus Server. For [Octopus Cloud](/docs/octopus-cloud/index.md), authentication using GoogleApps is supported with [Octopus ID](octopusid-authentication.md). See our [authentication provider compatibility](/docs/security/authentication/auth-provider-compatibility.md) section for further information. 
 :::
 
 To use GoogleApps authentication with Octopus Server, GoogleApps must be configured to trust Octopus - by setting it up as an app. This section covers the details on how to configure the app.

--- a/docs/security/authentication/googleapps-authentication.md
+++ b/docs/security/authentication/googleapps-authentication.md
@@ -1,7 +1,7 @@
 ---
 title: GoogleApps authentication
 description: Octopus Deploy can use GoogleApps authentication to identify users.
-position: 2
+position: 15
 ---
 
 :::hint

--- a/docs/security/authentication/googleapps-authentication.md
+++ b/docs/security/authentication/googleapps-authentication.md
@@ -27,9 +27,10 @@ Once you have an account, log in to [https://console.developers.google.com](htt
 7. Add `https://octopus.example.com/api/users/authenticatedToken/GoogleApps` (replacing `https://octopus.example.com` with the url of your Octopus Server) to the **Authorized Redirect URIs**.
 
 :::hint
-**Common issues:**
+**Tips:**
 - **Reply URLs are case-sensitive** - Be aware that the path in this URL after the domain name was **case sensitive** during our testing.
-- **Not using SSL?** - You can use `http` if you do not have SSL enabled on your Octopus Server. Please beware of the security implications in accepting a security token over an insecure channel.
+- **Not using SSL?** - We highly recommend using SSL, but we know its not always possible. You can use `http` if you do not have SSL enabled on your Octopus Server. Please beware of the security implications in accepting a security token over an insecure channel.
+Octopus integrates with [Let's Encrypt](/docs/security/exposing-octopus/lets-encrypt-integration.md) making it easier to setup SSL on your Octopus Server.
 :::
 
 ## Configure Octopus Server {#GoogleAppsauthentication-ConfiguringOctopusDeployServer}

--- a/docs/security/authentication/guest-login.md
+++ b/docs/security/authentication/guest-login.md
@@ -1,7 +1,7 @@
 ---
 title: Guest login
 description: Octopus Deploy supports a guest login if enabled.
-position: 4
+position: 20
 ---
 
 Sometimes you may wish to allow users to access your Octopus Server, without requiring them to create an account. Octopus provides the ability to configure a special guest login for your Octopus Server.

--- a/docs/security/authentication/index.md
+++ b/docs/security/authentication/index.md
@@ -13,18 +13,9 @@ Octopus Deploy supports the most common authentication providers out-of-the-box,
 - [Octopus ID](octopusid-authentication.md)
 - [Guest Login](/docs/security/authentication/guest-login.md)
 
-## Authentication provider support {#authentication-provider-support}
-
-|                                       | Octopus Server     | Octopus Cloud   |
-|---------------------------------------|:------------------:|:---------------:|
-| Username and Password                 | :white_check_mark: | :white_check_mark: *via Octopus ID |
-| Active Directory Authentication       | :white_check_mark: | :x: |
-| Azure Active Directory Authentication | :white_check_mark: | :white_check_mark: *via Octopus ID |
-| GoogleApps Authentication             | :white_check_mark: | :white_check_mark: *via Octopus ID |
-| Okta Authentication                   | :white_check_mark: | :x: |
-| Octopus ID                            | :x: | :white_check_mark: |
-| GitHub                                | :white_check_mark: | :white_check_mark: |
-| Guest Login                           | :x: | :white_check_mark: (via Octopus ID) |
+:::hint
+Support for authentication providers differ between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). Please see our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information. 
+:::
 
 ## Configuring authentication providers {#AuthenticationProviders-ConfiguringAuthenticationProviders}
 

--- a/docs/security/authentication/index.md
+++ b/docs/security/authentication/index.md
@@ -14,7 +14,7 @@ Octopus Deploy supports the most common authentication providers out-of-the-box,
 - [Guest Login](/docs/security/authentication/guest-login.md)
 
 :::hint
-Support for authentication providers differ between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). Please see our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information. 
+Support for authentication providers differ between Octopus Server and [Octopus Cloud](/docs/octopus-cloud/index.md). Please see our [authentication provider compatibility](/docs/security/authentication/auth-provider-compatibility.md) section for further information. 
 :::
 
 ## Configuring authentication providers {#AuthenticationProviders-ConfiguringAuthenticationProviders}

--- a/docs/security/authentication/index.md
+++ b/docs/security/authentication/index.md
@@ -13,6 +13,19 @@ Octopus Deploy supports the most common authentication providers out-of-the-box,
 - [Octopus ID](octopusid-authentication.md)
 - [Guest Login](/docs/security/authentication/guest-login.md)
 
+## Authentication provider support {#authentication-provider-support}
+
+|                                       | Octopus Server     | Octopus Cloud   |
+|---------------------------------------|--------------------|-----------------|
+| Username and Password                 | :heavy_check_mark: | :heavy_check_mark: (via Octopus ID) |
+| Active Directory Authentication       | :heavy_check_mark: | :x: |
+| Azure Active Directory Authentication | :heavy_check_mark: | :heavy_check_mark: (via Octopus ID) |
+| GoogleApps Authentication             | :heavy_check_mark: | :heavy_check_mark: (via Octopus ID) |
+| Okta Authentication                   | :heavy_check_mark: | :x: |
+| Octopus ID                            | :x: | :heavy_check_mark: |
+| GitHub                                | :heavy_check_mark: | :heavy_check_mark: |
+| Guest Login                           | :x: | :heavy_check_mark: (via Octopus ID) |
+
 ## Configuring authentication providers {#AuthenticationProviders-ConfiguringAuthenticationProviders}
 
 You can use the web user interface to configure authentication providers at {{Configuration>Settings}}.

--- a/docs/security/authentication/index.md
+++ b/docs/security/authentication/index.md
@@ -16,15 +16,15 @@ Octopus Deploy supports the most common authentication providers out-of-the-box,
 ## Authentication provider support {#authentication-provider-support}
 
 |                                       | Octopus Server     | Octopus Cloud   |
-|---------------------------------------|--------------------|-----------------|
-| Username and Password                 | :white_check_mark: | :white_check_mark: (via Octopus ID) |
-| Active Directory Authentication       | :ballot_box_with_check: | :x: |
-| Azure Active Directory Authentication | :ballot_box_with_check: | :ballot_box_with_check: (via Octopus ID) |
-| GoogleApps Authentication             | :ballot_box_with_check: | :ballot_box_with_check: (via Octopus ID) |
-| Okta Authentication                   | :ballot_box_with_check: | :x: |
-| Octopus ID                            | :x: | :ballot_box_with_check: |
-| GitHub                                | :ballot_box_with_check: | :ballot_box_with_check: |
-| Guest Login                           | :x: | :ballot_box_with_check: (via Octopus ID) |
+|---------------------------------------|:------------------:|:---------------:|
+| Username and Password                 | :white_check_mark: | :white_check_mark: *via Octopus ID |
+| Active Directory Authentication       | :white_check_mark: | :x: |
+| Azure Active Directory Authentication | :white_check_mark: | :white_check_mark: *via Octopus ID |
+| GoogleApps Authentication             | :white_check_mark: | :white_check_mark: *via Octopus ID |
+| Okta Authentication                   | :white_check_mark: | :x: |
+| Octopus ID                            | :x: | :white_check_mark: |
+| GitHub                                | :white_check_mark: | :white_check_mark: |
+| Guest Login                           | :x: | :white_check_mark: (via Octopus ID) |
 
 ## Configuring authentication providers {#AuthenticationProviders-ConfiguringAuthenticationProviders}
 

--- a/docs/security/authentication/index.md
+++ b/docs/security/authentication/index.md
@@ -17,14 +17,14 @@ Octopus Deploy supports the most common authentication providers out-of-the-box,
 
 |                                       | Octopus Server     | Octopus Cloud   |
 |---------------------------------------|--------------------|-----------------|
-| Username and Password                 | :heavy_check_mark: | :heavy_check_mark: (via Octopus ID) |
-| Active Directory Authentication       | :heavy_check_mark: | :x: |
-| Azure Active Directory Authentication | :heavy_check_mark: | :heavy_check_mark: (via Octopus ID) |
-| GoogleApps Authentication             | :heavy_check_mark: | :heavy_check_mark: (via Octopus ID) |
-| Okta Authentication                   | :heavy_check_mark: | :x: |
-| Octopus ID                            | :x: | :heavy_check_mark: |
-| GitHub                                | :heavy_check_mark: | :heavy_check_mark: |
-| Guest Login                           | :x: | :heavy_check_mark: (via Octopus ID) |
+| Username and Password                 | :white_check_mark: | :white_check_mark: (via Octopus ID) |
+| Active Directory Authentication       | :ballot_box_with_check: | :x: |
+| Azure Active Directory Authentication | :ballot_box_with_check: | :ballot_box_with_check: (via Octopus ID) |
+| GoogleApps Authentication             | :ballot_box_with_check: | :ballot_box_with_check: (via Octopus ID) |
+| Okta Authentication                   | :ballot_box_with_check: | :x: |
+| Octopus ID                            | :x: | :ballot_box_with_check: |
+| GitHub                                | :ballot_box_with_check: | :ballot_box_with_check: |
+| Guest Login                           | :x: | :ballot_box_with_check: (via Octopus ID) |
 
 ## Configuring authentication providers {#AuthenticationProviders-ConfiguringAuthenticationProviders}
 

--- a/docs/security/authentication/octopusid-authentication.md
+++ b/docs/security/authentication/octopusid-authentication.md
@@ -5,7 +5,7 @@ position: 7
 ---
 
 :::hint
-Octopus ID authentication is available only in **Octopus Cloud** and is being progressively rolled out to customers.
+Octopus ID authentication is only available in [Octopus Cloud](/docs/octopus-cloud/index.md) and is being progressively rolled out to customers.
 :::
 
 Octopus ID authentication allows you to log in to your Octopus Cloud instance using the same account that you use to sign in at [octopus.com](https://octopus.com). This allows you to manage who is able to access your Octopus instance from [your organization](https://octopus.com/organization/) and saves you time when moving between our website and your instance.

--- a/docs/security/authentication/octopusid-authentication.md
+++ b/docs/security/authentication/octopusid-authentication.md
@@ -1,7 +1,7 @@
 ---
 title: Octopus ID authentication
 description: Octopus Deploy can use Octopus accounts to identify users.
-position: 7
+position: 30
 ---
 
 :::hint

--- a/docs/security/authentication/okta-authentication.md
+++ b/docs/security/authentication/okta-authentication.md
@@ -46,14 +46,10 @@ After signing up to Okta you will receive your own url to access the Okta portal
    ![](okta/okta-create-openid-integration.png "width=500")
 
 :::hint
-**Reply URLs are case-sensitive**
-Please take care when adding this URL. They are **case-sensitive** and can be sensitive to trailing **slash** characters.
-:::
-
-:::hint
-**Not using SSL?**
-We highly recommend using SSL, but we know its not always possible. You can use `http` if you do not have SSL enabled on your Octopus Server. Please beware of the security implications in accepting a security token over an insecure channel.
-Octopus now integrates with [Let's Encrypt](/docs/security/exposing-octopus/lets-encrypt-integration.md) making it easier to setup SSL on your Octopus Server.
+**Tips::**
+- **Reply URLs are case-sensitive** - Please take care when adding this URL. They are **case-sensitive** and can be sensitive to trailing **slash** characters.
+- **Not using SSL?** - We highly recommend using SSL, but we know its not always possible. You can use `http` if you do not have SSL enabled on your Octopus Server. Please beware of the security implications in accepting a security token over an insecure channel.
+Octopus integrates with [Let's Encrypt](/docs/security/exposing-octopus/lets-encrypt-integration.md) making it easier to setup SSL on your Octopus Server.
 :::
 
 5. Under the **General Settings** for the app you have just created, ensure that **Implicit (Hybrid)** and **Allow ID Token with implicit grant type** are both checked, under the **Allowed grant types**. Click the **Save** button to continue.

--- a/docs/security/authentication/okta-authentication.md
+++ b/docs/security/authentication/okta-authentication.md
@@ -1,8 +1,7 @@
 ---
 title: Okta authentication
 description: Octopus Deploy can use Okta authentication to identify users.
-position: 6
-version: 3.16
+position: 25
 ---
 
 :::hint

--- a/docs/security/authentication/okta-authentication.md
+++ b/docs/security/authentication/okta-authentication.md
@@ -6,7 +6,7 @@ version: 3.16
 ---
 
 :::hint
-Okta authentication only works with Octopus Server and does not work with [Octopus Cloud](/docs/octopus-cloud/index.md).
+Okta authentication can only be configured for Octopus Server and not for [Octopus Cloud](/docs/octopus-cloud/index.md). See our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information.
 :::
 
 Authentication using [Okta](https://www.okta.com/), a cloud-based identity management service.

--- a/docs/security/authentication/okta-authentication.md
+++ b/docs/security/authentication/okta-authentication.md
@@ -6,7 +6,7 @@ version: 3.16
 ---
 
 :::hint
-Okta authentication can only be configured for Octopus Server and not for [Octopus Cloud](/docs/octopus-cloud/index.md). See our [authentication provider compatibility](/docs/authentication/auth-provider-compatibility.md) section for further information.
+Okta authentication can only be configured for Octopus Server and not for [Octopus Cloud](/docs/octopus-cloud/index.md). See our [authentication provider compatibility](/docs/security/authentication/auth-provider-compatibility.md) section for further information.
 :::
 
 Authentication using [Okta](https://www.okta.com/), a cloud-based identity management service.

--- a/docs/security/authentication/troubleshooting-authentication-problems.md
+++ b/docs/security/authentication/troubleshooting-authentication-problems.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting authentication problems
 description: A guide for troubleshooting authentication problems in Octopus Deploy.
-position: 40
+position: 50
 ---
 
 We take every reasonable effort to make Octopus Deploy secure by enabling you to use the best [authentication provider](/docs/security/authentication/index.md) for your organization. This guide will help you troubleshoot any problems you may encounter when signing in to the Octopus Deploy portal.


### PR DESCRIPTION
- Added a new compatibility page for the authentication providers
- Updated warning hint blocks to _hopefully_ more accurately describe auth differences between Cloud and Server
- Consolidated a few areas where double hints were present on auth provider pages
- Re-ordered pages to allow compatibility page to be the first child in sub-menu

This change has been deployed to the pre-prod site if you want to visualise the changes

**Could reviewers please check:**
- The matrix for support, and any footnotes for accuracy
- Particularly the External groups section :smile: 