### PR TITLE
Update to powershell script for publishing runbooks

### DIFF
--- a/docs/shared-content/scripts/create-and-publish-runbook-scripts.include.md
+++ b/docs/shared-content/scripts/create-and-publish-runbook-scripts.include.md
@@ -36,18 +36,16 @@ $body = @{
 # Include latest built-in feed packages
 foreach($package in $runbookSnapshotTemplate.Packages)
 {
-    if($package.FeedId -eq "feeds-builtin") {
-        # Get latest package version
-        $packages = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/feeds/feeds-builtin/packages/versions?packageId=$($package.PackageId)&take=1" -Headers $header 
-        $latestPackage = $packages.Items | Select-Object -First 1
-        $package = @{
-            ActionName = $package.ActionName
-            Version = $latestPackage.Version
-            PackageReferenceName = $package.PackageReferenceName
-        }
-        
-        $body.SelectedPackages += $package
+    # Get latest package version
+    $packages = Invoke-RestMethod -Uri "$octopusURL/api/$($space.Id)/feeds/$($package.FeedId)/packages/versions?packageId=$($package.PackageId)" -Headers $header 
+    $latestPackage = $packages.Items | Select-Object -First 1
+    $package = @{
+        ActionName = $package.ActionName
+        Version = $latestPackage.Version
+        PackageReferenceName = $package.PackageReferenceName
     }
+    
+    $body.SelectedPackages += $package
 }
 
 $body = $body | ConvertTo-Json -Depth 10


### PR DESCRIPTION
The powershell script for [Create and publish new runbook snapshot](https://octopus.com/docs/octopus-rest-api/examples/runbooks/create-and-publish-runbook) looks to be using an outdated endpoint. This PR brings the powershell script in line with the other examples from the page.