### PR TITLE
Removes private link to step-api repo from New-OctopusTarget command page

### DIFF
--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -8,7 +8,7 @@ Targets defined by step packages can be created either by PowerShell or bash fun
 
 :::hint
 **Targets from Step Packages**
-Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. Step packages are available in Octopus Deploy version 2021.3 and later. To learn more about step packages, read the [step package documentation](https://github.com/octopusdeploy/step-api#overview).
+Octopus Deploy has recently developed a new architecture for deployment steps and targets, known as step packages. Step packages are available in Octopus Deploy version 2021.3 and later.
 
 Targets defined by step packages use the new generic `New-OctopusTarget` function to create targets. 
 :::


### PR DESCRIPTION
The documentation for dynamically creating deployment targets that are authored with step packages (e.g. an AWS ECS cluster) currently contains a link to learn more about step packages which points to the https://github.com/OctopusDeploy/step-api repo. This repo is currently private and so will result in a 404 for any non-Octopus user of the docs. 

This PR removes the link for the moment. There are plans to make the repo public at which time the link could be restored.