### PR TITLE
Add Java to (some) examples

### DIFF
--- a/docs/octopus-rest-api/examples/index.md
+++ b/docs/octopus-rest-api/examples/index.md
@@ -39,6 +39,12 @@ The Python examples are written using Python 3 and use the [Requests](https://re
 
 The Go examples are written using the [go-octopusdeploy](https://github.com/OctopusDeploy/go-octopusdeploy) Client.
 
+### Java examples
+
+The Java examples are written using the [java-octopus-deploy](https://github.com/OctopusDeployLabs/java-octopus-deploy) Client.
+
+The Java Client library requires Java 1.8 or above.
+
 ## Bulk operations
 
 Sometimes you want to perform an action on a resource in Octopus multiple times. For example, connecting a tenant to all of your projects. Having to run a script that performs an operation once, repeatedly, can become tedious. 

--- a/docs/shared-content/scripts/add-a-space-with-environments-scripts.include.md
+++ b/docs/shared-content/scripts/add-a-space-with-environments-scripts.include.md
@@ -295,3 +295,41 @@ func CreateEnvironment(octopusURL *url.URL, APIKey string, space *octopusdeploy.
 	}
 }
 ```
+```java Java
+import com.octopus.sdk.Repository;
+import com.octopus.sdk.domain.Space;
+import com.octopus.sdk.http.ConnectData;
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.http.OctopusClientFactory;
+import com.octopus.sdk.model.space.SpaceOverviewResource;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Collections;
+
+public class AddSpace {
+
+  final static String octopusServerUrl = "http://localhost:8065";
+  final static String apiKey = "YOUR_API_KEY"; // as read from your profile in your Octopus Deploy server
+
+  public static void main(final String... args) throws IOException {
+    final OctopusClient client = createClient();
+
+    final Repository repo = new Repository(client);
+    final Space createdSpace = repo.spaces().create(new SpaceOverviewResource("NewSpaceName", Collections.singleton(
+        "spaceManagerTeamMembers")));
+
+  }
+
+  // Create an authenticated connection to your Octopus Deploy Server
+  private static OctopusClient createClient() throws MalformedURLException {
+    final Duration connectTimeout = Duration.ofSeconds(10L);
+    final ConnectData connectData = new ConnectData(new URL(octopusServerUrl), apiKey, connectTimeout);
+    final OctopusClient client = OctopusClientFactory.createClient(connectData);
+
+    return client;
+  }
+}
+```

--- a/docs/shared-content/scripts/create-project-scripts.include.md
+++ b/docs/shared-content/scripts/create-project-scripts.include.md
@@ -296,3 +296,67 @@ func CreateProject(client *octopusdeploy.Client, lifecycle *octopusdeploy.Lifecy
 	return project
 }
 ```
+```java Java
+import com.octopus.sdk.Repository;
+import com.octopus.sdk.domain.Lifecycle;
+import com.octopus.sdk.domain.Project;
+import com.octopus.sdk.domain.ProjectGroup;
+import com.octopus.sdk.domain.Space;
+import com.octopus.sdk.http.ConnectData;
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.http.OctopusClientFactory;
+import com.octopus.sdk.model.project.ProjectResource;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Optional;
+
+public class CreateProjectExample {
+
+  final static String octopusServerUrl = "http://localhost:8065";
+  final static String apiKey = "YOUR_API_KEY"; // as read from your profile in your Octopus Deploy server
+
+  public static void main(final String... args) throws IOException {
+    final OctopusClient client = createClient();
+
+    final Repository repo = new Repository(client);
+    final Optional<Space> space = repo.spaces().getByName("TheSpaceName");
+
+    if(!space.isPresent()) {
+      System.out.println("No space named 'TheSpaceName' exists on server");
+      return;
+    }
+
+    final Optional<Lifecycle> lifecycle = space.get().lifecycles().getByName("MyLifecycle");
+    if(!lifecycle.isPresent()) {
+      System.out.println("No lifecycle named 'MyLifecycle' exists on server");
+      return;
+    }
+
+    final Optional<ProjectGroup> projGroup = space.get().projectGroups().getByName("MyProjectGroup");
+    if(!projGroup.isPresent()) {
+      System.out.println("No lifecycle named 'MyProjectGroup' exists on server");
+      return;
+    }
+
+    final ProjectResource projectToCreate = new ProjectResource("Test Project",
+        lifecycle.get().getProperties().getId(),
+        projGroup.get().getProperties().getId());
+    projectToCreate.setAutoCreateRelease(false);
+    final Project createdProject = space.get().projects().create(projectToCreate);
+
+  }
+
+  // Create an authenticated connection to your Octopus Deploy Server
+  private static OctopusClient createClient() throws MalformedURLException {
+    final Duration connectTimeout = Duration.ofSeconds(10L);
+    final ConnectData connectData = new ConnectData(new URL(octopusServerUrl), apiKey, connectTimeout);
+    final OctopusClient client = OctopusClientFactory.createClient(connectData);
+
+    return client;
+  }
+}
+
+```

--- a/docs/shared-content/scripts/create-projectgroup-scripts.include.md
+++ b/docs/shared-content/scripts/create-projectgroup-scripts.include.md
@@ -274,3 +274,49 @@ func GetSpace(octopusURL *url.URL, APIKey string, spaceName string) *octopusdepl
 	return nil
 }
 ```
+```java Java
+import com.octopus.sdk.Repository;
+import com.octopus.sdk.domain.ProjectGroup;
+import com.octopus.sdk.domain.Space;
+import com.octopus.sdk.http.ConnectData;
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.http.OctopusClientFactory;
+import com.octopus.sdk.model.projectgroup.ProjectGroupResource;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Optional;
+
+public class CreateProjectGroupExample {
+
+  final static String octopusServerUrl = "http://localhost:8065";
+  final static String apiKey = "YOUR_API_KEY"; // as read from your profile in your Octopus Deploy server
+
+  public static void main(final String... args) throws IOException {
+    final OctopusClient client = createClient();
+
+    final Repository repo = new Repository(client);
+    final Optional<Space> space = repo.spaces().getByName("TheSpaceName");
+
+    if(!space.isPresent()) {
+      System.out.println("No space named 'TheSpaceName' exists on server");
+      return;
+    }
+    final ProjectGroupResource projectGroupResource = new ProjectGroupResource("TheProjectGroup");
+    final ProjectGroup projectGroup = space.get().projectGroups().create(projectGroupResource);
+
+  }
+
+  // Create an authenticated connection to your Octopus Deploy Server
+  private static OctopusClient createClient() throws MalformedURLException {
+    final Duration connectTimeout = Duration.ofSeconds(10L);
+    final ConnectData connectData = new ConnectData(new URL(octopusServerUrl), apiKey, connectTimeout);
+    final OctopusClient client = OctopusClientFactory.createClient(connectData);
+
+    return client;
+  }
+}
+
+```

--- a/docs/shared-content/scripts/create-release-with-version-scripts.include.md
+++ b/docs/shared-content/scripts/create-release-with-version-scripts.include.md
@@ -575,3 +575,55 @@ func GetPackageVersion(octopusURL *url.URL, APIKey string, space *octopusdeploy.
 	return mostRecentPackageVersion["Version"].(string)
 }
 ```
+```java Java
+import com.octopus.sdk.Repository;
+import com.octopus.sdk.domain.Project;
+import com.octopus.sdk.domain.Release;
+import com.octopus.sdk.domain.Space;
+import com.octopus.sdk.http.ConnectData;
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.http.OctopusClientFactory;
+import com.octopus.sdk.model.release.ReleaseResource;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Optional;
+
+public class CreateReleaseWithVersion {
+
+  final static String octopusServerUrl = "http://localhost:8065";
+  final static String apiKey = "YOUR_API_KEY"; // as read from your profile in your Octopus Deploy server
+
+  public static void main(final String... args) throws IOException {
+    final OctopusClient client = createClient();
+
+    final Repository repo = new Repository(client);
+    final Optional<Space> space = repo.spaces().getByName("TheSpaceName");
+    if(!space.isPresent()) {
+      System.out.println("No space named 'TheSpaceName' exists on server");
+      return;
+    }
+
+    final Optional<Project> project = space.get().projects().getByName("TheProjectName");
+    if(!project.isPresent()) {
+      System.out.println("No project named 'TheProjectName' exists on server");
+      return;
+    }
+
+    final ReleaseResource releaseResource = new ReleaseResource("1.0", project.get().getProperties().getId());
+    final Release release = space.get().releases().create(releaseResource);
+  }
+
+  // Create an authenticated connection to your Octopus Deploy Server
+  private static OctopusClient createClient() throws MalformedURLException {
+    final Duration connectTimeout = Duration.ofSeconds(10L);
+    final ConnectData connectData = new ConnectData(new URL(octopusServerUrl), apiKey, connectTimeout);
+    final OctopusClient client = OctopusClientFactory.createClient(connectData);
+
+    return client;
+  }
+}
+
+```

--- a/docs/shared-content/scripts/delete-a-space-scripts.include.md
+++ b/docs/shared-content/scripts/delete-a-space-scripts.include.md
@@ -196,3 +196,44 @@ func GetSpace(octopusURL *url.URL, APIKey string, spaceName string) *octopusdepl
 	return nil
 }
 ```
+```java Java
+import com.octopus.sdk.Repository;
+import com.octopus.sdk.domain.Space;
+import com.octopus.sdk.http.ConnectData;
+import com.octopus.sdk.http.OctopusClient;
+import com.octopus.sdk.http.OctopusClientFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Optional;
+
+public class DeleteSpace {
+
+  final static String octopusServerUrl = "http://localhost:8065";
+  final static String apiKey = "YOUR_API_KEY"; // as read from your profile in your Octopus Deploy server
+
+  public static void main(final String... args) throws IOException {
+    final OctopusClient client = createClient();
+    final Repository repo = new Repository(client);
+    final Optional<Space> space = repo.spaces().getByName("TheSpaceName");
+    if(!space.isPresent()) {
+      System.out.println("No space named 'TheSpaceName' exists on server");
+      return;
+    }
+
+    space.get().getProperties().setTaskQueueStopped(true);
+    final Space stoppedSpace = repo.spaces().update(space.get().getProperties());
+    repo.spaces().delete(stoppedSpace.getProperties());
+  }
+  
+  // Create an authenticated connection to your Octopus Deploy Server
+  private static OctopusClient createClient() throws MalformedURLException {
+    final Duration connectTimeout = Duration.ofSeconds(10L);
+    final ConnectData connectData = new ConnectData(new URL(octopusServerUrl), apiKey, connectTimeout);
+    final OctopusClient client = OctopusClientFactory.createClient(connectData);
+
+    return client;
+  }
+```


### PR DESCRIPTION
This change updates the docs to highlight the availability of a java wrapper to the Octopus Deploy HTTP Api.

It adds examples for:
* add-space
* create-project
* create-project-group
* create-release-with-version
* delete-space