### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -91,8 +91,8 @@ Where [<options>] is any of:
       --webReferrerPolicy=VALUE
                              Sets the 'Referrer-Policy' response header.
                                Defaults to 'no-referrer'.
-      --webServer=VALUE      Web server to use when running Octopus
-                               ('HttpSys', 'Kestrel')
+      --webServer=VALUE      Web server to use when running Octopus (HttpSys,
+                               Kestrel)
       --webTrustedRedirectUrls=VALUE
                              Comma-seperated list of URLs that are trusted
                                for redirection


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2021.3.8275.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 277