### PR TITLE
Adds documentation for creating dynamic infrastructure for step package targets

### DIFF
--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -50,7 +50,7 @@ Before you can create dynamic targets in an Environment, the environment needs t
 
 :::hint
 **Targets from Step Packages**
-Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. Step packages are available in Octopus Deploy version 2021.3 and later. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
 
 Targets defined by step packages use the new generic `New-OctopusTarget` function to create targets. 
 :::

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -59,7 +59,7 @@ Targets defined by step packages use the new generic `New-OctopusTarget` functio
 - [Azure Service Fabric](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md)
 - [Azure Cloud Service](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md)
 - [Kubernetes Cluster](/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md)
-- [New Target](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md)
+- [AWS ECS Cluster](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md)
 - [Remove Target](/docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md)
 
 ### Restrictions

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -59,7 +59,7 @@ Targets defined by step packages use the new generic `New-OctopusTarget` functio
 - [Azure Service Fabric](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md)
 - [Azure Cloud Service](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md)
 - [Kubernetes Cluster](/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md)
-- [AWS ECS Cluster](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md)
+- [New Target](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md)
 - [Remove Target](/docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md)
 
 ### Restrictions

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -6,8 +6,6 @@ position: 120
 
 You can use the [Octopus REST API](/docs/octopus-rest-api/index.md) or the Octopus commands below to create Octopus accounts, targets, and workers dynamically. You can make these requests in the same scripts that create your cloud infrastructure or in following steps.
 
-
-
 ## Enable dynamic infrastructure
 
 Dynamic infrastructure can be enabled when a new environment is created, or it can be enabled or disabled for existing environments.
@@ -29,11 +27,11 @@ Octopus comes with a REST API that can be used to register Octopus accounts and 
 
 To learn more about the things you can do with the API, take a look at our [API examples](/docs/octopus-rest-api/examples/index.md) section.
 
-## Available commands and syntax
+## Using PowerShell functions
 
 Each of the resource commands is available as a PowerShell function anywhere that a step allows you to run a PowerShell script.
 
-:::warning
+:::hint
 Only a subset of account types and deployment targets support being created dynamically using the commands listed below.
 :::
 
@@ -50,11 +48,19 @@ Only a subset of account types and deployment targets support being created dyna
 Before you can create dynamic targets in an Environment, the environment needs to be configured to allow it. See [Enabling dynamic infrastructure](/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md#enable-dynamic-infrastructure) for more information.
 :::
 
+:::hint
+**Targets from Step Packages**
+Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+
+Targets defined by step packages use the new generic `New-OctopusTarget` function to create targets. 
+:::
+
 - [Azure Web App](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md)
 - [Azure Service Fabric](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md)
 - [Azure Cloud Service](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md)
 - [Kubernetes Cluster](/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md)
-- [Remove Target](/docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-target.md)
+- [AWS ECS Cluster](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md)
+- [Remove Target](/docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md)
 
 ### Restrictions
 
@@ -64,6 +70,10 @@ This cannot be overridden through the commands.
 :::warning
 These commands are not available in the **Script Console**.
 :::
+
+## Using bash functions
+
+Any targets defined by a step package have access to creating that target with a bash script. See the [new-target function documentation](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-target.md) for further information.
 
 ## Examples
 

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -48,13 +48,6 @@ Only a subset of account types and deployment targets support being created dyna
 Before you can create dynamic targets in an Environment, the environment needs to be configured to allow it. See [Enabling dynamic infrastructure](/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md#enable-dynamic-infrastructure) for more information.
 :::
 
-:::hint
-**Targets from Step Packages**
-Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. Step packages are available in Octopus Deploy version 2021.3 and later. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
-
-Targets defined by step packages use the new generic `New-OctopusTarget` function to create targets. 
-:::
-
 - [Azure Web App](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md)
 - [Azure Service Fabric](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md)
 - [Azure Cloud Service](/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md)

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -73,7 +73,7 @@ These commands are not available in the **Script Console**.
 
 ## Using bash functions
 
-Any targets defined by a step package have access to creating that target with a bash script. See the [new-target function documentation](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-target.md) for further information.
+Any targets defined by a step package have access to creating that target with a bash script. See the [new-target function documentation](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md) for further information.
 
 ## Examples
 

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -8,11 +8,11 @@ Targets defined by step packages can be created either by PowerShell or bash fun
 
 To create a target defined by a step package, you will need to know the `target identifier`, and the `inputs` required by the target. These can currently be found in the following locations:
 
-#### Target Identifiers
+**Target Identifiers**
 
 - [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/metadata.json#L5)
 
-#### Required Inputs
+**Required Inputs**
 
 - [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/inputs.ts)
 

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -1,0 +1,70 @@
+---
+title: New Octopus Target Command
+description: Function for removing an Octopus target
+position: 50
+---
+
+Targets defined by step packages can be created either by PowerShell or bash functions available in any Octopus script-running context.  To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+
+To create a target defined by a step package, you will need to know the `target identifier`, and the `inputs` required by the target. These can currently be found in the following locations:
+
+#### Target Identifiers
+
+- [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/metadata.json#L5)
+
+#### Required Inputs
+
+- [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/inputs.ts)
+
+## New octopus target
+Command (pwsh): **New-OctopusTarget** 
+
+| Parameter                           | Value                                  |
+| ----------------------------------- | -------------------------------------- |
+| `-name`                             | The Name of the target to create |
+| `-targetId`                         | The target identifier of target to create |
+| `-inputs`                           | The inputs required to define the target being created |
+| `-roles`                            | Comma separated list of Roles to assign |
+| `-updateIfExisting`                 | Will update an existing target with the same name, create if it doesn't exist |
+| `-workerPoolIdOrName`               | Name or Id of the Worker Pool for the deployment target to use. (Optional) |
+
+Command (bash) **new_octopustarget** 
+
+| Parameter                           | Value                                  |
+| ----------------------------------- | -------------------------------------- |
+| `-n` | `--name`                     | The Name of the target to create |
+| `-t` | `--targetId`                 | The target identifier of target to create |
+| `--inputs`                          | The inputs required to define the target being created |
+| `--roles`                           | Comma separated list of Roles to assign |
+| `--update-if-existing`              | Will update an existing target with the same name, create if it doesn't exist |
+| `--worker-pool`                     | Name or Id of the Worker Pool for the deployment target to use. (Optional) |
+
+### Examples
+
+The below examples demonstrate creating a new AWS ECS Cluster target, evidenced by the `aws-ecs-target` target identifier. These scripts would typically be invoked after creating the cluster in a preceeding step. The required information can be passed to these scripts via [passing parameters](/docs/deployments/custom-scripts/passing-parameters-to-scripts.md), or via [output variables](/docs/deployments/custom-scripts/output-variables.md) published in preceeding steps, or can simply be hard-coded.
+
+#### PowerShell
+```powershell
+$inputs = @"
+{
+    "clusterName": "$($OctopusParameters["clusterName"])",
+    "region": "$($OctopusParameters["region"])",
+    "awsAccount": "$($OctopusParameters["awsAccount"])",
+}
+"@
+
+New-OctopusTarget -Name $OctopusParameters["target_name"] -TargetId "aws-ecs-target" -Inputs $inputs -Roles $OctopusParameters["role"]
+```
+
+#### Bash
+```bash
+read -r -d '' INPUTS <<EOT
+{
+    "clusterName": "$(get_octopusvariable "clusterName")",
+    "name": "$(get_octopusvariable "target_name")",
+    "awsAccount": "$(get_octopusvariable "awsAccount")",
+}
+EOT
+
+new_octopustarget -n "$(get_octopusvariable "target_name")" -t "aws-ecs-target" --inputs "$INPUTS" --roles "$(get_octopusvariable "role")"
+```

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -56,7 +56,7 @@ $inputs = @"
 }
 "@
 
-New-OctopusTarget -Name $OctopusParameters["target_name"] -TargetId "aws-ecs-target" -Inputs $inputs -Roles $OctopusParameters["role"]
+New-OctopusTarget -Name "$($OctopusParameters["target_name"])" -TargetId "aws-ecs-target" -Inputs $inputs -Roles "$($OctopusParameters["role"])"
 ```
 ```bash Bash
 read -r -d '' INPUTS <<EOT

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -17,6 +17,7 @@ To create a target defined by a step package, you will need to know the `target 
 - [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/inputs.ts)
 
 ## New octopus target
+
 Command (pwsh): **New-OctopusTarget** 
 
 | Parameter                           | Value                                  |
@@ -43,8 +44,7 @@ Command (bash) **new_octopustarget**
 
 The below examples demonstrate creating a new AWS ECS Cluster target, evidenced by the `aws-ecs-target` target identifier. These scripts would typically be invoked after creating the cluster in a preceeding step. The required information can be passed to these scripts via [passing parameters](/docs/deployments/custom-scripts/passing-parameters-to-scripts.md), or via [output variables](/docs/deployments/custom-scripts/output-variables.md) published in preceeding steps, or can simply be hard-coded.
 
-#### PowerShell
-```powershell
+```powershell PowerShell
 $inputs = @"
 {
     "clusterName": "$($OctopusParameters["clusterName"])",
@@ -55,9 +55,7 @@ $inputs = @"
 
 New-OctopusTarget -Name $OctopusParameters["target_name"] -TargetId "aws-ecs-target" -Inputs $inputs -Roles $OctopusParameters["role"]
 ```
-
-#### Bash
-```bash
+```bash Bash
 read -r -d '' INPUTS <<EOT
 {
     "clusterName": "$(get_octopusvariable "clusterName")",

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -4,17 +4,18 @@ description: Function for removing an Octopus target
 position: 50
 ---
 
-Targets defined by step packages can be created either by PowerShell or bash functions available in any Octopus script-running context.  To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+Targets defined by step packages can be created either by PowerShell or bash functions available in any Octopus script-running context. Not all targets are defined by step packages. The complete list of targets defined by step packages is available below.
+
+:::hint
+**Targets from Step Packages**
+Step packages are available in Octopus Deploy version 2021.3 and later. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+:::
 
 To create a target defined by a step package, you will need to know the `target identifier`, and the `inputs` required by the target. These can currently be found in the following locations:
 
-**Target Identifiers**
-
-- [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/metadata.json#L5)
-
-**Required Inputs**
-
-- [AWS ECS Cluster](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/inputs.ts)
+| Target                              | Identifier                             | Required Inputs                        |
+| ----------------------------------- | -------------------------------------- | -------------------------------------- |
+| AWS ECS Cluster | [Identifier](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/metadata.json#L5) | [Inputs](https://github.com/OctopusDeploy/step-package-ecs/blob/main/targets/ecs-target/src/inputs.ts)
 
 ## New octopus target
 

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -8,7 +8,9 @@ Targets defined by step packages can be created either by PowerShell or bash fun
 
 :::hint
 **Targets from Step Packages**
-Step packages are available in Octopus Deploy version 2021.3 and later. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. Step packages are available in Octopus Deploy version 2021.3 and later. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+
+Targets defined by step packages use the new generic `New-OctopusTarget` function to create targets. 
 :::
 
 To create a target defined by a step package, you will need to know the `target identifier`, and the `inputs` required by the target. These can currently be found in the following locations:

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md
@@ -1,7 +1,7 @@
 ---
-title: Remove Target Command
+title: Remove Octopus Target Command
 description: Cmdlet for removing an Octopus target
-position: 50
+position: 60
 ---
 
 ## Delete target

--- a/redirects.txt
+++ b/redirects.txt
@@ -196,7 +196,7 @@ docs/infrastructure/dynamic-infrastructure/azure-cloud-service-target.md -> docs
 docs/infrastructure/dynamic-infrastructure/azure-service-fabric-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md
 docs/infrastructure/dynamic-infrastructure/azure-web-app-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md
 docs/infrastructure/dynamic-infrastructure/kubernetes-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md
-docs/infrastructure/dynamic-infrastructure/remove-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-target.md
+docs/infrastructure/dynamic-infrastructure/remove-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md
 docs/infrastructure/ssh-targets/index.md -> docs/infrastructure/deployment-targets/linux/index.md
 docs/infrastructure/ssh-targets/configuring-ssh-connection.md -> docs/infrastructure/deployment-targets/linux/index.md
 docs/infrastructure/ssh-targets/mono-calamari.md -> docs/infrastructure/deployment-targets/linux/ssh-requirements.md

--- a/redirects.txt
+++ b/redirects.txt
@@ -197,6 +197,7 @@ docs/infrastructure/dynamic-infrastructure/azure-service-fabric-target.md -> doc
 docs/infrastructure/dynamic-infrastructure/azure-web-app-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md
 docs/infrastructure/dynamic-infrastructure/kubernetes-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md
 docs/infrastructure/dynamic-infrastructure/remove-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md
+docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-target.md -> docs/infrastructure/deployment-targets/dynamic-infrastructure/remove-octopustarget.md
 docs/infrastructure/ssh-targets/index.md -> docs/infrastructure/deployment-targets/linux/index.md
 docs/infrastructure/ssh-targets/configuring-ssh-connection.md -> docs/infrastructure/deployment-targets/linux/index.md
 docs/infrastructure/ssh-targets/mono-calamari.md -> docs/infrastructure/deployment-targets/linux/ssh-requirements.md


### PR DESCRIPTION
In August we added functionality to dynamically create targets emitted from step packages.

This PR documents the new functions.

Related changes:

https://github.com/OctopusDeploy/Calamari/pull/785
https://github.com/OctopusDeploy/OctopusDeploy/pull/9774
https://github.com/OctopusDeploy/Calamari/commit/2413e18f6f6fb409f2c58dbe3ada53b339bd199f