### PR TITLE
Config as code - links for Git providers access token instructions

### DIFF
--- a/docs/projects/version-control/index.md
+++ b/docs/projects/version-control/index.md
@@ -59,7 +59,12 @@ The _Default Branch Name_ is the branch on which the Octopus configuration will 
 
 The default branch must exist.
 
-The _Authentication_ field specifies the credentials used by Octopus when authenticating with the git provider.  The password will likely be a personal access token. 
+The _Authentication_ field specifies the credentials used by Octopus when authenticating with the git provider.  For the Password field, we recommend using a personal access token where possible. Click on the relevant link below to get your personal access token -
+
+* [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+* [Azure DevOps - Use personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
+* [BitBucket - Personal access tokens](https://confluence.atlassian.com/bitbucketserver063/personal-access-tokens-972354166.html)
+* [GitLab - Personal access tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 
 _Git File Storage Directory_ specifies the path within the repository where the Octopus configuration will be stored.  If only a single Octopus project will be stored in the repo, we recommend putting the configuration directly under the `.octopus` directory. If multiple projects will be persisted to the repository, adding the project name to the path is the recommended convention, e.g. `./octopus/acme`
 

--- a/docs/projects/version-control/index.md
+++ b/docs/projects/version-control/index.md
@@ -64,7 +64,7 @@ The _Authentication_ field specifies the credentials used by Octopus when authen
 * [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 * [Azure DevOps - Use personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
 * [BitBucket](https://confluence.atlassian.com/bitbucketserver063/personal-access-tokens-972354166.html)
-* [GitLab - Personal access tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
+* [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 
 _Git File Storage Directory_ specifies the path within the repository where the Octopus configuration will be stored.  If only a single Octopus project will be stored in the repo, we recommend putting the configuration directly under the `.octopus` directory. If multiple projects will be persisted to the repository, adding the project name to the path is the recommended convention, e.g. `./octopus/acme`
 

--- a/docs/projects/version-control/index.md
+++ b/docs/projects/version-control/index.md
@@ -63,7 +63,7 @@ The _Authentication_ field specifies the credentials used by Octopus when authen
 
 * [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 * [Azure DevOps - Use personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
-* [BitBucket - Personal access tokens](https://confluence.atlassian.com/bitbucketserver063/personal-access-tokens-972354166.html)
+* [BitBucket](https://confluence.atlassian.com/bitbucketserver063/personal-access-tokens-972354166.html)
 * [GitLab - Personal access tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 
 _Git File Storage Directory_ specifies the path within the repository where the Octopus configuration will be stored.  If only a single Octopus project will be stored in the repo, we recommend putting the configuration directly under the `.octopus` directory. If multiple projects will be persisted to the repository, adding the project name to the path is the recommended convention, e.g. `./octopus/acme`

--- a/docs/projects/version-control/index.md
+++ b/docs/projects/version-control/index.md
@@ -59,7 +59,7 @@ The _Default Branch Name_ is the branch on which the Octopus configuration will 
 
 The default branch must exist.
 
-The _Authentication_ field specifies the credentials used by Octopus when authenticating with the git provider.  For the Password field, we recommend using a personal access token where possible. Click on the relevant link below to get your personal access token -
+The _Authentication_ field specifies the credentials used by Octopus when authenticating with the git provider.  For the Password field, we recommend using a personal access token. Git providers allow you to create an access token in different ways:
 
 * [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
 * [Azure DevOps - Use personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)

--- a/docs/projects/version-control/index.md
+++ b/docs/projects/version-control/index.md
@@ -62,7 +62,7 @@ The default branch must exist.
 The _Authentication_ field specifies the credentials used by Octopus when authenticating with the git provider.  For the Password field, we recommend using a personal access token. Git providers allow you to create an access token in different ways:
 
 * [GitHub - Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
-* [Azure DevOps - Use personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
+* [Azure DevOps](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
 * [BitBucket](https://confluence.atlassian.com/bitbucketserver063/personal-access-tokens-972354166.html)
 * [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 


### PR DESCRIPTION
Add in links to git providers for users to easily get their personal access token.