### PR TITLE
Clarify/restate how the built-in package repo retention policy works.

### DIFF
--- a/docs/administration/retention-policies/index.md
+++ b/docs/administration/retention-policies/index.md
@@ -48,7 +48,7 @@ When a package retention policy is applied, Octopus will delete packages that me
 2. The package is **not associated with any releases in Octopus**.
 
 :::hint
-When using a repository retention policy, pay close attention to your [retention policy on releases](#releases-whats-deleted). When releases are deleted as a result of your release retention policy, then packages associated with those releases may become subject to cleanup by your repository policy.
+When configuring the repository retention policy, it's also worth making note of your [release retention policy](#releases-whats-deleted) settings too. When releases are deleted as a result of your release retention policy, then packages associated with those releases may become subject to cleanup by your repository policy.
 :::
 
 ### Build information {#build-information-whats-deleted}

--- a/docs/administration/retention-policies/index.md
+++ b/docs/administration/retention-policies/index.md
@@ -39,9 +39,17 @@ We talk about Tentacles here, but the same process and logic applies to [SSH Tar
 
 ### Built-in repository {#built-in-repo-whats-deleted}
 
-The built-in repository will delete any **packages** that are not attached to any release. If you happen to have higher versions of packages that have not been released, we will keep them assuming a release will be created. If you delete releases using the Octopus Server retention policy then any packages that were associated with those releases will then be deleted with that task.
+A retention policy can be applied to packages in the built-in Octopus package repository. By default, the policy is set to keep all packages indefinitely. This policy is *separate* from the [release retention policy](#releases-whats-deleted) described above.
 
-A list of packages IDs that a project has deployed is kept and then used to determine retention for projects that [dynamically select packages using variables](/docs/deployments/packages/dynamically-selecting-packages.md). A package will be kept if it appears in that list and the package's version matches any of the package versions referenced by the project's releases.
+![](images/3278059.png "width=500")
+
+When a package retention policy is applied, Octopus will delete packages that meet *both* of the following criteria:
+1. The time span from the package's initial publish date exceeds the configured time period in the policy
+2. The package is **not associated with any releases in Octopus**.
+
+:::hint
+When using a repository retention policy, pay close attention to your [retention policy on releases](#releases-whats-deleted). When releases are deleted as a result of your release retention policy, then packages associated with those releases may become subject to cleanup by your repository policy.
+:::
 
 ### Build information {#build-information-whats-deleted}
 


### PR DESCRIPTION
The wording in this section I found to be confusing (and possibly even just wrong).

The section says:
> If you happen to have higher versions of packages that have not been released, we will keep them assuming a release will be created.

This is simply not true. I tested this recently:
```
16:07:00   Info     |     Applying retention policies to the built-in package repository.
16:07:00   Verbose  |     Packages uploaded before 12/9/2021 12:07:00 AM +00:00, and not used by any active release, will be deleted.
16:07:00   Info     |     OctopusDeploy.OctoPetShop.Database.1.0.0 was published on 10/22/2021 7:50:27 PM +00:00. It will be kept because the package is used in the following release: Retention Policy Test v0.0.1.
16:07:00   Info     |     OctopusDeploy.OctoPetShop.Database.1.0.1 was published on 12/8/2021 11:48:28 PM +00:00. It will be deleted.
16:07:00   Verbose  |     Deleting package OctopusDeploy.OctoPetShop.Database.1.0.1.nupkg.
16:07:00   Info     |     Removed 1 package from built-in repository.
```

The suggested change I believe more simply explains how the package retention policy works.

A bit of internal discussion: https://octopusdeploy.slack.com/archives/C012AMYFLPR/p1638994779126500