### PR TITLE
Deprecating Octopus Server windows container images

### DIFF
--- a/docs/installation/octopus-in-container/docker-compose-linux.md
+++ b/docs/installation/octopus-in-container/docker-compose-linux.md
@@ -7,8 +7,6 @@ position: 3
 There is a [known issue](https://github.com/OctopusDeploy/Issues/issues/6629) when providing both the `ADMIN_PASSWORD` and `ADMIN_API_KEY` for the Octopus Server Linux Container that prevents the Administrator from logging in. This will be resolved in a future version of Octopus.
 :::
 
-If you want to run an Octopus Deploy Windows container or a Tentacle Windows Container, please refer to the [Docker Compose Windows](/docs/installation/octopus-in-container/docker-compose-windows.md) documentation.
-
 For evaluation purposes you may want to run a stand-alone SQL Server instance alongside the Octopus Server. For this scenario, you can leverage [Docker Compose](https://docs.docker.com/compose/overview/) to spin up and manage a multi-container Docker application as a single unit.
 
 The following example is a simple `docker-compose.yml` file combining a SQL Server instance with a dependent Octopus Server:

--- a/docs/installation/octopus-in-container/docker-compose-windows.md
+++ b/docs/installation/octopus-in-container/docker-compose-windows.md
@@ -4,7 +4,10 @@ description: A fully self-contained SQL Server, Octopus Server and Octopus Tenta
 position: 3
 ---
 
-If you want to run an Octopus Deploy Linux container with Docker Compose, please refer to the [Docker Compose Linux](/docs/installation/octopus-in-container/docker-compose-linux.md) documentation.
+:::warning
+The Octopus Deploy Server Windows containers are deprecated, and no longer maintained.
+For hosting Octopus Server in a container, we recommend using the [Octopus Server Linux Container](/docs/installation/octopus-in-container/docker-compose-linux.md).
+:::
 
 For evaluation purposes you may want to run a stand-alone SQL Server instance to run alongside the Octopus Server. For this scenario, you can leverage [Docker Compose](https://docs.docker.com/compose/overview/) to spin up and manage a multi-container Docker application as a single unit.
 

--- a/docs/installation/octopus-in-container/octopus-server-container-linux.md
+++ b/docs/installation/octopus-in-container/octopus-server-container-linux.md
@@ -5,10 +5,10 @@ position: 1
 ---
 
 :::hint
-Octopus Server Linux Containers launched as part of **2020.6** and it's our recommended way to use containers with Octopus Deploy. You will need to upgrade to **2020.6** before using the Octopus Linux Container.
+Octopus Server Linux Containers launched as part of **2020.6**. You will need to upgrade to **2020.6** before using the Octopus Linux Container.
 :::
 
-This page describes how to run Octopus Deploy within a Linux Container. If you want to run an Octopus Deploy Windows container, please refer to the [Octopus Server Container Windows](/docs/installation/octopus-in-container/octopus-server-container-windows.md) documentation.
+This page describes how to run Octopus Deploy within a Linux Container.
 
 **Note:** When using Linux containers on a Windows machine, please ensure you have [switched to Linux Containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
 

--- a/docs/installation/octopus-in-container/octopus-server-container-windows.md
+++ b/docs/installation/octopus-in-container/octopus-server-container-windows.md
@@ -5,7 +5,8 @@ position: 1
 ---
 
 :::warning
-For hosting Octopus in a container, we recommend using the [Octopus Server Linux Container](/docs/installation/octopus-in-container/octopus-server-container-linux.md).
+The Octopus Deploy Server Windows containers are deprecated, and no longer maintained.
+For hosting Octopus Server in a container, we recommend using the [Octopus Server Linux Container](/docs/installation/octopus-in-container/octopus-server-container-linux.md).
 :::
 
 Running the Octopus Server inside a container provides a simple way to set up an Octopus Deploy instance. Upgrading to the latest version of Octopus is just a matter of running a new container with the new image version.

--- a/docs/installation/octopus-in-container/troubleshooting-octopus-server-in-a-container.md
+++ b/docs/installation/octopus-in-container/troubleshooting-octopus-server-in-a-container.md
@@ -4,6 +4,11 @@ description: Troubleshooting steps for running Octopus Deploy in a Container
 position: 10
 ---
 
+:::warning
+The Octopus Deploy Server Windows containers are deprecated, and no longer maintained.
+For hosting Octopus Server in a container, we recommend using the [Octopus Server Linux Container](/docs/installation/octopus-in-container/octopus-server-container-linux.md).
+:::
+
 ## Ensure you've accepted the EULA
 
 When you create an Octopus Server container, you must agree with the [Octopus Deploy EULA](https://octopus.com/company/legal).
@@ -28,7 +33,7 @@ or
 ```
 image operating system "linux" cannot be used on this platform.
 ```
-then you likely are using an Windows image with Linux Containers or a Linux image with Windows Containers.
+then you likely are using a Windows image with Linux Containers or a Linux image with Windows Containers.
 
 When running Containers on a Windows host machine, there is the options to run both Windows Containers and Linux Containers. Docker must be set to the correct container mode for the image you are using. Please refer to [switching between Windows and Linux Containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers) documentation to learn how to switch between them.
 


### PR DESCRIPTION
We have decided to [deprecate support for hosting Octopus Server](https://octopusdeploy.slack.com/archives/C033W4273/p1621221332252800) in a windows container.