### PR TITLE
Update cached worker tools docs

### DIFF
--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -130,14 +130,18 @@ For deployments and runbook runs that require additional software dependencies o
 
 :::hint
 **Octopus worker-tools cached on Dynamic Workers**
-The `octopusdeploy/worker-tools` images provided for the execution containers feature have the most recent version cached on a Dynamic Worker when its created. This makes them a great choice over installing additional software on a Dynamic worker.
+The `octopusdeploy/worker-tools` images provided for the execution containers feature have a range of version cached on a Dynamic Worker when its created. This makes them a great choice over installing additional software on a Dynamic worker.
 
-
-The following worker-tools images are cached:
-
+The following latest worker-tools images are cached and recommended for usage:
 - [Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019): `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>`
 
 - [Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04): `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>`
+
+Additionally we cache a set of ad-hoc versions of worker tools, selected for a combination of their usage rates and release date. These older versions will be removed from dynamic workers as newer versions are added.
+- `!docker-image <octopusdeploy/worker-tools:3.3.1-ubuntu.18.04>`
+- `!docker-image <octopusdeploy/worker-tools:3.2.1-ubuntu.18.04>`
+- `!docker-image <octopusdeploy/worker-tools:3.2.0-ubuntu.18.04>`
+- `!docker-image <octopusdeploy/worker-tools:3.0.0-ubuntu.18.04>`
 
 Using older non-cached versions of these worker-tools can result in long downloads.
 


### PR DESCRIPTION
### -- Draft -- Waiting for review/input from others.

Updates to reflect changes in cached Worker Tools for dynamic workers. Requires https://github.com/OctopusDeploy/DynamicWorkerVmImages/pull/71 to merge first