### PR TITLE
Updating cli docs for tentacle.exe

### DIFF
--- a/docs/octopus-rest-api/tentacle.exe-command-line/agent.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/agent.md
@@ -13,6 +13,7 @@ Usage: tentacle agent [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --wait=VALUE           Delay (ms) before starting
       --console              Don't attempt to run as a service, even if the
                                user is non-interactive

--- a/docs/octopus-rest-api/tentacle.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/configure.md
@@ -13,6 +13,7 @@ Usage: tentacle configure [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --home, --homedir=VALUE
                              Home directory
       --app, --appdir=VALUE  Default directory to deploy applications to

--- a/docs/octopus-rest-api/tentacle.exe-command-line/delete-instance.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/delete-instance.md
@@ -13,6 +13,7 @@ Usage: tentacle delete-instance [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
 
 Or one of the common options:
 

--- a/docs/octopus-rest-api/tentacle.exe-command-line/deregister-from.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/deregister-from.md
@@ -13,6 +13,7 @@ Usage: tentacle deregister-from [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --server=VALUE         The Octopus Server - e.g., 'http://octopus'
       --apiKey=VALUE         Your API key; you can get this from the Octopus
                                web portal

--- a/docs/octopus-rest-api/tentacle.exe-command-line/deregister-worker.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/deregister-worker.md
@@ -13,6 +13,7 @@ Usage: tentacle deregister-worker [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --server=VALUE         The Octopus Server - e.g., 'http://octopus'
       --apiKey=VALUE         Your API key; you can get this from the Octopus
                                web portal

--- a/docs/octopus-rest-api/tentacle.exe-command-line/import-certificate.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/import-certificate.md
@@ -13,6 +13,7 @@ Usage: tentacle import-certificate [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
   -r, --from-registry        Import the Octopus Tentacle 1.x certificate from
                                the Windows registry
   -f, --from-file=VALUE      Import a certificate from the specified file

--- a/docs/octopus-rest-api/tentacle.exe-command-line/new-certificate.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/new-certificate.md
@@ -13,6 +13,7 @@ Usage: tentacle new-certificate [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
   -b, --if-blank             Generates a new certificate only if there is none
   -e, --export-file=VALUE    DEPRECATED: Exports a new certificate to the
                                specified file as unprotected base64 text, but

--- a/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md
@@ -13,6 +13,7 @@ Usage: tentacle poll-server [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --server=VALUE         The Octopus Server - e.g., 'http://octopus'
       --apiKey=VALUE         Your API key; you can get this from the Octopus
                                web portal

--- a/docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy.md
@@ -13,6 +13,7 @@ Usage: tentacle polling-proxy [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --proxyEnable=VALUE    Whether to use a proxy
       --proxyUsername=VALUE  Username to use when authenticating with the
                                proxy

--- a/docs/octopus-rest-api/tentacle.exe-command-line/proxy.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/proxy.md
@@ -13,6 +13,7 @@ Usage: tentacle proxy [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --proxyEnable=VALUE    Whether to use a proxy
       --proxyUsername=VALUE  Username to use when authenticating with the
                                proxy

--- a/docs/octopus-rest-api/tentacle.exe-command-line/register-with.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/register-with.md
@@ -13,6 +13,7 @@ Usage: tentacle register-with [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --server=VALUE         The Octopus Server - e.g., 'http://octopus'
       --apiKey=VALUE         Your API key; you can get this from the Octopus
                                web portal

--- a/docs/octopus-rest-api/tentacle.exe-command-line/register-worker.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/register-worker.md
@@ -13,6 +13,7 @@ Usage: tentacle register-worker [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --server=VALUE         The Octopus Server - e.g., 'http://octopus'
       --apiKey=VALUE         Your API key; you can get this from the Octopus
                                web portal

--- a/docs/octopus-rest-api/tentacle.exe-command-line/server-comms.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/server-comms.md
@@ -13,6 +13,7 @@ Usage: tentacle server-comms [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --thumbprint=VALUE     The thumbprint of the Octopus Server to
                                configure communication with; if only one
                                Octopus Server is configured, this may be omitted

--- a/docs/octopus-rest-api/tentacle.exe-command-line/show-configuration.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/show-configuration.md
@@ -13,6 +13,7 @@ Usage: tentacle show-configuration [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --file=VALUE           Exports the server configuration to a file. If
                                not specified output goes to the console
       --space=VALUE          The space from which the server data

--- a/docs/octopus-rest-api/tentacle.exe-command-line/show-thumbprint.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/show-thumbprint.md
@@ -13,6 +13,7 @@ Usage: tentacle show-thumbprint [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
   -e, --export-file=VALUE    Exports the Tentacle thumbprint to a file
       --thumbprint-only      DEPRECATED: Only print out the thumbprint, with
                                no additional text. This switch has been

--- a/docs/octopus-rest-api/tentacle.exe-command-line/update-trust.md
+++ b/docs/octopus-rest-api/tentacle.exe-command-line/update-trust.md
@@ -13,6 +13,7 @@ Usage: tentacle update-trust [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --oldThumbprint=VALUE  The thumbprint of the old Octopus Server to be
                                replaced
       --newThumbprint=VALUE  The thumbprint of the new Octopus Server


### PR DESCRIPTION
An automated update of the command line docs for tentacle.exe version 6.0.481.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 238