### PR TITLE
Add info on how to disable insecure tls protocols

### DIFF
--- a/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
+++ b/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
@@ -62,7 +62,7 @@ Octopus Tentacle Specific Registries - Check in each folder for a key with a Dis
 
 :::problem
 **Take care removing registry entries**
-Removing entries from the registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always backup any keys before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
+Removing entries from the registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always [backup any keys](https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692) before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
 :::
 
 5. Find and delete any Octopus folders from:

--- a/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
+++ b/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/manually-uninstall-tentacle.md
@@ -62,7 +62,7 @@ Octopus Tentacle Specific Registries - Check in each folder for a key with a Dis
 
 :::problem
 **Take care removing registry entries**
-Removing entries from the registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always backup any keys before they are modified. If you have any questions or need assistance, please [email our support team](mailto:support@octopus.com).
+Removing entries from the registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always backup any keys before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
 :::
 
 5. Find and delete any Octopus folders from:

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -229,7 +229,7 @@ The following bash scripts install, configure and register Linux Tentacle for us
 
 ## Disabling weak TLS protocols {#disable-weak-tls-protocols}
 
-It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols) section.
+To harden the TLS implementation used, review our documentation on [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols).
 
 ## Learn more
 

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -227,6 +227,10 @@ The following bash scripts install, configure and register Linux Tentacle for us
 
 !include <rootless-tentacle-instance-creation>
 
+## Disabling insecure TLS protocols {#disable-insecure-tls-protocols}
+
+It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-insecure-tls-protocols) section.
+
 ## Learn more
 
 - [Linux blog posts](https://octopus.com/blog/tag/linux)

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -227,9 +227,9 @@ The following bash scripts install, configure and register Linux Tentacle for us
 
 !include <rootless-tentacle-instance-creation>
 
-## Disabling insecure TLS protocols {#disable-insecure-tls-protocols}
+## Disabling weak TLS protocols {#disable-weak-tls-protocols}
 
-It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-insecure-tls-protocols) section.
+It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols) section.
 
 ## Learn more
 

--- a/docs/runbooks/runbook-examples/routine/hardening-ubuntu.md
+++ b/docs/runbooks/runbook-examples/routine/hardening-ubuntu.md
@@ -91,4 +91,4 @@ The above script is a very basic hardening of Ubuntu.  Using the CIS guidelines,
 
 ## Disabling weak TLS protocols {#disable-weak-tls-protocols}
 
-It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols) section.
+To harden the TLS implementation used, review our documentation on [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols).

--- a/docs/runbooks/runbook-examples/routine/hardening-ubuntu.md
+++ b/docs/runbooks/runbook-examples/routine/hardening-ubuntu.md
@@ -89,6 +89,6 @@ sudo passwd -l root
 
 The above script is a very basic hardening of Ubuntu.  Using the CIS guidelines, you could further harden the installation per your organizations requirements.
 
-## Disabling insecure TLS protocols {#disable-insecure-tls-protocols}
+## Disabling weak TLS protocols {#disable-weak-tls-protocols}
 
-It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-insecure-tls-protocols) section.
+It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols) section.

--- a/docs/runbooks/runbook-examples/routine/hardening-ubuntu.md
+++ b/docs/runbooks/runbook-examples/routine/hardening-ubuntu.md
@@ -88,3 +88,7 @@ sudo passwd -l root
 ```
 
 The above script is a very basic hardening of Ubuntu.  Using the CIS guidelines, you could further harden the installation per your organizations requirements.
+
+## Disabling insecure TLS protocols {#disable-insecure-tls-protocols}
+
+It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-insecure-tls-protocols) section.

--- a/docs/runbooks/runbook-examples/routine/hardening-windows.md
+++ b/docs/runbooks/runbook-examples/routine/hardening-windows.md
@@ -146,7 +146,7 @@ catch {
 }
 
 Write-Verbose "Disable SSL v3"
-###Impact: SL 3.0 is an obsolete and insecure protocol.
+###Impact: SSL 3.0 is an obsolete and insecure protocol.
 ###Encryption in SSL 3.0 uses either the RC4 stream cipher, or a block cipher in CBC mode.
 ###RC4 is known to have biases, and the block cipher in CBC mode is vulnerable to the POODLE attack.
 try {

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -151,7 +151,7 @@ On Windows, the way to disable insecure versions of SSL and TLS are by editing t
 Editing the Windows registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always backup any keys before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
 :::
 
-The following example PowerShell will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
+The following example PowerShell script will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
 
 ```powershell
 # SSLv3
@@ -191,14 +191,14 @@ Once the version of TLS is set, reboot your Server and it should be available vi
 
 On Ubuntu `20.04` using OpenSSL `1.1.1f` (the latest at time of writing), you can specify the minimum TLS version to use to be `TLSv1.2` by setting the `MinProtocol` directive in the `/etc/ssl/openssl.cnf` OpenSSL config file:
 
-```bash
+```text
 [system_default_sect]
 MinProtocol = TLSv1.2
 ```
 
 On Ubuntu `18.04`, if the `MinProtocol` directive doesn't work, you can try this alternative. When using OpenSSL `1.1.1` (the latest at time of writing), you can specify the available TLS Protocols explicitly in the `/etc/ssl/openssl.cnf` OpenSSL config file:
 
-```bash
+```text
 [system_default_sect]
 Protocol = -SSLv3, -TLSv1, -TLSv1.1, TLSv1.2
 ```

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -78,7 +78,7 @@ These steps apply to the host operating system for your Octopus Server. You may 
 
 1. Rename local administrator account.
 1. Configure malware protection.
-1. Disable insecure TLS protocols.
+1. Disable weak TLS protocols.
 1. Prevent user-provided scripts from doing harm.
     a. Run workers under a different security context.
     a. Prevent unwanted file access.
@@ -134,7 +134,7 @@ Add-MpPreference -ExclusionPath "C:\Octopus\Work"
 Add-MpPreference -ExclusionPath "C:\Octopus\Work\*"
 ```
 
-### Disable insecure TLS protocols {#disable-insecure-tls-protocols}
+### Disable weak TLS protocols {#disable-weak-tls-protocols}
 
 All communication between Octopus Server and Tentacles is performed over a secure ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)) connection. Both Server and Tentacle rely on the host OS for the available TLS version to use when establishing a secure TLS connection when communicating. 
 
@@ -142,9 +142,9 @@ It's possible to disable older, less secure versions of SSL and TLS. This can be
 
 !include <security-disclaimer>
 
-#### Disable SSLv3, TLS 1.0 and 1.1 on Windows {#disable-insecure-tls-protocols-windows}
+#### Disable SSLv3, TLS 1.0 and 1.1 on Windows {#disable-weak-tls-protocols-windows}
 
-On Windows, the way to disable insecure versions of SSL and TLS are by editing the registry.
+On Windows, the way to disable weak versions of SSL and TLS are by editing the registry.
 
 :::problem
 **Take care editing registry entries**
@@ -187,7 +187,7 @@ New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders
 Once the version of TLS is set, reboot your Server and it should be available via `TLSv1.2`.
 :::
 
-#### Disable SSLv3, TLS 1.0 and 1.1 on Ubuntu Server  {#disable-insecure-tls-protocols-ubuntu}
+#### Disable SSLv3, TLS 1.0 and 1.1 on Ubuntu Server  {#disable-weak-tls-protocols-ubuntu}
 
 On Ubuntu `20.04` using OpenSSL `1.1.1f` (the latest at time of writing), you can specify the minimum TLS version to use to be `TLSv1.2` by setting the `MinProtocol` directive in the `/etc/ssl/openssl.cnf` OpenSSL config file:
 

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -136,9 +136,7 @@ Add-MpPreference -ExclusionPath "C:\Octopus\Work\*"
 
 ### Disable weak TLS protocols {#disable-weak-tls-protocols}
 
-All communication between Octopus Server and Tentacles is performed over a secure ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)) connection. Both Server and Tentacle rely on the host OS for the available TLS version to use when establishing a secure TLS connection when communicating. 
-
-It's possible to disable older, weaker versions of SSL and TLS. This can be done on your Octopus Server as well as both [deployment targets](/docs/infrastructure/index.md) and any [workers](/docs/infrastructure/workers/index.md) you have.
+All communication between Octopus Server and Tentacles is performed over a secure ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)) connection. Since both Server and Tentacle rely on the host OS for the available TLS version to use when establishing a secure TLS connection when communicating, you can harden the available TLS implementation.
 
 !include <security-disclaimer>
 

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -182,10 +182,10 @@ New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders
 ```
 
 :::hint
-Once the version of TLS is set, reboot your Server and it should be available via `TLSv1.2`.
+Once the TLS versions are disabled, reboot your Server and importantly [verify the change was successful](#disable-weak-tls-protocols-verify).
 :::
 
-#### Disable SSLv3, TLS 1.0 and 1.1 on Ubuntu Server  {#disable-weak-tls-protocols-ubuntu}
+#### Disable SSLv3, TLS 1.0 and 1.1 on Ubuntu Server {#disable-weak-tls-protocols-ubuntu}
 
 On Ubuntu `20.04` using OpenSSL `1.1.1f` (the latest at time of writing), you can specify the minimum TLS version to use to be `TLSv1.2` by setting the `MinProtocol` directive in the `/etc/ssl/openssl.cnf` OpenSSL config file:
 
@@ -202,8 +202,12 @@ Protocol = -SSLv3, -TLSv1, -TLSv1.1, TLSv1.2
 ```
 
 :::hint
-Once the version of TLS is set in your config, you'll want to restart any Tentacle service, and it should be available via `TLSv1.2`.
+Once the version of TLS is set in your config, you'll want to restart any Tentacle service, and importantly [verify the change was successful](#disable-weak-tls-protocols-verify).
 :::
+
+#### Verification of disabling weak TLS protocols {#disable-weak-tls-protocols-verify}
+
+Once you have performed changes to the available versions of TLS, you should verify that they have been disabled successfully. Tools such as [openssl](https://www.openssl.org/) and [nmap](https://nmap.org/), and web sites like [Qualys SSL Labs](https://www.ssllabs.com/ssltest/) can be used to verify the TLS version and cipher suites available.
 
 ### Prevent user-provided scripts from doing harm
 

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -78,6 +78,7 @@ These steps apply to the host operating system for your Octopus Server. You may 
 
 1. Rename local administrator account.
 1. Configure malware protection.
+1. Disable insecure TLS protocols.
 1. Prevent user-provided scripts from doing harm.
     a. Run workers under a different security context.
     a. Prevent unwanted file access.
@@ -132,6 +133,79 @@ Write-Output "Excluding Octopus Work folder from Windows Defender..."
 Add-MpPreference -ExclusionPath "C:\Octopus\Work"
 Add-MpPreference -ExclusionPath "C:\Octopus\Work\*"
 ```
+
+### Disable insecure TLS protocols {#disable-insecure-tls-protocols}
+
+All communication between Octopus Server and Tentacles is performed over a secure ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)) connection. Both Server and Tentacle rely on the host OS for the available TLS version to use when establishing a secure TLS connection when communicating. 
+
+It's possible to disable older, less secure versions of SSL and TLS. This can be done on your Octopus Server as well as both [deployment targets](/docs/infrastructure/index.md) and any [workers](/docs/infrastructure/workers/index.md) you have.
+
+!include <security-disclaimer>
+
+#### Disable SSLv3, TLS 1.0 and 1.1 on Windows {#disable-insecure-tls-protocols-windows}
+
+On Windows, the way to disable insecure versions of SSL and TLS are by editing the registry.
+
+:::problem
+**Take care editing registry entries**
+Editing the Windows registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always backup any keys before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
+:::
+
+The following example PowerShell will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
+
+```powershell
+# SSLv3
+New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server" -name "Enabled" -value "0" -PropertyType "DWord" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Server" -name "DisabledByDefault" -value 1 -PropertyType "DWord" -Force | Out-Null
+New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client" -name "Enabled" -value "0" -PropertyType "DWord" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\SSL 3.0\Client" -name "DisabledByDefault" -value 1 -PropertyType "DWord" -Force | Out-Null
+
+# TLSv1.0
+Write-Output "Disable TLS 1.0"
+
+New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server" -name "Enabled" -value "0" -PropertyType "DWord" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Server" -name "DisabledByDefault" -value 1 -PropertyType "DWord" -Force | Out-Null
+New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client" -Force | Out-Null    
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client" -name "Enabled" -value "0" -PropertyType "DWord" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client" -name "DisabledByDefault" -value 1 -PropertyType "DWord" -Force | Out-Null
+
+# TLSv1.1
+Write-Output "Disable TLS 1.1"
+
+New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server" -name "Enabled" -value "0" -PropertyType "DWord" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server" -name "DisabledByDefault" -value 1 -PropertyType "DWord" -Force | Out-Null
+New-Item "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client" -Force | Out-Null
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client" -name "Enabled" -value "0" -PropertyType "DWord" -Force | Out-Null    
+New-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Client" -name "DisabledByDefault" -value 1 -PropertyType "DWord" -Force | Out-Null
+```
+
+:::hint
+Once the version of TLS is set, reboot your Server and it should be available via `TLSv1.2`.
+:::
+
+#### Disable SSLv3, TLS 1.0 and 1.1 on Ubuntu Server  {#disable-insecure-tls-protocols-ubuntu}
+
+On Ubuntu `20.04` using OpenSSL `1.1.1f` (the latest at time of writing), you can specify the minimum TLS version to use to be `TLSv1.2` by setting the `MinProtocol` directive in the `/etc/ssl/openssl.cnf` OpenSSL config file:
+
+```bash
+[system_default_sect]
+MinProtocol = TLSv1.2
+```
+
+On Ubuntu `18.04`, if the `MinProtocol` directive doesn't work, you can try this alternative. When using OpenSSL `1.1.1` (the latest at time of writing), you can specify the available TLS Protocols explicitly in the `/etc/ssl/openssl.cnf` OpenSSL config file:
+
+```bash
+[system_default_sect]
+Protocol = -SSLv3, -TLSv1, -TLSv1.1, TLSv1.2
+```
+
+:::hint
+Once the version of TLS is set in your config, you'll want to restart any Tentacle service, and it should be available via `TLSv1.2`.
+:::
 
 ### Prevent user-provided scripts from doing harm
 

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -138,20 +138,20 @@ Add-MpPreference -ExclusionPath "C:\Octopus\Work\*"
 
 All communication between Octopus Server and Tentacles is performed over a secure ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)) connection. Both Server and Tentacle rely on the host OS for the available TLS version to use when establishing a secure TLS connection when communicating. 
 
-It's possible to disable older, less secure versions of SSL and TLS. This can be done on your Octopus Server as well as both [deployment targets](/docs/infrastructure/index.md) and any [workers](/docs/infrastructure/workers/index.md) you have.
+It's possible to disable older, weaker versions of SSL and TLS. This can be done on your Octopus Server as well as both [deployment targets](/docs/infrastructure/index.md) and any [workers](/docs/infrastructure/workers/index.md) you have.
 
 !include <security-disclaimer>
 
 #### Disable SSLv3, TLS 1.0 and 1.1 on Windows {#disable-weak-tls-protocols-windows}
 
-On Windows, the way to disable weak versions of SSL and TLS are by editing the registry.
+On Windows, the easiest way to disable weak versions of SSL and TLS are by using a tool like [IISCrypto](https://www.nartac.com/Products/IISCrypto) to change the Windows Registry. 
 
 :::problem
 **Take care editing registry entries**
 Editing the Windows registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always [backup any keys](https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692) before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
 :::
 
-The following example PowerShell script will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
+If you prefer, you can also script it too. This can be useful when automating installation of Servers. The following example PowerShell script will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
 
 ```powershell
 # SSLv3

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -148,7 +148,7 @@ On Windows, the way to disable insecure versions of SSL and TLS are by editing t
 
 :::problem
 **Take care editing registry entries**
-Editing the Windows registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always backup any keys before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
+Editing the Windows registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always [backup any keys](https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692) before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
 :::
 
 The following example PowerShell script will disable `SSLv3`, `TLSv1` and `TLSv1.1`:

--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -151,7 +151,7 @@ On Windows, the easiest way to disable weak versions of SSL and TLS are by using
 Editing the Windows registry can have serious implications. Please make sure you understand and are comfortable with the potential risks. Remember to always [backup any keys](https://support.microsoft.com/en-us/topic/how-to-back-up-and-restore-the-registry-in-windows-855140ad-e318-2a13-2829-d428a2ab0692) before they are modified. If you have any questions or need assistance, please [contact us](https://octopus.com/support).
 :::
 
-If you prefer, you can also script it too. This can be useful when automating installation of Servers. The following example PowerShell script will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
+If you prefer, you can also script it too. This can be useful when automating Server installation. The following example PowerShell script will disable `SSLv3`, `TLSv1` and `TLSv1.1`:
 
 ```powershell
 # SSLv3

--- a/docs/security/octopus-tentacle-communication/index.md
+++ b/docs/security/octopus-tentacle-communication/index.md
@@ -71,7 +71,7 @@ The TLS implementation uses the [.NET SslStream](https://docs.microsoft.com/en-u
 TLS 1.2 requires .NET 4.5 which was introduced as a requirement in **Octopus 3.1**. Earlier versions of Octopus use TLS 1.0.
 :::
 
-It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-insecure-tls-protocols) section.
+It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols) section.
 
 ## Troubleshooting Tentacle communication problems {#Octopus-Tentaclecommunication-TroubleshootingTentaclecommunicationproblems}
 

--- a/docs/security/octopus-tentacle-communication/index.md
+++ b/docs/security/octopus-tentacle-communication/index.md
@@ -71,7 +71,7 @@ The TLS implementation uses the [.NET SslStream](https://docs.microsoft.com/en-u
 TLS 1.2 requires .NET 4.5 which was introduced as a requirement in **Octopus 3.1**. Earlier versions of Octopus use TLS 1.0.
 :::
 
-It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols) section.
+To harden the TLS implementation used, review our documentation on [Disabling weak TLS protocols](/docs/security/hardening-octopus.md#disable-weak-tls-protocols).
 
 ## Troubleshooting Tentacle communication problems {#Octopus-Tentaclecommunication-TroubleshootingTentaclecommunicationproblems}
 

--- a/docs/security/octopus-tentacle-communication/index.md
+++ b/docs/security/octopus-tentacle-communication/index.md
@@ -63,11 +63,15 @@ Both Tentacle and Server expose a simple page on the listening port to web brows
 
 ### Transport Layer Security (TLS) implementation {#Octopus-Tentaclecommunication-TransportLayerSecurity(TLS)implementation}
 
-The TLS implementation uses the [SslStream](http://msdn.microsoft.com/en-us/library/system.net.security.sslstream(v=vs.110).aspx) class from the .NET Framework, and uses the best available of TLS 1.2, TLS 1.1 or TLS 1.0. Fallback to SSL is disallowed.
+Octopus Server and Tentacle rely on the host OS for the available TLS version to use when establishing a secure TLS connection when communicating. 
+
+The TLS implementation uses the [.NET SslStream](https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslstream) class, and uses the best available of TLS 1.2, TLS 1.1 or TLS 1.0. Fallback to SSL is disallowed. 
 
 :::hint
 TLS 1.2 requires .NET 4.5 which was introduced as a requirement in **Octopus 3.1**. Earlier versions of Octopus use TLS 1.0.
 :::
+
+It's possible to restrict the version of TLS available to use on both Tentacle and Server. For more information on how to do this, see our [Disabling insecure TLS protocols](/docs/security/hardening-octopus.md#disable-insecure-tls-protocols) section.
 
 ## Troubleshooting Tentacle communication problems {#Octopus-Tentaclecommunication-TroubleshootingTentaclecommunicationproblems}
 


### PR DESCRIPTION
We had a customer ask about disabling older TLS versions for tentacle, and I thought it'd be good to add this to the docs, under the security/hardening sections.

Since security isn't my forte, could someone confirm it looks ok? :stuck_out_tongue: 

Usual caveats around security have been added:

![image](https://user-images.githubusercontent.com/1418993/150777966-2ee27070-80fe-4b30-b1a6-742843006312.png)
