### PR TITLE
Remove reference to Windows 2003

### DIFF
--- a/docs/shared-content/tentacle/tentacle-downloads.include.md
+++ b/docs/shared-content/tentacle/tentacle-downloads.include.md
@@ -1,9 +1,3 @@
 ## Download the Tentacle installer
 
 Octopus Tentacle is available to download for both Windows and Linux (GZip, APT, and RPM) from the [downloads page](https://octopus.com/downloads).
-
-:::warning
-If you are using Windows Server 2003 with .NET Framework 4.0, you will need to download either:
-- [Octopus Tentacle x64](https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.0.26.0-x64.msi)
-- [Octopus Tentacle 32-bit/x86](https://download.octopusdeploy.com/octopus/Octopus.Tentacle.3.0.26.0.msi)
-:::


### PR DESCRIPTION
This is a small thing. I hope no one is still using Windows Server 2003, but since it's not officially supported by Tentacle, I think we shouldn't suggest anything here.