### PR TITLE
API can't handle sending "bytes" data type.

### DIFF
--- a/docs/shared-content/scripts/create-certificate-scripts.include.md
+++ b/docs/shared-content/scripts/create-certificate-scripts.include.md
@@ -154,6 +154,7 @@ certificate_tenanted_deployment = 'Tenanted'
 
 certificate_data = open(certificate_file_path, 'rb').read()
 certificate_base64 = base64.b64encode(certificate_data)
+certificate_base64 = str(certificate_base64, 'utf-8')
 
 space = get_by_name('{0}/spaces/all'.format(octopus_server_uri), space_name)
 


### PR DESCRIPTION
Issue with Create Certificate Python script; adding step to convert BASE-64 certificate data from 'byte' type to utf-8 string.