### PR TITLE
consider removing reference to HA Kerberos as it's not supported

### DIFF
--- a/docs/security/authentication/active-directory/index.md
+++ b/docs/security/authentication/active-directory/index.md
@@ -23,7 +23,7 @@ If you are using Active Directory Authentication with Octopus, there are two way
 ## Authentication Schemes
 By default, Active Directory Authentication will use NTLM as the Authentication Scheme. In many circumstances, you can also configure Octopus to use Kerberos for authentication.
 
-If you would like to use Kerberos for authentication, you should consider if you require User Mode authentication. User Mode is required for Kerberos authentication when Octopus is in a [High Availability](/docs/administration/high-availability/index.md) configuration. By default, Kerberos authentication for Octopus Deploy runs in Kernel Mode. The mode is dictated by the web server running Octopus Deploy, which can be configured using the `configure` command. Select HTTP.sys for Kernel Mode, or Kestrel for User Mode:
+If you would like to use Kerberos for authentication, you should consider if you require User Mode authentication. By default, Kerberos authentication for Octopus Deploy runs in Kernel Mode. The mode is dictated by the web server running Octopus Deploy, which can be configured using the `configure` command. Select HTTP.sys for Kernel Mode, or Kestrel for User Mode:
 
 **Kernel Mode authentication via HTTP.sys (default) - Command Line** {#ActiveDirectoryAuthentication-KernelModeAuthentication}\
 Select this mode if you require features of HTTP.sys, such as port sharing.


### PR DESCRIPTION
Docs have note:
If you are running a HA Octopus Deploy environment, Kerberos authentication is not currently supported.

https://octopus.com/docs/security/authentication/active-directory#ActiveDirectoryAuthentication-ConfiguringKerberos

@harrisonmeister 