### PR TITLE
Clarify treatment of ampersands in XML Files processed by Structured Variable Replacement

### DIFF
--- a/docs/shared-content/structured-configuration-variables.include.md
+++ b/docs/shared-content/structured-configuration-variables.include.md
@@ -301,16 +301,16 @@ Octopus variables with names that are valid XPath expressions are matched agains
 
 When replacing content, the replacement can only be as rich as what was originally there. If you select an element that contains only text, the replacement will be treated as text and structure-defining characters will be encoded as entity references. However, if you select an element that contains further element structures, the replacement is treated as an XML fragment, and structure-defining characters will be added as is.
 
-This means that if you replace a password or connection string, any characters like `<` and `>` will be safely encoded within the string. For example, assume the target file contains the following:
+This means that if you replace a password or connection string, any characters like `&`, `<` and `>` will be safely encoded within the string (as required by the [XML Specification](https://www.w3.org/TR/2008/REC-xml-20081126/)). For example, assume the target file contains the following:
 
 ```xml
 <connectionString>Server=.;Database=db;User Id=admin;Password=password;</connectionString>
 ```
 
-If you define a variable called `//connectionString` with the value `Server=.;Database=db;User Id=admin;Password=Pass<word>1;` the structure will be updated as follows:
+If you define a variable called `//connectionString` with the value `Server=.;Database=db;User Id=admin&boss;Password=Pass<word>1;` the structure will be updated as follows:
 
 ```xml
-<connectionString>Server=.;Database=db;User Id=admin;Password=Pass&lt;word&gt;1;</connectionString>
+<connectionString>Server=.;Database=db;User Id=admin&amp;boss;Password=Pass&lt;word&gt;1;</connectionString>
 ```
 
 It's worth noting that an empty element, such as `<rules />`, contains no element structures and will only be filled with text. For example, assume the target file contains the following:


### PR DESCRIPTION
* Explicitly add ampersand (`&`) as a character required to be escaped when replacing text elements in XML documents
* Add reference to the spec for clarity that this is required, not just something we chose to do

This fixes OctopusDeploy/Issues#5907