### PR TITLE
Note caveat about default lifecycle for Environments export

### DIFF
--- a/docs/projects/export-import/index.md
+++ b/docs/projects/export-import/index.md
@@ -75,9 +75,14 @@ The Octopus Deploy data-model is a web, not a graph.  Some resources are shared 
 
 Any environments which can be reached via the project will be included in the export.  This includes:
 
-- Environments included in any of the project's lifecycles 
-- Environments used to scope variables in any [library variable sets](/docs/projects/variables/library-variable-sets.md) connected to the project 
-- Environment restrictions defined on any accounts or certificates referenced by the project 
+- Environments included in any of the project's lifecycles.
+
+:::hint
+Important caveat: If your projects use the Octopus built-in, [default Lifecycle](/docs/releases/lifecycles#default-lifecycle), environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior when during project import.
+:::
+
+- Environments used to scope variables in any [library variable sets](/docs/projects/variables/library-variable-sets.md) connected to the project
+- Environment restrictions defined on any accounts or certificates referenced by the project
 
 ### Deployment targets #{deployment-targets}
 

--- a/docs/projects/export-import/index.md
+++ b/docs/projects/export-import/index.md
@@ -75,13 +75,13 @@ The Octopus Deploy data-model is a web, not a graph.  Some resources are shared 
 
 Any environments which can be reached via the project will be included in the export.  This includes:
 
-- Environments included in any of the project's lifecycles, *except* when using the [default lifecycle](/docs/releases/lifecycles#default-lifecycle).
+- Environments included in any of the project's lifecycles, *except* when using the [default lifecycle](/docs/releases/lifecycles.md#default-lifecycle).
 - Environments used to scope variables in any [library variable sets](/docs/projects/variables/library-variable-sets.md) connected to the project
 - Environment restrictions defined on any accounts or certificates referenced by the project
 
 :::warning
 **Environments from the default lifecycle are not exported:**
-If your projects use the [default lifecycle](/docs/releases/lifecycles#default-lifecycle) that Octopus creates, environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior when during project import.
+If your projects use the [default lifecycle](/docs/releases/lifecycles.md#default-lifecycle) that Octopus creates, environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior when during project import.
 :::
 
 ### Deployment targets #{deployment-targets}

--- a/docs/projects/export-import/index.md
+++ b/docs/projects/export-import/index.md
@@ -75,14 +75,14 @@ The Octopus Deploy data-model is a web, not a graph.  Some resources are shared 
 
 Any environments which can be reached via the project will be included in the export.  This includes:
 
-- Environments included in any of the project's lifecycles.
-
-:::hint
-Important caveat: If your projects use the Octopus built-in, [default Lifecycle](/docs/releases/lifecycles#default-lifecycle), environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior when during project import.
-:::
-
+- Environments included in any of the project's lifecycles, *except* when using the [default lifecycle](/docs/releases/lifecycles#default-lifecycle).
 - Environments used to scope variables in any [library variable sets](/docs/projects/variables/library-variable-sets.md) connected to the project
 - Environment restrictions defined on any accounts or certificates referenced by the project
+
+:::warning
+**Environments from the default lifecycle are not exported:**
+If your projects use the [default lifecycle](/docs/releases/lifecycles#default-lifecycle) that Octopus creates, environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior when during project import.
+:::
 
 ### Deployment targets #{deployment-targets}
 

--- a/docs/projects/export-import/index.md
+++ b/docs/projects/export-import/index.md
@@ -81,7 +81,7 @@ Any environments which can be reached via the project will be included in the ex
 
 :::warning
 **Environments from the default lifecycle are not exported:**
-If your projects use the [default lifecycle](/docs/releases/lifecycles.md#default-lifecycle) that Octopus creates, environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior when during project import.
+If your projects use the [default lifecycle](/docs/releases/lifecycles.md#default-lifecycle) that Octopus creates, environments associated with that lifecycle will *not* be included in the project export. This was an intentional design decision made to avoid some tricky, unexpected behavior during project import.
 :::
 
 ### Deployment targets #{deployment-targets}


### PR DESCRIPTION
This was surprising to me when testing this feature and I think deserves mention in the docs.

https://octopusdeploy.slack.com/archives/C033W4273/p1639525456152800