### PR TITLE
Fix Golang script example for deployment release with prompted variables

### DIFF
--- a/docs/shared-content/scripts/deploy-release-with-prompted-variables-scripts.include.md
+++ b/docs/shared-content/scripts/deploy-release-with-prompted-variables-scripts.include.md
@@ -385,7 +385,7 @@ func main() {
 
 		// check to see if the element display name matches
 		if (element["Control"].(map[string]interface{}))["Name"] == parsedPromptedVariable[0] {
-			formElements[element["Control"].(map[string]interface{})["Name"].(string)] = parsedPromptedVariable[1]
+			formElements[element["Name"].(string)] = parsedPromptedVariable[1]
 		}
 	}
 


### PR DESCRIPTION
Current script does not pass `FormValues` properly. 
API expects UUID of variable as key instead of variable name.
For example: 
```"FormValues": {"8f457792-62f1-d607-2194-cd9846235130": "MyValue"}}```

Currently it is:
```"FormValues": {"MyVariable": "MyValue"}}```

