### PR TITLE
Encouraging the use of Execution Containers for script steps

### DIFF
--- a/docs/deployments/azure/cloud-services/index.md
+++ b/docs/deployments/azure/cloud-services/index.md
@@ -65,7 +65,7 @@ Please note these features actually run on the Octopus Server prior to deploying
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
 
-The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers/index.md) for your step.
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
@@ -96,7 +96,7 @@ Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bu
 
 From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
 
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
 :::
 
 For your convenience the PowerShell session for your [custom scripts](/docs/deployments/custom-scripts/index.md) will have the Azure PowerShell module loaded, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticate with Azure yourself. See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information. You can write very straightforward scripts like the example below:

--- a/docs/deployments/azure/cloud-services/index.md
+++ b/docs/deployments/azure/cloud-services/index.md
@@ -26,7 +26,7 @@ If you haven't already, create an [Azure Management Certificate Account](/docs
 
 ## Step 3: Create the Azure Cloud Service deployment step {#DeployingapackagetoanAzureCloudService-Step3:CreatetheAzureCloudServicedeploymentstep}
 
-Add a new Azure Cloud Service Deployment Step to your project. For information about adding a step to the deployment process, see the [add step](/docs/projects/steps/index.md) section. 
+Add a new Azure Cloud Service Deployment Step to your project. For information about adding a step to the deployment process, see the [add step](/docs/projects/steps/index.md) section.
 
 ![](5865904.png "width=170")
 
@@ -34,18 +34,18 @@ Add a new Azure Cloud Service Deployment Step to your project. For information 
 
 Once an Account is selected, the list of Cloud Services and Storage Accounts available to the Azure subscription associated with the chosen Account will be populated for you to choose from.
 
-| Setting         | Default | Description                              |
-| --------------- | ------- | ---------------------------------------- |
-| Account         |         | The [Azure Account](/docs/infrastructure/accounts/azure/index.md) you want to  target when deploying this cloud service. Select one from the list, or use a [variable binding](/docs/projects/variables/variable-substitutions.md) to select an account by its name or ID. |
-| Cloud Service   |         | The actual cloud service you want to target. Select one from the list, or use a [variable binding](/docs/projects/variables/variable-substitutions.md) to define the name of the cloud service. |
-| Storage Account |         | The Azure Storage Account where the Cloud Service Package (`*.cspkg`) file will be pushed in order to be deployed. |
-| Slot            |         | You can choose to deploy to either the Staging or Production slot. |
-| Swap            |         | Azure allows staging and production deployments to be swapped, by switching virtual IP addresses. When deploying to production, Octopus can detect whether the current staging deployment can be swapped, and if so, it can do a swap rather than a new deployment.<br/>If **Always deploy** is selected, the package will always be deployed to the selected Slot.<br/>If **Swap staging to production if possible** is selected and the selected Slot is Production, then a swap will occur between Production and Staging (if there is a deployment in the Staging slot).<br/>See [VIP Swap](/docs/deployments/azure/cloud-services/vip-swap.md) for more information on how to configure a VIP swap.|
-| Instance Count  |         | If you have scaled your Windows Azure service using the management portal (for example, changing the role count from 1 to 4), during a deployment Octopus can be configured to keep the existing instance counts rather than using the instance counts defined in your cloud service configuration file. |
+| Setting         | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| --------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Account         |         | The [Azure Account](/docs/infrastructure/accounts/azure/index.md) you want to target when deploying this cloud service. Select one from the list, or use a [variable binding](/docs/projects/variables/variable-substitutions.md) to select an account by its name or ID.                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Cloud Service   |         | The actual cloud service you want to target. Select one from the list, or use a [variable binding](/docs/projects/variables/variable-substitutions.md) to define the name of the cloud service.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Storage Account |         | The Azure Storage Account where the Cloud Service Package (`*.cspkg`) file will be pushed in order to be deployed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Slot            |         | You can choose to deploy to either the Staging or Production slot.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Swap            |         | Azure allows staging and production deployments to be swapped, by switching virtual IP addresses. When deploying to production, Octopus can detect whether the current staging deployment can be swapped, and if so, it can do a swap rather than a new deployment.<br/>If **Always deploy** is selected, the package will always be deployed to the selected Slot.<br/>If **Swap staging to production if possible** is selected and the selected Slot is Production, then a swap will occur between Production and Staging (if there is a deployment in the Staging slot).<br/>See [VIP Swap](/docs/deployments/azure/cloud-services/vip-swap.md) for more information on how to configure a VIP swap. |
+| Instance Count  |         | If you have scaled your Windows Azure service using the management portal (for example, changing the role count from 1 to 4), during a deployment Octopus can be configured to keep the existing instance counts rather than using the instance counts defined in your cloud service configuration file.                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 :::success
 **Use variable binding expressions**
-Any of the settings above can be switched to use a variable binding expression. A common example is when you use a naming convention for your different cloud services, like **MyCloudService\_Production** and **MyCloudService\_Test** - you can use environment-scoped variables to automatically configure this step depending on the environment you are targeting.
+Any of the settings above can be switched to use a variable binding expression. A common example is when you use a naming convention for your different cloud services, like **MyCloudService_Production** and **MyCloudService_Test** - you can use environment-scoped variables to automatically configure this step depending on the environment you are targeting.
 :::
 
 ### Deployment features available to Azure Cloud Service steps {#DeployingapackagetoanAzureCloudService-DeploymentfeaturesavailabletoAzureCloudServicesteps}
@@ -58,11 +58,22 @@ The following features are available when deploying a package to an Azure Cloud 
 - [Structured configuration variables](/docs/projects/steps/configuration-features/structured-configuration-variables-feature.md)
 - [Substitute variables in templates](/docs/projects/steps/configuration-features/substitute-variables-in-templates.md)
 
-:::hint
 Please note these features actually run on the Octopus Server prior to deploying the Cloud Service package to Azure. They don't execute in the Azure Cloud Service instances you are eventually targeting.
-:::
 
-For your convenience the PowerShell session for your [custom scripts](/docs/deployments/custom-scripts/index.md) will have the Azure PowerShell module loaded, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticate with Azure yourself. See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information. You can write very straightforward scripts like the example below:
+:::hint
+[Custom scripts](/docs/deployments/custom-scripts/index.md) typically rely on specific tools being available when they execute.
+
+It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
+
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+
+If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
+
+If the Azure PowerShell module is available, it will be loaded for your convenience, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticating with Azure yourself.
+
+See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information.
+
+You can write very straightforward scripts like the example below which is from our [guide on using deployment slots with Azure Web Apps](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md):
 
 ```powershell
 #Swap the staging slot into production
@@ -77,6 +88,18 @@ if ($Deployment -ne $null -AND $Deployment.DeploymentId  -ne $null) {
   Write-Host ("There is no deployment in staging slot of {0} to swap." -f $ServiceName)
 }
 ```
+
+:::
+
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+
+From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+:::
+
+For your convenience the PowerShell session for your [custom scripts](/docs/deployments/custom-scripts/index.md) will have the Azure PowerShell module loaded, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticate with Azure yourself. See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information. You can write very straightforward scripts like the example below:
 
 ## Deployment process {#DeployingapackagetoanAzureCloudService-Deploymentprocess}
 

--- a/docs/deployments/azure/cloud-services/index.md
+++ b/docs/deployments/azure/cloud-services/index.md
@@ -70,6 +70,14 @@ The easiest way to achieve this is to use an [execution container](/docs/project
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+
+From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
+:::
+
 If the Azure PowerShell module is available, it will be loaded for your convenience, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticating with Azure yourself. 
 
 You can write very straightforward scripts like the example below:
@@ -88,14 +96,6 @@ if ($Deployment -ne $null -AND $Deployment.DeploymentId  -ne $null) {
 }
 ```
 See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information.
-
-:::warning
-Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
-
-From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
-
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
-:::
 
 ## Deployment process {#DeployingapackagetoanAzureCloudService-Deploymentprocess}
 

--- a/docs/deployments/azure/cloud-services/index.md
+++ b/docs/deployments/azure/cloud-services/index.md
@@ -60,7 +60,8 @@ The following features are available when deploying a package to an Azure Cloud 
 
 Please note these features actually run on the Octopus Server prior to deploying the Cloud Service package to Azure. They don't execute in the Azure Cloud Service instances you are eventually targeting.
 
-:::hint
+#### Using custom scripts
+
 [Custom scripts](/docs/deployments/custom-scripts/index.md) typically rely on specific tools being available when they execute.
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
@@ -69,14 +70,12 @@ The easiest way to achieve this is to use an [execution container](/docs/project
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
-If the Azure PowerShell module is available, it will be loaded for your convenience, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticating with Azure yourself.
+If the Azure PowerShell module is available, it will be loaded for your convenience, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticating with Azure yourself. 
 
-See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information.
-
-You can write very straightforward scripts like the example below which is from our [guide on using deployment slots with Azure Web Apps](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md):
+You can write very straightforward scripts like the example below:
 
 ```powershell
-#Swap the staging slot into production
+# Swap the staging slot into production
 $ServiceName = $OctopusParameters["Octopus.Action.Azure.CloudServiceName"]
 $Deployment = Get-AzureDeployment -Slot "Staging" -ServiceName $ServiceName
 if ($Deployment -ne $null -AND $Deployment.DeploymentId  -ne $null) {
@@ -88,8 +87,7 @@ if ($Deployment -ne $null -AND $Deployment.DeploymentId  -ne $null) {
   Write-Host ("There is no deployment in staging slot of {0} to swap." -f $ServiceName)
 }
 ```
-
-:::
+See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information.
 
 :::warning
 Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
@@ -98,8 +96,6 @@ From **Octopus 2021.2**, a warning will also appear in the deployment logs if th
 
 We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
 :::
-
-For your convenience the PowerShell session for your [custom scripts](/docs/deployments/custom-scripts/index.md) will have the Azure PowerShell module loaded, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticate with Azure yourself. See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information. You can write very straightforward scripts like the example below:
 
 ## Deployment process {#DeployingapackagetoanAzureCloudService-Deploymentprocess}
 

--- a/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
+++ b/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
@@ -25,20 +25,20 @@ See the [packaging application docs](/docs/packaging-applications/index.md)
 
 !partial <configurestep>
 
-4. On the **Deployment** section you can configure any of the below settings which are related to *how* your files are going to be pushed to Azure.
+4. On the **Deployment** section you can configure any of the below settings which are related to _how_ your files are going to be pushed to Azure.
 
-| Setting                     | Default     | Description                              |
-| --------------------------- | ----------- | ---------------------------------------- |
-| **Deployment Slot**         |             | The target slot to deploy the application to. Requires a **Standard** or **Premium** App Service Plan. |
-| **Physical Path**           |             | The physical path relative to site root on the web app host. e.g. 'foo' will deploy to 'site\wwwroot\foo'. Leave blank to deploy to root. |
-| **Remove additional files** | *False*     | When *True* instructs Web Deploy to delete files from the destination that aren't in the source package |
-| **Preserve App\_Data**      | *False*     | When *True* instructs Web Deploy to skip Delete operations in the **App\_Data** directory |
-| **Enable AppOffline**       | *False*     | When *True* instructs Web Deploy to place *app\_offline.htm* in root deployment directory to safely bring down the app domain.</br>Click [here](http://www.iis.net/learn/publish/deploying-application-packages/taking-an-application-offline-before-publishing) for more details. |
-| **File comparison method**  | *Timestamp* | Can be *timestamp* or *checksum* and instructs web deploy to use the selected algorithm to determine which files to update.</br>*Note: There have been some issues with checksum in earlier versions of web deploy, and we've written about that in detail [here](https://octopus.com/blog/reliably-deploying-large-azure-web-apps).* |
+| Setting                     | Default     | Description                                                                                                                                                                                                                                                                                                                           |
+| --------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Deployment Slot**         |             | The target slot to deploy the application to. Requires a **Standard** or **Premium** App Service Plan.                                                                                                                                                                                                                                |
+| **Physical Path**           |             | The physical path relative to site root on the web app host. e.g. 'foo' will deploy to 'site\wwwroot\foo'. Leave blank to deploy to root.                                                                                                                                                                                             |
+| **Remove additional files** | _False_     | When _True_ instructs Web Deploy to delete files from the destination that aren't in the source package                                                                                                                                                                                                                               |
+| **Preserve App_Data**       | _False_     | When _True_ instructs Web Deploy to skip Delete operations in the **App_Data** directory                                                                                                                                                                                                                                              |
+| **Enable AppOffline**       | _False_     | When _True_ instructs Web Deploy to place _app_offline.htm_ in root deployment directory to safely bring down the app domain.</br>Click [here](http://www.iis.net/learn/publish/deploying-application-packages/taking-an-application-offline-before-publishing) for more details.                                                     |
+| **File comparison method**  | _Timestamp_ | Can be _timestamp_ or _checksum_ and instructs web deploy to use the selected algorithm to determine which files to update.</br>_Note: There have been some issues with checksum in earlier versions of web deploy, and we've written about that in detail [here](https://octopus.com/blog/reliably-deploying-large-azure-web-apps)._ |
 
 :::success
 **Use variable binding expressions**
-Any of the settings above can be switched to use a variable binding expression. A common example is when you use a naming convention for your different web apps, like **MyApp\_Production** and **MyApp\_Test** - you can use environment-scoped variables to automatically configure this step depending on the environment you are targeting.
+Any of the settings above can be switched to use a variable binding expression. A common example is when you use a naming convention for your different web apps, like **MyApp_Production** and **MyApp_Test** - you can use environment-scoped variables to automatically configure this step depending on the environment you are targeting.
 :::
 
 ### Deployment features available to Azure web app steps {#DeployingapackagetoanAzureWebApp-DeploymentfeaturesavailabletoAzureWebAppsteps}
@@ -56,12 +56,33 @@ Please note these features actually run on the Octopus Server prior to executing
 :::
 
 :::hint
-For your convenience the PowerShell session for your [custom scripts](/docs/deployments/custom-scripts/index.md) will have the Azure PowerShell module loaded, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticate with Azure yourself. See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information. You can write very straightforward scripts like the example below which is from our [guide on using deployment slots with Azure Web Apps](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md):
+[Custom scripts](/docs/deployments/custom-scripts/index.md) typically rely on specific tools being available when they execute.
+
+It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
+
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+
+If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
+
+If the Azure PowerShell module is available, it will be loaded for your convenience, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticating with Azure yourself.
+
+See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information.
+
+You can write very straightforward scripts like the example below which is from our [guide on using deployment slots with Azure Web Apps](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md):
 
 ```powershell
 #Swap the staging slot into production
 Switch-AzureWebsiteSlot -Name #{WebSite} -Slot1 Staging -Slot2 Production -Force
 ```
+
+:::
+
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+
+From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
 :::
 
 ### What happens when the step is executed? {#DeployingapackagetoanAzureWebApp-ExecutingTheStep}
@@ -80,7 +101,6 @@ When the `Deploy an Azure Web App` step gets executed, the below actions will ha
 
 ## Simple and advanced deployment scenarios {#DeployingapackagetoanAzureWebApp-Simpleandadvanceddeploymentscenarios}
 
-
 ### Deploying to multiple geographic regions {#DeployingapackagetoanAzureWebApp-Deployingtomultiplegeographicregions}
 
 When your application is deployed to more than one geographic region, you are likely to need per-region configuration settings. You can achieve this result in many different ways, but the two most popular methods we have seen are:
@@ -98,4 +118,3 @@ to the Azure portal with a value of `false`. If you have multiple slots, this se
 ## Learn more
 
 - Generate an Octopus guide for [Azure and the rest of your CI/CD pipeline](https://octopus.com/docs/guides?destination=Azure%20websites).
-

--- a/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
+++ b/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
@@ -51,11 +51,10 @@ The following features are available when deploying a package to an Azure Web Ap
 - [Structured configuration variables](/docs/projects/steps/configuration-features/structured-configuration-variables-feature.md)
 - [Substitute variables in templates](/docs/projects/steps/configuration-features/substitute-variables-in-templates.md)
 
-:::hint
 Please note these features actually run on the Octopus Server prior to executing web deploy to synchronize the resultant files to the Azure Web App slot. They don't execute in the Azure Web App host you are eventually targeting.
-:::
 
-:::hint
+#### Using custom scripts
+
 [Custom scripts](/docs/deployments/custom-scripts/index.md) typically rely on specific tools being available when they execute.
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
@@ -71,11 +70,9 @@ See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-
 You can write very straightforward scripts like the example below which is from our [guide on using deployment slots with Azure Web Apps](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md):
 
 ```powershell
-#Swap the staging slot into production
+# Swap the staging slot into production
 Switch-AzureWebsiteSlot -Name #{WebSite} -Slot1 Staging -Slot2 Production -Force
 ```
-
-:::
 
 :::warning
 Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.

--- a/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
+++ b/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
@@ -63,6 +63,14 @@ The easiest way to achieve this is to use an [execution container](/docs/project
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+
+From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
+:::
+
 If the Azure PowerShell module is available, it will be loaded for your convenience, and the subscription from the account associated with the target will be selected. This means you don't have to worry about loading the Azure PowerShell module nor authenticating with Azure yourself.
 
 See the [Azure PowerShell documentation](/docs/deployments/azure/running-azure-powershell/index.md) for more information.
@@ -73,14 +81,6 @@ You can write very straightforward scripts like the example below which is from 
 # Swap the staging slot into production
 Switch-AzureWebsiteSlot -Name #{WebSite} -Slot1 Staging -Slot2 Production -Force
 ```
-
-:::warning
-Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
-
-From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
-
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
-:::
 
 ### What happens when the step is executed? {#DeployingapackagetoanAzureWebApp-ExecutingTheStep}
 

--- a/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
+++ b/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
@@ -60,7 +60,7 @@ Please note these features actually run on the Octopus Server prior to executing
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
 
-The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers/index.md) for your step.
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
@@ -82,7 +82,7 @@ Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bu
 
 From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
 
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
 :::
 
 ### What happens when the step is executed? {#DeployingapackagetoanAzureWebApp-ExecutingTheStep}

--- a/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md
+++ b/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md
@@ -91,14 +91,14 @@ Use the PowerShell:
 **Azure Service Management**
 
 ```powershell
-#Swap the staging slot into production
+# Swap the staging slot into production
 Switch-AzureWebsiteSlot -Name #{WebSite} -Slot1 Staging -Slot2 Production -Force
 ```
 
 **Azure Resource Management**
 
 ```powershell
-#Swap the staging slot into production
+# Swap the staging slot into production
 Switch-AzureRmWebAppSlot -ResourceGroupName #{ResourceGroup} -Name #{Website} -SourceSlotName Staging -DestinationSlotName Production
 ```
 

--- a/docs/deployments/azure/running-azure-powershell/index.md
+++ b/docs/deployments/azure/running-azure-powershell/index.md
@@ -1,14 +1,18 @@
 ---
 title: Running Azure PowerShell
-description: Octopus supports executing PowerShell against Azure and will automatically import the Azure PowerShell modules.
+description: Octopus supports executing PowerShell against Azure and will automatically import the Azure PowerShell modules if they are available.
 hideInThisSectionHeader: true
 ---
 
-Octopus Deploy can help you run scripts on targets within Microsoft Azure.
+Octopus can help you to run scripts on targets within Microsoft Azure.
 
-These scripts typically rely on tools being available on the target worker.
+These scripts typically rely on tools being available when they execute.
 
-We recommend that you provision your own tools on your worker - this way you can control what version of the tools are provisioned, and ensure their compatibility with the scripts you are trying to execute.
+It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
+
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+
+If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
 :::warning
 Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
@@ -38,12 +42,14 @@ Azure supports two authentication methods, each of which provides access to a di
 
 Learn more about [configuring the right Azure Account](/docs/infrastructure/accounts/azure/index.md).
 
-## Dynamic Worker Pools
+## Running Scripts in Octopus Cloud
 
-Octopus Cloud uses a special type of worker pool called a [Dynamic Worker Pool](/docs/infrastructure/workers/dynamic-worker-pools.md). Octopus provides these, and you cannot easily install custom versions of the Azure tools on them. To use your own version of the Azure CLI or Azure Powershell cmdlets when using Dynamic Worker Pools, please do the following:
+Octopus Cloud uses a special type of worker pool called a [Dynamic Worker Pool](/docs/infrastructure/workers/dynamic-worker-pools.md). Octopus provides these, and you cannot easily install custom versions of the Azure tools on them.
 
-- Configure your step to use a Dynamic Worker pool that supports [execution containers](/docs/projects/steps/execution-containers-for-workers/index.md). You may need to create a new worker pool using one of the images that support execution containers.
-- Configure your step to run in an execution container, selecting a docker image that contains the versions of the Azure CLI or Azure Powershell cmdlets that you would like to use. For more information about selecting an image to use, see the [Which Docker images can I use?](/docs/projects/steps/execution-containers-for-workers/index.md#which-image) section.
+To use your own version of the Azure CLI or Azure Powershell cmdlets when using Dynamic Worker Pools, please do the following:
+
+- Configure your step to use a Dynamic Worker pool that supports [execution containers](/docs/projects/steps/execution-containers-for-workers/index.md).
+- Configure your step to run in an execution container with a [compatible docker image](/docs/projects/steps/execution-containers-for-workers/index.md#which-image) that contains the versions of the Azure CLI or Azure Powershell cmdlets that you would like to use.
 
 ## Run an Azure PowerShell script step {#RunningAzurePowerShell-RunanAzurePowerShellScriptStep}
 

--- a/docs/deployments/azure/running-azure-powershell/index.md
+++ b/docs/deployments/azure/running-azure-powershell/index.md
@@ -10,7 +10,7 @@ These scripts typically rely on tools being available when they execute.
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
 
-The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers/index.md) for your script step.
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
@@ -19,7 +19,7 @@ Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bu
 
 From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
 
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
 :::
 
 When executing PowerShell against Azure, Octopus Deploy will automatically use your configured Azure account details to authenticate you into the [AzureRM PowerShell modules](https://docs.microsoft.com/powershell/azure/azurerm/overview), the [Azure PowerShell modules](https://docs.microsoft.com/powershell/azure/overview), and [Azure CLI tools](https://docs.microsoft.com/cli/azure/), if they exist on the worker executing the script.

--- a/docs/deployments/custom-scripts/aws-cli-scripts.md
+++ b/docs/deployments/custom-scripts/aws-cli-scripts.md
@@ -10,7 +10,7 @@ These scripts typically rely on tools being available when they execute.
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
 
-The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers/index.md) for your script step.
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 

--- a/docs/deployments/custom-scripts/aws-cli-scripts.md
+++ b/docs/deployments/custom-scripts/aws-cli-scripts.md
@@ -1,14 +1,18 @@
 ---
-title: AWS CLI PowerShell scripts
-description: AWS CLI PowerShell Scripts.
+title: AWS CLI and PowerShell scripts
+description: AWS CLI and PowerShell Scripts.
 position: 90
 ---
 
 Octopus can help you to run scripts on targets within AWS.
 
-These scripts typically rely on tools being available on the target worker.
+These scripts typically rely on tools being available when they execute.
 
-We recommend that you provision your own tools on your worker - this way you can control what version of the tools are provisioned, and ensure their compatibility with the scripts you are trying to execute.
+It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
+
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+
+If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
 :::warning
 Using the AWS tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the [AWS PowerShell modules](https://aws.amazon.com/powershell/) and [AWS CLI](https://aws.amazon.com/cli/). These were originally provided as convenience mechanisms for users wanting to run scripts against AWS targets. The versions bundled are now out of date, and we will not be updating them further.
@@ -93,9 +97,11 @@ The second option is to run a script from a package. This is done by selecting t
 
 ![AWS script package](images/step-aws-package.png "width=500")
 
-## Dynamic Worker Pools
+## Running Scripts in Octopus Cloud
 
-Octopus Cloud uses a special type of worker pool called a [Dynamic Worker Pool](/docs/infrastructure/workers/dynamic-worker-pools.md). Octopus provides these, and you cannot easily install custom versions of the AWS tools on them. To use your own version of the AWS CLI or AWS Powershell cmdlets when using Dynamic Worker Pools, please do the following:
+Octopus Cloud uses a special type of worker pool called a [Dynamic Worker Pool](/docs/infrastructure/workers/dynamic-worker-pools.md). Octopus provides these, and you cannot easily install custom versions of the AWS tools on them.
 
-- Configure your step to use a Dynamic Worker pool that supports [execution containers](/docs/projects/steps/execution-containers-for-workers/index.md). You may need to create a new worker pool using one of the images that support execution containers.
-- Configure your step to run in an execution container, selecting a docker image that contains the versions of the AWS CLI or AWS Powershell cmdlets that you would like to use. For more information about selecting an image to use, see the [Which Docker images can I use?](/docs/projects/steps/execution-containers-for-workers/index.md#which-image) section.
+To use your own version of the AWS CLI or AWS Powershell cmdlets when using Dynamic Worker Pools, please do the following:
+
+- Configure your step to use a Dynamic Worker pool that supports [execution containers](/docs/projects/steps/execution-containers-for-workers/index.md).
+- Configure your step to run in an execution container with a [compatible docker image](/docs/projects/steps/execution-containers-for-workers/index.md#which-image) that contains the versions of the AWS CLI or AWS Powershell cmdlets that you would like to use.

--- a/docs/deployments/custom-scripts/aws-cli-scripts.md
+++ b/docs/deployments/custom-scripts/aws-cli-scripts.md
@@ -1,6 +1,6 @@
 ---
 title: AWS CLI and PowerShell scripts
-description: AWS CLI and PowerShell Scripts.
+description: AWS CLI and PowerShell Scripts allow you to manage your AWS resources as part of your deployment process.
 position: 90
 ---
 

--- a/docs/deployments/custom-scripts/azure-powershell-scripts.md
+++ b/docs/deployments/custom-scripts/azure-powershell-scripts.md
@@ -1,12 +1,52 @@
 ---
-title: Azure PowerShell scripts
-description: Azure PowerShell scripts allow you to manage your Azure subscription using the Azure PowerShell SDK for the Resource Management (RM) or Service Management (SM) API as part of your deployment process.
+title: Azure CLI and PowerShell Scripts
+description: Azure CLI and PowerShell Scripts allow you to manage your Azure resources as part of your deployment process.
 position: 80
 ---
 
-You can use all of the features we provide for [custom scripts](/docs/deployments/custom-scripts/index.md), like [using variables](/docs/deployments/custom-scripts/using-variables-in-scripts.md), [passing parameters](/docs/deployments/custom-scripts/passing-parameters-to-scripts.md), publishing [output variables](/docs/deployments/custom-scripts/output-variables.md) and [collecting artifacts](/docs/deployments/custom-scripts/index.md#Customscripts-Collectingartifacts).
+Octopus can help you to run scripts on targets within Microsoft Azure.
 
-You can manage your Azure subscription using the Azure PowerShell SDK for the Resource Management (RM) or Service Management (SM) API as part of your deployment process.
+Within your Azure scripts, you can use all of the features we provide for [custom scripts](/docs/deployments/custom-scripts/index.md), like [using variables](/docs/deployments/custom-scripts/using-variables-in-scripts.md), [passing parameters](/docs/deployments/custom-scripts/passing-parameters-to-scripts.md), publishing [output variables](/docs/deployments/custom-scripts/output-variables.md) and [collecting artifacts](/docs/deployments/custom-scripts/index.md#Customscripts-Collectingartifacts).
+
+These scripts typically rely on tools being available when they execute.
+
+It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
+
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+
+If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
+
+:::warning
+Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bundles versions of the Azure Resource Manager Powershell modules (AzureRM) and Azure CLI. These were originally provided as convenience mechanisms for users wanting to run scripts against Azure targets. The versions bundled are now out of date, and we will not be updating them further.
+
+From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
+
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+:::
+
+When executing PowerShell against Azure, Octopus Deploy will automatically use your configured Azure account details to authenticate you into the [AzureRM PowerShell modules](https://docs.microsoft.com/powershell/azure/azurerm/overview), the [Azure PowerShell modules](https://docs.microsoft.com/powershell/azure/overview), and [Azure CLI tools](https://docs.microsoft.com/cli/azure/), if they exist on the worker executing the script.
+
+This functionality requires the Azure CLI version 2.0 or above to be installed on the worker.
+
+**Choosing the right Azure account type**
+
+Azure supports two authentication methods, each of which provides access to a different set of Azure APIs:
+
+- To use the Azure Service Management (ASM) API, use an [Azure Management Certificate Account](/docs/infrastructure/accounts/azure/index.md#azure-management-certificate).
+- To use the Azure Resource Management (ARM) API, use an [Azure Service Principal Account](/docs/infrastructure/accounts/azure/index.md#azure-service-principal).
+  - The ARM PowerShell cmdlets are prefixed with `AzureRM`, like `Get-AzureRMWebApp`.
+  - The Az PowerShell cmdlets are prefixed with `Az`, like `Get-AzWebApp`.
+
+Learn more about [configuring the right Azure Account](/docs/infrastructure/accounts/azure/index.md).
+
+## Running Scripts in Octopus Cloud
+
+Octopus Cloud uses a special type of worker pool called a [Dynamic Worker Pool](/docs/infrastructure/workers/dynamic-worker-pools.md). Octopus provides these, and you cannot easily install custom versions of the Azure tools on them.
+
+To use your own version of the Azure CLI or Azure Powershell cmdlets when using Dynamic Worker Pools, please do the following:
+
+- Configure your step to use a Dynamic Worker pool that supports [execution containers](/docs/projects/steps/execution-containers-for-workers/index.md).
+- Configure your step to run in an execution container with a [compatible docker image](/docs/projects/steps/execution-containers-for-workers/index.md#which-image) that contains the versions of the Azure CLI or Azure Powershell cmdlets that you would like to use.
 
 ![](images/5865912.png "width=170")
 
@@ -29,7 +69,3 @@ New-AzureWebsite -Name #{WebSite} -Slot Staging
 ```
 
 ![](images/5865518.png "width=500")
-
-## Bring your own Azure SDK {#AzurePowerShellscripts-BringyourownAzureSDK}
-
-We bundle a version of the Azure SDKs with Octopus Server so you can start deploying to Azure very quickly. In certain situations you may want (or need) to use a different version of the Azure SDK. Refer to [this guide](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) for more details.

--- a/docs/deployments/custom-scripts/azure-powershell-scripts.md
+++ b/docs/deployments/custom-scripts/azure-powershell-scripts.md
@@ -12,7 +12,7 @@ These scripts typically rely on tools being available when they execute.
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
 
-The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers/index.md) for your script step.
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
@@ -21,7 +21,7 @@ Using the Azure tools bundled with Octopus Deploy is not recommended. Octopus bu
 
 From **Octopus 2021.2**, a warning will also appear in the deployment logs if the Azure tools bundled with Octopus Deploy are used in a step.
 
-We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](configuring-the-version-of-the-azure-cli.md).
+We recommend you configure Octopus Deploy to use your own [version of the Azure PowerShell cmdlets](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-powershell-modules.md) and [version of the Azure CLI](/docs/deployments/azure/running-azure-powershell/configuring-the-version-of-the-azure-cli.md).
 :::
 
 When executing PowerShell against Azure, Octopus Deploy will automatically use your configured Azure account details to authenticate you into the [AzureRM PowerShell modules](https://docs.microsoft.com/powershell/azure/azurerm/overview), the [Azure PowerShell modules](https://docs.microsoft.com/powershell/azure/overview), and [Azure CLI tools](https://docs.microsoft.com/cli/azure/), if they exist on the worker executing the script.

--- a/docs/deployments/google-cloud/run-gcloud-script/index.md
+++ b/docs/deployments/google-cloud/run-gcloud-script/index.md
@@ -11,7 +11,7 @@ These scripts typically rely on tools being available when they execute.
 
 It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
 
-The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers/index.md) for your script step.
 
 If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 

--- a/docs/deployments/google-cloud/run-gcloud-script/index.md
+++ b/docs/deployments/google-cloud/run-gcloud-script/index.md
@@ -1,19 +1,23 @@
 ---
-title: Running gcloud scripts
-description: Octopus supports executing PowerShell/Bash scripts against Google cloud targets.
+title: Google Cloud CLI scripts
+description: Google Cloud CLI Scripts allow you to manage your Google Cloud resources as part of your deployment process.
 position: 10
 hideInThisSectionHeader: true
 ---
 
-Octopus Deploy can help you run scripts on targets within Google cloud platforms.
+Octopus Deploy can help you run scripts on targets within Google Cloud Platform.
 
-These scripts typically rely on tools being available on the target worker.
+These scripts typically rely on tools being available when they execute.
 
-We recommend that you provision your own tools on your worker - this way you can control what version of the tools are provisioned, and ensure their compatibility with the scripts you are trying to execute.
+It is best that you control the version of these tools - your scripts will rely on a specific version that they are compatible with to function correctly.
+
+The easiest way to achieve this is to use an [execution container](/docs/projects/steps/execution-containers-for-workers.md) for your script step.
+
+If this is not an option in your scenario, we recommend that you provision your own tools on your worker.
 
 When executing a script against GCP, Octopus Deploy will automatically use your provided Google cloud account details to authenticate you to the target instance, or you can choose to use the service account associated with the target instance.
 
-This functionality requires the gcloud CLI to be installed on the worker.
+This functionality requires the Google Cloud (gcloud) CLI to be installed on the worker.
 
 ## Run a gcloud script step {#RunningGcloudScript}
 
@@ -21,7 +25,7 @@ This functionality requires the gcloud CLI to be installed on the worker.
 The **Run gcloud in a Script** step was added in Octopus **2021.2**.
 :::
 
-Octopus Deploy provides a *Run gcloud in a Script* step type, for executing script in the context of a Google cloud platform instance. For information about adding a step to the deployment process, see the [add step](/docs/projects/steps/index.md) section.
+Octopus Deploy provides a _Run gcloud in a Script_ step type, for executing script in the context of a Google cloud platform instance. For information about adding a step to the deployment process, see the [add step](/docs/projects/steps/index.md) section.
 
 ![](google-cloud-script-step.png "width=170")
 


### PR DESCRIPTION
We are making an effort to encourage Octopus customers towards using execution containers when executing custom scripts - particularly scripts for cloud providers.

This PR updates all Azure, AWS and GCP documentation that mentions running scripts, and aligns the messaging and content around customers managing their own tooling for their scripts, and encourages them towards using execution containers.