### PR TITLE
Fix Octopus.Client installation for PowerShell on Windows 2016

### DIFF
--- a/docs/octopus-rest-api/octopus.client/getting-started.md
+++ b/docs/octopus-rest-api/octopus.client/getting-started.md
@@ -72,12 +72,7 @@ await client.Repository.Users.SignIn(new LoginCommand { Username = "me", Passwor
 ### Package installation
 
 To get started with the Octopus Client library from PowerShell, use the `Install-Package` command from the Microsoft [PackageManagement](https://docs.microsoft.com/en-us/powershell/module/packagemanagement) module:
-```powershell PowerShell
-Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies
-$path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"
-Add-Type -Path $path
-```
-```powershell PowerShell on Windows 2016
+```powershell Windows PowerShell
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies
 $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"
@@ -89,7 +84,7 @@ $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.Ful
 Add-Type -Path $path
 ```
 :::hint
-Note that for the `PowerShell Core` example above, the path needs to be slightly different than the one for `PowerShell`.
+Note: The `PowerShell Core` example above needs the path to be slightly different than the one for `Windows PowerShell`.
 :::
 
 If you're referencing an older version of the .NET Standard version of Octopus.Client, you may find you also need to add a reference to `NewtonSoft.Json.dll` and `Octodiff`:

--- a/docs/octopus-rest-api/octopus.client/getting-started.md
+++ b/docs/octopus-rest-api/octopus.client/getting-started.md
@@ -77,6 +77,12 @@ Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDepende
 $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"
 Add-Type -Path $path
 ```
+```powershell PowerShell on Windows 2016
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies
+$path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/net452/Octopus.Client.dll"
+Add-Type -Path $path
+```
 ```powershell PowerShell Core
 Install-Package Octopus.Client -source https://www.nuget.org/api/v2 -SkipDependencies
 $path = Join-Path (Get-Item ((Get-Package Octopus.Client).source)).Directory.FullName "lib/netstandard2.0/Octopus.Client.dll"


### PR DESCRIPTION
When trying to install Octopus.Client for PowerShell on Windows 2016 the exception below is thrown.

This happens because Microsoft dropped support for TLS 1.1 on their host. I added this step to set TLS 1.2 for the session which fix the issue.

https://stackoverflow.com/questions/55826791/powershell-installing-nuget-says-unable-to-access-internet-but-i-actually-can
https://rnelson0.com/2018/05/17/powershell-in-a-post-tls1-1-world/

```
WARNING: MSG:UnableToDownload «https://go.microsoft.com/fwlink/?LinkID=627338&clcid=0x409» «»
WARNING: Unable to download the list of available providers. Check your internet connection.
Install-Package : Unable to find package source 'https://www.nuget.org/api/v2'. Use Get-PackageSource to see all available package sources.
At C:\Users\kindwhale77\Desktop\test - Copy.ps1:4 char:1
+ Install-Package Octopus.Client -source https://www.nuget.org/api/v2 - ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (Microsoft.Power....InstallPackage:InstallPackage) [Install-Package], Exception
    + FullyQualifiedErrorId : SourceNotFound,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
```