### PR TITLE
Remove 2008 R2 as a supported option

### DIFF
--- a/docs/infrastructure/deployment-targets/windows-targets/requirements/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/requirements/index.md
@@ -11,14 +11,13 @@ The installation requirements for the latest version of Tentacle are:
 
 ## Windows Server
 
--  Windows Server 2008 R2
 -  Windows Server 2012
 -  Windows Server 2012 R2 
 -  Windows Server 2016 (Both "Server Core" and "Server with a GUI" installations are supported for Tentacle).
 -  Windows Server 2019 
 
 :::warning
-Octopus does not actively test against Windows 2008, and certain operating system specific issues may not be fixed as [Microsoft no longer supports Windows 2008](https://docs.microsoft.com/en-us/lifecycle/).
+Octopus does not actively test against Windows 2008 nor Windows 2008 R2. Certain operating system specific issues may not be fixed as [Microsoft no longer supports Windows 2008](https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2008) nor [Windows 2008R2](https://docs.microsoft.com/en-us/lifecycle/products/windows-server-2008-r2).
 :::
 
 ## .NET Framework


### PR DESCRIPTION
Windows 2008 and 2008R2 went out of extended support on Jan 14, 2020.
See the [#investigation-dropping-support-for-2008-and-2008r2](https://octopusdeploy.slack.com/archives/C01K8UMMQTX) channel in slack for details.