### PR TITLE
Add ITSM change management metrics to "Telemetry"

### DIFF
--- a/docs/security/outbound-requests/telemetry.md
+++ b/docs/security/outbound-requests/telemetry.md
@@ -47,6 +47,7 @@ In addition, we'll send some specific aggregate criteria along with the request.
 | Structured Configuration Variable usage across projects including how many steps have Structured Configuration Variables enabled and what file extensions are being used | 2020.4.0 |
 | OS Architecture of Deployment Target Tentacles | 2021.1.0 |
 | The number of Projects that are version controlled | 2021.2.0 |
+| Aggregated data about the number and type of change managed deployments | 2022.2.0 |
 
 The installation ID is a GUID that we generate when Octopus is installed. This GUID is simply a way for us to get a rough idea of the number of installations there are in the wild, and which versions people are using, so we can make decisions about backwards compatibility support.
 


### PR DESCRIPTION
Update telemetry document to include details about ITSM change request metrics.


See story [sc-6309](https://app.shortcut.com/octopusdeploy/story/6309/add-documentation-to-the-telemetry-page-that-we-are-collecting-change-management-metrics)

## Before

![image](https://user-images.githubusercontent.com/89003774/176819282-bde02b51-f2a4-4146-a69e-4a1b55c75c6b.png)


## After

![image](https://user-images.githubusercontent.com/89003774/176819220-3ea16052-cf33-4155-bf22-5708b92e16bf.png)
