### PR TITLE
Additional sections for the create test instance guide

### DIFF
--- a/docs/administration/upgrading/guide/creating-test-instance.md
+++ b/docs/administration/upgrading/guide/creating-test-instance.md
@@ -30,11 +30,15 @@ The process to create an instance with a subset of projects is:
 1. Install Octopus Deploy on a new VM.
 1. Export a subset of projects from the main instance.
 1. Import that subset of projects to the test instance.
-1. Test and verify the test instance.  
+1. Download the latest version of Octopus Deploy.
+1. Upgrade the test instance to the latest version of Octopus Deploy.
+1. Test and verify the test instance.
 
 !include <upgrade-download-same-version>
 !include <upgrade-install-test-version>
 !include <upgrade-export-import-test-projects>
+!include <upgrade-download-latest-version>
+!include <upgrade-install-latest-version>
 !include <upgrade-testing-upgraded-instance>
 
 ## Test instance is a clone
@@ -56,6 +60,9 @@ Creating a clone of an existing instance involves:
 1. Installing that version on a new server and configuring it to point to the cloned database.
 1. Copying all the files from the backed up folders from the source instance.
 1. *Optionally*, disabling targets on the cloned instance.
+1. Download the latest version of Octopus Deploy.
+1. Upgrade the test instance to the latest version of Octopus Deploy.
+1. Test and verify the test instance.
 
 !include <upgrade-octopus-backup-database>
 !include <upgrade-restore-backup>
@@ -63,4 +70,6 @@ Creating a clone of an existing instance involves:
 !include <upgrade-install-cloned-version>
 !include <upgrade-copy-files-for-cloned-instance>
 !include <upgrade-disable-targets-cloned-instance>
+!include <upgrade-download-latest-version>
+!include <upgrade-install-latest-version>
 !include <upgrade-testing-upgraded-instance>

--- a/docs/shared-content/upgrade/upgrade-download-same-version.include.md
+++ b/docs/shared-content/upgrade/upgrade-download-same-version.include.md
@@ -1,6 +1,6 @@
 ### Downloading the same version of Octopus Deploy
 
-The migration tool requires both the main instance and test instance are on the same version.  You can find the version you are running by clicking on your name in the top right corner of your Octopus Deploy instance.
+Migrating data from Octopus to a test instance requires both the main instance and test instance are on the same version.  You can find the version you are running by clicking on your name in the top right corner of your Octopus Deploy instance.
 
 ![](/docs/shared-content/upgrade/images/find-current-version.png "width=500")
 

--- a/docs/shared-content/upgrade/upgrade-download-same-version.include.md
+++ b/docs/shared-content/upgrade/upgrade-download-same-version.include.md
@@ -1,6 +1,6 @@
 ### Downloading the same version of Octopus Deploy
 
-Migrating data from Octopus to a test instance requires both the main instance and test instance are on the same version.  You can find the version you are running by clicking on your name in the top right corner of your Octopus Deploy instance.
+Migrating data from Octopus to a test instance requires both the main instance and test instance to be on the same version.  You can find the version you are running by clicking on your name in the top right corner of your Octopus Deploy instance.
 
 ![](/docs/shared-content/upgrade/images/find-current-version.png "width=500")
 

--- a/docs/shared-content/upgrade/upgrade-install-latest-version.include.md
+++ b/docs/shared-content/upgrade/upgrade-install-latest-version.include.md
@@ -1,0 +1,3 @@
+### Install the latest version of Octopus Deploy
+
+Installing a newer version of Octopus Deploy is as simple as running MSI and following the wizard.  The MSI will copy all the binaries to the install location.  Once the MSI is complete, it will automatically launch the `Octopus Manager`.


### PR DESCRIPTION
This change adds some additional sections for the creating test instance page within the upgrading octopus guides

It includes: 
- download the latest version for test instance
- and install the latest version for test instance