### PR TITLE
Updates our Azure tool guidance

### DIFF
--- a/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md
+++ b/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md
@@ -3,26 +3,33 @@ title: Configuring the version of the Azure CLI
 description: A version of Azure CLI is bundled with Octopus Deploy and it's possible to configure which version you wish to use in your deployments.
 ---
 
-A version of [Azure CLI](https://docs.microsoft.com/cli/azure/) is bundled with Octopus Deploy.  To determine the version of the bundled CLI, add the command below to an Azure PowerShell Script Step:
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+:::
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+
+To determine the version of the bundled CLI is installed on your worker, add the command below to an Azure Script Step:
 
 ```powershell
 az --version
 ```
 
-If you wish to use a different version, you can install the Azure CLI on your Octopus Server, and configure Octopus to use the installed version instead. 
+If you wish to use a different version, you can install the Azure CLI on your worker, and configure Octopus to use the installed version.
+
+To be compatible with Octopus's automated Azure CLI login behaviour, the Azure CLI version you install must be 2.0 or above.
 
 The procedure to configure this differs depending on which version of Octopus Deploy you are using:
 
 ## Octopus 2020.1 or newer {#ConfiguringtheversionoftheAzurePowerShellmodules-Octopus2020.1(ornewer)}
 
-The PowerShell Azure step has an option called "Azure Tools". Toggle the setting to **Use Azure Tools pre-installed on the worker**.
+The Azure Script step has an option called "Azure Tools". Toggle the setting to **Use Azure Tools pre-installed on the worker** if it is not already selected.
 
 ## Octopus 2018.5.5 to 2019.13.7 {#ConfiguringtheversionoftheAzurePowerShellmodules-Octopus2018.5.5-to-2019.13.7}
 
 Create a [variable](/docs/projects/variables/index.md) named **OctopusUseBundledAzureCLI** and set its value to **False**.
 
 With this value set, Octopus Deploy will not load the bundled Azure CLI.
-
 
 If you need to disable the Azure CLI altogether due to errors or the added time to login to the CLI, use **OctopusDisableAzureCLI** and set its value to **True**.
 

--- a/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md
+++ b/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md
@@ -17,7 +17,7 @@ az --version
 
 If you wish to use a different version, you can install the Azure CLI on your worker, and configure Octopus to use the installed version.
 
-To be compatible with Octopus's automated Azure CLI login behaviour, the Azure CLI version you install must be 2.0 or above.
+To be compatible with Octopus's automated Azure CLI login behavior, the Azure CLI version you install must be 2.0 or above.
 
 The procedure to configure this differs depending on which version of Octopus Deploy you are using:
 

--- a/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md
+++ b/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md
@@ -7,7 +7,7 @@ description: A version of Azure CLI is bundled with Octopus Deploy and it's poss
 Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
 :::
 
-We recommend you configure Octopus Deploy to use your own [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+We recommend you configure Octopus Deploy to use your own version of the Azure CLI.
 
 To determine the version of the bundled CLI is installed on your worker, add the command below to an Azure Script Step:
 

--- a/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md
+++ b/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md
@@ -3,7 +3,13 @@ title: Configuring the version of the Azure PowerShell Modules
 description: A version of Azure PowerShell is bundled with Octopus Deploy and it's possible to configure which version you wish to use in your deployments.
 ---
 
-A version of Azure PowerShell is bundled with Octopus Deploy.  To determine the versions of the various Azure modules, add the PowerShell below to an Azure PowerShell Script Step:
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+:::
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md).
+
+To determine the versions of the various Azure modules that are present on your worker, add the PowerShell below to an Azure Script Step:
 
 **AzureRM Module Versions**
 
@@ -17,11 +23,11 @@ Get-Module -ListAvailable -Name Azure*
 Get-Module -ListAvailable -Name Az*
 ```
 
-If you wish to use a different version, you can install the Azure PowerShell modules on your Octopus Server, and configure Octopus to use the installed version.  The procedure to configure this differs depending on which version of Octopus Deploy you are using:
+If you wish to use a different version, you can install the Azure PowerShell modules on your worker, and configure Octopus to use those modules. The procedure to configure Octopus to use the installed modules differs depending on which version you are using:
 
 ## Octopus 2020.1 or newer {#ConfiguringtheversionoftheAzurePowerShellmodules-Octopus2020.1(ornewer)}
 
-The PowerShell Azure step has an option called "Azure Tools". Toggle the setting to **Use Azure Tools pre-installed on the worker**.
+The Azure Script step has an option called "Azure Tools". Toggle the setting to **Use Azure Tools pre-installed on the worker** if it is not already selected.
 
 ## Octopus 2018.5.5 to 2019.13.7 {#ConfiguringtheversionoftheAzurePowerShellmodules-Octopus2018.5.5-to-2019.13.7}
 

--- a/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md
+++ b/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md
@@ -7,7 +7,7 @@ description: A version of Azure PowerShell is bundled with Octopus Deploy and it
 Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
 :::
 
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md).
+We recommend you configure Octopus Deploy to use your own version of the Azure PowerShell cmdlets.
 
 To determine the versions of the various Azure modules that are present on your worker, add the PowerShell below to an Azure Script Step:
 

--- a/docs/deployments/azure/running-azure-powershell/index.md
+++ b/docs/deployments/azure/running-azure-powershell/index.md
@@ -4,20 +4,29 @@ description: Octopus supports executing PowerShell against Azure and will automa
 hideInThisSectionHeader: true
 ---
 
-:::warning
-Using the Azure tools bundled with Octopus Deploy is not recommended. You can continue to use both the bundled cmdlets and CLI. However, it is recommended to configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+Octopus Deploy can help you run scripts on targets within Microsoft Azure.
 
-The Azure Resource Manager Powershell modules (AzureRM) that are included have been replaced by Azure Powershell Modules (Az). See [Introducing the Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/new-azureps-module-az) for further information about migrating from AzureRM to Az.
+These scripts typically rely on tools being available on the target worker.
+
+We recommend that you provision your own tools on your worker - this way you can control what version of the tools are provisioned, and ensure their compatibility with the scripts you are trying to execute.
+
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
 :::
 
-When executing PowerShell against Azure, Octopus Deploy will automatically import the [Azure Resource Manager (AzureRM) PowerShell](https://docs.microsoft.com/powershell/azure/azurerm/overview) and the [Azure PowerShell modules](https://docs.microsoft.com/powershell/azure/overview) if they are present on the worker. The Azure PowerShell modules require the [Azure CLI](https://docs.microsoft.com/cli/azure/) version 2.0 or above to be installed on the worker. Finally, it will authenticate with Azure using the configured [Azure Account](/docs/infrastructure/deployment-targets/azure/index.md).
+When executing PowerShell against Azure, Octopus Deploy will automatically use your configured Azure account details to authenticate you into the [AzureRM PowerShell modules](https://docs.microsoft.com/powershell/azure/azurerm/overview), the [Azure PowerShell modules](https://docs.microsoft.com/powershell/azure/overview), and [Azure CLI tools](https://docs.microsoft.com/cli/azure/), if they exist on the worker executing the script.
 
 This applies to:
 
 - 'Run an Azure Script' steps.
 - Scripts packaged or configured with [Deploying a package to an Azure Cloud Service](/docs/deployments/azure/cloud-services/index.md) or [Azure Web App](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md) steps.
 
+This functionality requires the Azure CLI version 2.0 or above to be installed on the worker.
+
 **Choosing the right Azure account type**
+
 Azure supports two authentication methods, each of which provides access to a different set of Azure APIs:
 
 - To use the Azure Service Management (ASM) API, use an [Azure Management Certificate Account](/docs/infrastructure/deployment-targets/azure/index.md#azure-management-certificate).
@@ -34,12 +43,6 @@ Octopus Deploy provides a *Run an Azure PowerShell Script* step type, for exec
 ![](5865912.png "width=170")
 
 ![](azure-new-powershell-script-step.png "width=500")
-
-### Staying up to date
-
-Octopus Deploy ships with a version of the Azure RM PowerShell Modules and Azure CLI, so you can deploy applications as soon as you install Octopus Deploy. Microsoft Azure is changing very quickly, introducing more application services and commands frequently. In addition the AzureRM Powershell modules only work on Windows workers. 
-
-You can use the bundled cmdlets or/and CLI if they cover everything you need; however, this is **not recommended**. Instead, consider configuring Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and/or [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
 
 ## Learn more
 


### PR DESCRIPTION
This PR makes changes to our Azure Script Step documentation.

The main reason for the changes was to make it very explicit that we do not recommend people use the inbuilt Azure tools, and that we will no longer be updating them.