### PR TITLE
Use $instance to define file paths

### DIFF
--- a/docs/administration/managing-infrastructure/moving-your-octopus/move-the-octopus-home-folder-and-the-tentacle-home-and-application-folders.md
+++ b/docs/administration/managing-infrastructure/moving-your-octopus/move-the-octopus-home-folder-and-the-tentacle-home-and-application-folders.md
@@ -55,8 +55,8 @@ N.B. The delete-instance command will not actually delete any files, just the Re
 ```powershell
 ##Config##
 $instance = "InstanceName" #Name of the instance.
-$oldHome = "C:\Octopus\InstanceName" #Current home of the instance.
-$newHome = "C:\NewHome\InstanceName" #New home path for the instance.
+$oldHome = "C:\Octopus\$instance" #Current home of the instance.
+$newHome = "C:\NewHome\$instance" #New home path for the instance.
 $appFolder = "Applications" #Name of the folder being used for applications.
 
 ##Process##


### PR DESCRIPTION
When moving a tentacle the script wasn't using the $instance variable defined in the config section, so the folder path ended up being hard coded to "InstanceName" instead of the value that was defined in the instance name. This change updates the script so that it will use $instance in the folder paths for $oldHome and $newHome