### PR TITLE
Updating cli docs for octo.exe

### DIFF
--- a/docs/octopus-rest-api/octopus-cli/delete-package.md
+++ b/docs/octopus-rest-api/octopus-cli/delete-package.md
@@ -16,7 +16,8 @@ Where [<options>] is any of:
 
 Deletion:
 
-      --package=VALUE        Id of the package.
+      --packageId=VALUE      Id of the package.
+      --version=VALUE        Version number of the package.
 
 Common options:
 


### PR DESCRIPTION
An automated update of the command line docs for octo.exe version 7.4.3556.0.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 282