### PR TITLE
Fixes Octo CLI help command example in packaging applications

### DIFF
--- a/docs/packaging-applications/create-packages/octopus-cli.md
+++ b/docs/packaging-applications/create-packages/octopus-cli.md
@@ -21,7 +21,7 @@ For more installation details, options, and update instructions, see [The Octopu
 For a full list of the `pack` command options see [Octopus CLI - Pack](/docs/octopus-rest-api/octopus-cli/pack.md) or run the following command:
 
 ```powershell
-C:\> dotnet octo help pack
+dotnet octo help pack
 ```
 
 ## Usage


### PR DESCRIPTION
This is a minor fix to the help command example that is given in the "Create packages with the Octopus CLI" page, the current version doesn't run when pasted into powershell as it includes the path "C:\>"