### PR TITLE
Adding cached worker-tools information

### DIFF
--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -130,7 +130,17 @@ For deployments and runbook runs that require additional software dependencies o
 
 :::hint
 **Octopus worker-tools cached on Dynamic Workers**
-The `octopusdeploy/worker-tools` images provided for the execution containers feature have the most recent version cached on a Dynamic Worker when its created. This makes them a great choice over installing additional software on a Dynamic worker.
+The `octopusdeploy/worker-tools` images provided for the execution containers feature have the most recent version cached on a Dynamic Worker when its created. This makes them a great choice over installing additional software on a Dynamic worker.  
+
+
+**Cached worker-tools**
+
+- [Latest Windows-based image:](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019/Dockerfile) `octopusdeploy/worker-tools:3.3.2-windows.ltsc2019`
+
+- [Latest Linux-based image:](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04/Dockerfile) `octopusdeploy/worker-tools:3.3.2-ubuntu.18.04`
+
+Using older non-cached versions of these worker-tools can result in long downloads.
+
 :::
 
 If you choose to install additional software on a dynamic worker, you are responsible for:


### PR DESCRIPTION
This is a part of #deploy-fnm's worker-tools work. In the future we're looking to automate updating this documentation with the latest worker-tools that have been pushed to dynamic workers. 