### PR TITLE
Update recommended minimum version of Mono to 5.14

### DIFF
--- a/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
+++ b/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
@@ -60,7 +60,7 @@ Self-contained Calamari is built as a [.NET Core self-contained distributable](h
 
 [Calamari](/docs/octopus-rest-api/calamari.md) can execute on the [Mono framework](http://www.mono-project.com/).
 
-Version **3.10** or greater of Mono is required; however, we recommended a minimum of version **5.14.0**.
+Version **3.10** or greater of Mono is required; however, we recommend a minimum of version **5.14.0**.
 
 You can find instructions for installing Mono in the [Mono documentation](http://www.mono-project.com/docs/getting-started/install/linux/).
 

--- a/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
+++ b/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
@@ -60,7 +60,7 @@ Self-contained Calamari is built as a [.NET Core self-contained distributable](h
 
 [Calamari](/docs/octopus-rest-api/calamari.md) can execute on the [Mono framework](http://www.mono-project.com/).
 
-Version **3.10** or greater of Mono is required; however, we recommend a minimum of version **5.14.0**.
+Version **5.14.0** or greater of Mono is supported. Version **3.10** or greater may work, however we strongly recommend using a supported version.
 
 You can find instructions for installing Mono in the [Mono documentation](http://www.mono-project.com/docs/getting-started/install/linux/).
 

--- a/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
+++ b/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
@@ -60,7 +60,7 @@ Self-contained Calamari is built as a [.NET Core self-contained distributable](h
 
 [Calamari](/docs/octopus-rest-api/calamari.md) can execute on the [Mono framework](http://www.mono-project.com/).
 
-Version **3.10** or greater of Mono is required; however, we recommended a minimum of version **4.8.0**.
+Version **3.10** or greater of Mono is required; however, we recommended a minimum of version **5.14.0**.
 
 You can find instructions for installing Mono in the [Mono documentation](http://www.mono-project.com/docs/getting-started/install/linux/).
 


### PR DESCRIPTION
Mono support is something that we want to deprecate, but as an interim step for keeping it around we don't want to support Mono < 5.14.0 anymore. This will help us simplify our codebase and CI pipeline for Calamari.