### PR TITLE
Add cached worker tools versions

### DIFF
--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -138,7 +138,7 @@ The following worker-tools images are cached:
 **On Linux Workers**:
 
 - [Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04): `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>`
-- octopusdeploy/worker-tools:3.3.1-ubuntu.18.04
+- `!docker-image <octopusdeploy/worker-tools:3.3.1-ubuntu.18.04>`
 - octopusdeploy/worker-tools:3.2.1-ubuntu.18.04
 - octopusdeploy/worker-tools:3.2.0-ubuntu.18.04
 - octopusdeploy/worker-tools:3.0.0-ubuntu.18.04

--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -137,15 +137,15 @@ The following worker-tools images are cached:
 
 **On Linux Workers**:
 
-- [Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04): `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>`
+- `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>` ([Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04))
 - `!docker-image <octopusdeploy/worker-tools:3.3.1-ubuntu.18.04>`
-- octopusdeploy/worker-tools:3.2.1-ubuntu.18.04
-- octopusdeploy/worker-tools:3.2.0-ubuntu.18.04
-- octopusdeploy/worker-tools:3.0.0-ubuntu.18.04
+- `!docker-image <octopusdeploy/worker-tools:3.2.1-ubuntu.18.04>`
+- `!docker-image <octopusdeploy/worker-tools:3.2.0-ubuntu.18.04>`
+- `!docker-image <octopusdeploy/worker-tools:3.0.0-ubuntu.18.04>`
 
 **On Windows Workers**:
 
-- [Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019): `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>`
+- `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>` ([Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019))
 
 Using non-cached versions of these worker-tools can result in long downloads.
 

--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -130,7 +130,7 @@ For deployments and runbook runs that require additional software dependencies o
 
 :::hint
 **Octopus worker-tools cached on Dynamic Workers**
-The `octopusdeploy/worker-tools` images provided for the execution containers feature have the most recent version cached on a Dynamic Worker when its created. This makes them a great choice over installing additional software on a Dynamic worker.
+The `octopusdeploy/worker-tools` images provided for the execution containers feature have the most commonly used versions (including the newest) cached on a Dynamic Worker when it's created. This makes them a great choice over installing additional software on a Dynamic worker.
 
 
 The following worker-tools images are cached:
@@ -146,7 +146,6 @@ The following worker-tools images are cached:
 **On Windows Workers**:
 
 - [Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019): `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>`
-- octopusdeploy/worker-tools:3.3.1-windows.ltsc2019
 
 Using non-cached versions of these worker-tools can result in long downloads.
 

--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -135,11 +135,20 @@ The `octopusdeploy/worker-tools` images provided for the execution containers fe
 
 The following worker-tools images are cached:
 
-- [Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019): `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>`
+**On Linux Workers**:
 
 - [Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04): `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>`
+- octopusdeploy/worker-tools:3.3.1-ubuntu.18.04
+- octopusdeploy/worker-tools:3.2.1-ubuntu.18.04
+- octopusdeploy/worker-tools:3.2.0-ubuntu.18.04
+- octopusdeploy/worker-tools:3.0.0-ubuntu.18.04
 
-Using older non-cached versions of these worker-tools can result in long downloads.
+**On Windows Workers**:
+
+- [Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019): `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>`
+- octopusdeploy/worker-tools:3.3.1-windows.ltsc2019
+
+Using non-cached versions of these worker-tools can result in long downloads.
 
 :::
 


### PR DESCRIPTION
Add more cached versions of worker tools images.
<img width="951" alt="Screen Shot 2022-05-24 at 3 42 49 PM" src="https://user-images.githubusercontent.com/97418140/169944492-d798fd41-1894-4b92-86e8-b13cd65fc562.png">


