### PR TITLE
Removing warnings related to using variables for ARC.

### DIFF
--- a/docs/projects/project-triggers/automatic-release-creation.md
+++ b/docs/projects/project-triggers/automatic-release-creation.md
@@ -33,11 +33,6 @@ From the project's trigger tab, under the section called **Automatic Release Cre
 
 As a project can contain multiple packages you need to select the package that will upload LAST in your build and push CI process. If you have multiple packages, make sure you select the package that is always uploaded last.
 
-:::warning
-**Cannot use variables for PackageId**
-You cannot use variables to define the PackageId (either in full or in part). Octopus will only create a release on your behalf when you have selected a specific Package (the PackageId must be a constant value).
-:::
-
 ![Automatic release creation last package option](images/automatic-release-creation-last-package.png "width=500")
 
 When a release is set to be created this way, the audit will tell you that is how the release was created.


### PR DESCRIPTION
Using variables in ARC was added in 2019.3.1, docs haven't been updated to reflect this.

Github Issue: [Issue 4236](https://github.com/OctopusDeploy/Issues/issues/4236).
Code Change and Commit: [Evaluate variables in package names during Auto Release Creation and Scheduled Triggers Commit.](https://github.com/OctopusDeploy/OctopusDeploy/commit/cf79d48cfd512acd086be1a15ba6b426bb98c6e3).