### PR TITLE
Adding warning about firewall rules.

### DIFF
--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -87,6 +87,10 @@ Many instances of Tentacle can be configured on a single machine. To configure a
 
 Additional instances of Tentacle can be created and configured by passing the `--instance $instanceName` argument to all of the commands listed here.
 
+:::warning
+The installer script does not make any adjustments to firewalls, be sure to check the port specified is open for listening tentacles.
+:::
+
 ## Running Tentacle
 
 ### Running Tentacle interactively

--- a/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -88,7 +88,7 @@ Many instances of Tentacle can be configured on a single machine. To configure a
 Additional instances of Tentacle can be created and configured by passing the `--instance $instanceName` argument to all of the commands listed here.
 
 :::warning
-The installer script does not make any adjustments to firewalls, be sure to check the port specified is open for listening tentacles.
+The installer script does not make any adjustments to firewalls. Be sure to check any ports specified are open on your firewalls. For example port `10933` for listening tentacles.
 :::
 
 ## Running Tentacle


### PR DESCRIPTION
Our Windows installer has a checkbox that will automatically add a firewall rule as part of the Tentacle installation, our Linux script does not (with so many distros, I understand why).  I've added a warning callout so it's readily apparent that they may need to adjust firewall rules.