### PR TITLE
Add Private Space doc

### DIFF
--- a/docs/administration/spaces/private-space.md
+++ b/docs/administration/spaces/private-space.md
@@ -5,7 +5,7 @@ position: 30
 version: 2022.2
 ---
 
-As the name suggests, a Private Space is just like a normal [Space](./index.md), except it’s just for you. No one else on your team will be able to view or edit any projects in your private space. It allows users a safe environment to learn basic Octopus concepts. It’s also a great place to experiment with workflows that aren’t ready to be shared with the rest of your company.
+As the name suggests, a Private Space is just like a normal [Space](/docs/administration/spaces/index.md), except it’s just for you. No one else on your team will be able to view or edit any projects in your private space. It allows users a safe environment to learn basic Octopus concepts. It’s also a great place to experiment with workflows that aren’t ready to be shared with the rest of your company.
 
 Each Private Space will soon be populated with a sample project to provide an example of a real-world Octopus setup.
 

--- a/docs/administration/spaces/private-space.md
+++ b/docs/administration/spaces/private-space.md
@@ -1,0 +1,15 @@
+---
+title: Private Space
+description: Information on Private Spaces
+position: 30
+version: 2022.2
+---
+
+As the name suggests, a Private Space is just like a normal [Space](./index.md), except it’s just for you. No one else on your team will be able to view or edit any projects in your private space. It allows users a safe environment to learn basic Octopus concepts. It’s also a great place to experiment with workflows that aren’t ready to be shared with the rest of your company.
+
+Each Private Space will soon be populated with a sample project to provide an example of a real-world Octopus setup.
+
+Note:
+
+1. Deployment targets created in your private space will be counted against your company’s license limits.
+2. Once you’ve got a project working just right, it can be [exported](/docs/projects/export-import/index.md) to a shared space, where the rest of the company can collaborate as normal.

--- a/docs/administration/spaces/private-space.md
+++ b/docs/administration/spaces/private-space.md
@@ -1,3 +1,9 @@
+---
+title: Private Space
+description: Information on Private Spaces
+position: 30
+---
+
 :::hint
 Private spaces were added in **Octopus 2022.2**.
 :::

--- a/docs/administration/spaces/private-space.md
+++ b/docs/administration/spaces/private-space.md
@@ -1,9 +1,6 @@
----
-title: Private Space
-description: Information on Private Spaces
-position: 30
-version: 2022.2
----
+:::hint
+Private spaces were added in **Octopus 2022.2**.
+:::
 
 As the name suggests, a Private Space is just like a normal [Space](/docs/administration/spaces/index.md), except it’s just for you. No one else on your team will be able to view or edit any projects in your private space. It allows users a safe environment to learn basic Octopus concepts. It’s also a great place to experiment with workflows that aren’t ready to be shared with the rest of your company.
 


### PR DESCRIPTION
#team-user-onboarding has been working on adding a feature called Private Space, which is now ready to ship. We'd like to include a link in the help sidebar to the docs (a "Learn more" link would appear here under "and learn Octopus"):
<img width="449" alt="image" src="https://user-images.githubusercontent.com/5858312/168208803-59190415-f7e1-4af2-9119-52f29e20d09f.png">

In private-space.md, can you let me know if the relative link to the page on Spaces is correct? Should it be absolute instead (`/docs/administration/spaces/index.md`)?