### PR TITLE
Add hyphen to project name slug

### DIFF
--- a/docs/projects/variables/variable-templates.md
+++ b/docs/projects/variables/variable-templates.md
@@ -14,7 +14,7 @@ There are two types of variable templates:
 - [Project templates](#project-templates) are variable values that differ between projects and environments for a tenant. For example, server names or database connection settings. 
 
 :::hint
-View a working example on our [samples instance](https://samples.octopus.app/app#/Spaces-682/projects/vetclinic/variables).
+View a working example on our [samples instance](https://samples.octopus.app/app#/Spaces-682/projects/vet-clinic/variables).
 :::
 
 ## Library variable set templates {#adding-a-variable-template}


### PR DESCRIPTION
Current link ends up here:
![image](https://user-images.githubusercontent.com/6306934/153253773-edfb4f92-9f1a-4022-9a52-385b4328e947.png)

Maybe the project name just got changed at some point to have a space.