### PR TITLE
Updating cli docs for octopus.migrator.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.migrator.exe-command-line/export.md
+++ b/docs/octopus-rest-api/octopus.migrator.exe-command-line/export.md
@@ -13,6 +13,7 @@ Usage: octopus.migrator export [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --directory=VALUE      The target directory for the exported data file-
                                s. This directory will be created if it does not
                                already exist. Use the --clean argument to purge

--- a/docs/octopus-rest-api/octopus.migrator.exe-command-line/import.md
+++ b/docs/octopus-rest-api/octopus.migrator.exe-command-line/import.md
@@ -15,6 +15,7 @@ Usage: octopus.migrator import [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --directory=VALUE      Directory for imported files
       --password=VALUE       Password for any sensitive values
       --dry-run              Do not commit changes, just print what would

--- a/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md
+++ b/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md
@@ -13,6 +13,7 @@ Usage: octopus.migrator migrate [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --file=VALUE           Octopus 2.6 (.octobak) file
       --master-key=VALUE     Master Key used to decrypt the file
       --dry-run              Do not commit changes, just print what would

--- a/docs/octopus-rest-api/octopus.migrator.exe-command-line/partial-export.md
+++ b/docs/octopus-rest-api/octopus.migrator.exe-command-line/partial-export.md
@@ -13,6 +13,7 @@ Usage: octopus.migrator partial-export [<options>]
 Where [<options>] is any of:
 
       --instance=VALUE       Name of the instance to use
+      --config=VALUE         Configuration file to use
       --directory=VALUE      The target directory for the exported data file-
                                s. This directory will be created if it does not
                                already exist. Use the --clean argument to purge


### PR DESCRIPTION
An automated update of the command line docs for octopus.migrator.exe version 2020.6.4688.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 239