### PR TITLE
Explain that Private Space is a cloud-only feature

### DIFF
--- a/docs/administration/spaces/private-space.md
+++ b/docs/administration/spaces/private-space.md
@@ -5,7 +5,7 @@ position: 30
 ---
 
 :::hint
-Private spaces were added in **Octopus 2022.2** as a Cloud-only feature. The feature is not currently available for on-premises instances.
+Private spaces were added in **Octopus 2022.2** as a Cloud-only feature. The feature is not currently available for self-hosted instances.
 :::
 
 As the name suggests, a Private Space is just like a normal [Space](/docs/administration/spaces/index.md), except it’s just for you. No one else on your team will be able to view or edit any projects in your private space. It allows users a safe environment to learn basic Octopus concepts. It’s also a great place to experiment with workflows that aren’t ready to be shared with the rest of your company.

--- a/docs/administration/spaces/private-space.md
+++ b/docs/administration/spaces/private-space.md
@@ -5,7 +5,7 @@ position: 30
 ---
 
 :::hint
-Private spaces were added in **Octopus 2022.2**.
+Private spaces were added in **Octopus 2022.2** as a Cloud-only feature. The feature is not currently available for on-premises instances.
 :::
 
 As the name suggests, a Private Space is just like a normal [Space](/docs/administration/spaces/index.md), except it’s just for you. No one else on your team will be able to view or edit any projects in your private space. It allows users a safe environment to learn basic Octopus concepts. It’s also a great place to experiment with workflows that aren’t ready to be shared with the rest of your company.


### PR DESCRIPTION
The Private Space feature has caused a bit of confusion with users that were expecting it to be available for on-premises installations. Adding this note should help them understand that they'd have to switch to Cloud if they want to use the feature.