### PR TITLE
Added Registries to Remove for Manual Tentacle Uninstallation

### DIFF
--- a/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
+++ b/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
@@ -47,7 +47,11 @@ These steps will remove all traces of Octopus Tentacle from your computer:
 :::problem
 This will also remove your deployed applications if you have not configured Tentacle to use a different Application folder. See below for more details.
 :::
-4. Find and delete the Octopus registry entries from **`HKLM\SOFTWARE\Octopus`**.
+4. Find and delete the Octopus registry entries from the following locations:
+    * **`HKLM\SOFTWARE\Octopus`** 
+    * **`HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Installer\Products`**
+    * **`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData`**
+    * **`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`**
 5. Find and delete any Octopus folders from:
     * **`%ProgramData%\Octopus`** - used for storing instance configuration and can be used for log files when a Home Directory cannot be discovered
     * **`%LocalAppData%\Octopus`** - could be used for log files when a Home Directory cannot be discovered

--- a/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
+++ b/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
@@ -49,9 +49,9 @@ This will also remove your deployed applications if you have not configured Tent
 :::
 4. Find and delete the Octopus registry entries from the following locations:
     * **`HKLM\SOFTWARE\Octopus`** 
-    * **`HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Installer\Products`**
-    * **`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData`**
-    * **`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`**
+    * **`HKLM\SOFTWARE\Classes\Installer\Products`**
+    * **`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData`**
+    * **`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`**
 5. Find and delete any Octopus folders from:
     * **`%ProgramData%\Octopus`** - used for storing instance configuration and can be used for log files when a Home Directory cannot be discovered
     * **`%LocalAppData%\Octopus`** - could be used for log files when a Home Directory cannot be discovered


### PR DESCRIPTION
It was found that when uninstalling a tentacle manually then installing a newer version would cause the installer to fail. It was determined that there were some additional registries to remove.

As per: https://help.octopus.com/t/unable-to-uninstall-or-install-octopus-tentacle/27043/15 
