### PR TITLE
Add list of roles required by service account to use integration

### DIFF
--- a/docs/approvals/service-now/index.md
+++ b/docs/approvals/service-now/index.md
@@ -42,10 +42,13 @@ The Octopus Deploy / ServiceNow integration requires security configuration in y
 
 Follow the [ServiceNow OAuth documentation](https://docs.servicenow.com/bundle/sandiego-platform-administration/page/administer/security/task/t_SettingUpOAuth.html) to configure an OAuth endpoint for Octopus to use for authentication. Take note of the OAuth client id and client secret from the configuration.
 
-Next, the integration will require a user account on ServiceNow. The recommendation is to ser account specifically for Octopus.
-To create a new ServiceNow user, follow the [ServiceNow user documentation](https://docs.servicenow.com/en-US/bundle/sandiego-platform-administration/page/administer/users-and-groups/task/t_CreateAUser.html). 
+Next, the integration will require a user account in ServiceNow. The recommendation is to create a service account specifically for Octopus, once created the user must be assigned the following two roles:
 
-Ensure that the new user has `Web service access only` checked. 
+- `sn_change_read`
+- `sn_change_write`
+
+Ensure that the new user has the `Web service access only` checkbox checked.
+
 Take note of the password assigned or generated for this user.
 
 ### Licensing


### PR DESCRIPTION
Update the "Configure ServiceNow" section to include the roles required by the service account to use the integration.

Minor text and formatting changes included

See story [sc-6150](https://app.shortcut.com/octopusdeploy/story/6150/documentation-is-not-clear-about-which-servicenow-role-to-assign)

## Before

![image](https://user-images.githubusercontent.com/89003774/174940171-7d361162-5d52-47ce-8917-1506b262f1a0.png)

## After

![image](https://user-images.githubusercontent.com/89003774/174940932-7a960261-048a-4a93-b8c6-8058ea429b76.png)
