### PR TITLE
Remove Fargate requirement for ECS Update Service step

### DIFF
--- a/docs/deployments/aws/ecs-update-service/index.md
+++ b/docs/deployments/aws/ecs-update-service/index.md
@@ -7,7 +7,7 @@ Octopus supports deploying a new release to an existing ECS Service through the 
 This step provides an opinionated deployment workflow that allows new released to be deployed to an ECS Cluster that is managed externally, for example manually or via Terraform.
 
 :::hint
-The `Update Amazon ECS Step` was added in Octopus **2021.3**. Presently only **Fargate** clusters are supported.
+The `Update Amazon ECS Step` was added in Octopus **2021.3**.
 :::
 
 At a high level, the `Update Amazon ECS Service` step will:
@@ -22,7 +22,7 @@ The following instructions can be followed to configure the `Update Amazon ECS S
 ## Step 1: Make a note of your ECS cluster's settings
 
 :::hint
-Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html) for detailed instructions on how to provision a new ECS cluster. When presented with the `Select cluster compatibility` screen select the `Networking only` option, this will automatically associate your cluster with the `FARGATE` capacity provider.
+Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html) for detailed instructions on how to provision a new ECS cluster.
 :::
 
 The following settings will need to be configured:

--- a/docs/deployments/aws/ecs/index.md
+++ b/docs/deployments/aws/ecs/index.md
@@ -6,7 +6,7 @@ description: Deploy a service to an Amazon ECS cluster.
 Octopus supports deployments to ECS clusters through the `Deploy Amazon ECS Service` step. This step provides an opinionated deployment workflow that combines a Fargate task definition and service into a single step.
 
 :::hint
-The `Deploy Amazon ECS Service` step was added in Octopus **2021.3**. Presently only **Fargate** clusters are supported.
+The `Deploy Amazon ECS Service` step was added in Octopus **2021.3**.
 :::
 
 At a high level, the `Deploy Amazon ECS Service` step will:
@@ -23,7 +23,7 @@ The followed instructions can be used to configure the `Deploy Amazon ECS Servic
 ## Step 1: Make a note of your ECS cluster's settings
 
 :::hint
-Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html) for detailed instructions on how to provision a new ECS cluster. When presented with the `Select cluster compatibility` screen select the `Networking only` option, this will automatically associate your cluster with the `FARGATE` capacity provider.
+Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html) for detailed instructions on how to provision a new ECS cluster.
 :::
 
 Configuring an ECS service for the first time can be quite intimidating due to a large number of available options. Fortunately, most of them are optional. At a minimum the following settings will need to be configured:

--- a/docs/deployments/aws/ecs/index.md
+++ b/docs/deployments/aws/ecs/index.md
@@ -6,7 +6,7 @@ description: Deploy a service to an Amazon ECS cluster.
 Octopus supports deployments to ECS clusters through the `Deploy Amazon ECS Service` step. This step provides an opinionated deployment workflow that combines a Fargate task definition and service into a single step.
 
 :::hint
-The `Deploy Amazon ECS Service` step was added in Octopus **2021.3**.
+The `Deploy Amazon ECS Service` step was added in Octopus **2021.3**. Presently only **Fargate** clusters are supported.
 :::
 
 At a high level, the `Deploy Amazon ECS Service` step will:
@@ -23,7 +23,7 @@ The followed instructions can be used to configure the `Deploy Amazon ECS Servic
 ## Step 1: Make a note of your ECS cluster's settings
 
 :::hint
-Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html) for detailed instructions on how to provision a new ECS cluster.
+Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create_cluster.html) for detailed instructions on how to provision a new ECS cluster. When presented with the `Select cluster compatibility` screen select the `Networking only` option, this will automatically associate your cluster with the `FARGATE` capacity provider.
 :::
 
 Configuring an ECS service for the first time can be quite intimidating due to a large number of available options. Fortunately, most of them are optional. At a minimum the following settings will need to be configured:


### PR DESCRIPTION
The Update Amazon ECS Service step works on EC2-backed instances. This removes the documentation directing users that only Fargate clusters are supported.