### PR TITLE
Dynamic Workers: add kubectl 1.21.9 and 1.22.6 for Win2019

### DIFF
--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -117,6 +117,8 @@ A specific version can be used by [specifying a custom kubectl location](/docs/d
 - `1.18.0`
 - `1.19.9`
 - `1.20.5`
+- `1.21.9`
+- `1.22.6`
 
 ## Installing Software On Dynamic Workers
 


### PR DESCRIPTION
This MUST NOT go out before the images have gone live (versions to come).