### PR TITLE
Mention behavioural telemetry as an outbound requests in security section

### DIFF
--- a/docs/security/outbound-requests/index.md
+++ b/docs/security/outbound-requests/index.md
@@ -27,6 +27,7 @@ The Octopus Server makes the following outbound requests:
 4. Checking for updates (if enabled).
 5. Checking for updated [built-in step templates](/docs/projects/built-in-step-templates/index.md) (if enabled).
 6. Checking for updated [community contributed step templates](/docs/projects/community-step-templates.md) (if enabled).
+7. Behavioural telemetry is sent to https://telemetry.octopus.com (if enabled).
 
 ### Built-in step templates
 

--- a/docs/security/outbound-requests/index.md
+++ b/docs/security/outbound-requests/index.md
@@ -27,7 +27,7 @@ The Octopus Server makes the following outbound requests:
 4. Checking for updates (if enabled).
 5. Checking for updated [built-in step templates](/docs/projects/built-in-step-templates/index.md) (if enabled).
 6. Checking for updated [community contributed step templates](/docs/projects/community-step-templates.md) (if enabled).
-7. Behavioural telemetry is sent to https://telemetry.octopus.com (if enabled).
+7. Behavioral telemetry is sent to https://telemetry.octopus.com (if enabled).
 
 ### Built-in step templates
 


### PR DESCRIPTION
We recently updated our amplitude integration to also function for on-prem customers when telemetry has been enabled. As such, behavioural telemetry requests will make its way to `https://telemetry.octopus.com`, which there was no mention of in the docs. This PR simply rectifies this.