### PR TITLE
Additions to ECS docs

### DIFF
--- a/docs/deployments/aws/ecs-update-service/index.md
+++ b/docs/deployments/aws/ecs-update-service/index.md
@@ -6,6 +6,8 @@ description: Update an existing Amazon ECS Service.
 Octopus supports deploying a new release to an existing ECS Service through the `Update Amazon ECS Service` step.
 This step provides an opinionated deployment workflow that allows new released to be deployed to an ECS Cluster that is managed externally, for example manually or via Terraform.
 
+Choose this step if you have an existing ECS cluster, service, and task definition, and want Octopus to update your task definition for you during deployments.  
+
 :::hint
 The `Update Amazon ECS Step` was added in Octopus **2021.3**.
 :::

--- a/docs/deployments/aws/ecs/index.md
+++ b/docs/deployments/aws/ecs/index.md
@@ -19,7 +19,7 @@ At a high level, the `Deploy Amazon ECS Service` step will:
     * A service that references the task definition.
 * Perform variable substitution on the CloudFormation template.
 * Deploy a CloudFormation stack with the template.
-* In subsequent deployments, update the deployed CloudFormation stack with an updated task definition
+* In subsequent deployments, update the deployed CloudFormation stack with an updated task definition.
 
 The followed instructions can be used to configure the `Deploy Amazon ECS Service` step. We have chosen not to document some fields here as they map directly to ECS settings and are well documented in the AWS documentation (a link to the relevant documentation section is typically provided in each fields' notes in the Octopus UI). 
 

--- a/docs/deployments/aws/ecs/index.md
+++ b/docs/deployments/aws/ecs/index.md
@@ -5,6 +5,8 @@ description: Deploy a service to an Amazon ECS cluster.
 
 Octopus supports deployments to ECS clusters through the `Deploy Amazon ECS Service` step. This step provides an opinionated deployment workflow that combines a Fargate task definition and service into a single step.
 
+Choose this step if you have an ECS cluster, and want Octopus to create and manage your service and task definition for you.  
+
 :::hint
 The `Deploy Amazon ECS Service` step was added in Octopus **2021.3**. Presently only **Fargate** clusters are supported.
 :::
@@ -17,6 +19,7 @@ At a high level, the `Deploy Amazon ECS Service` step will:
     * A service that references the task definition.
 * Perform variable substitution on the CloudFormation template.
 * Deploy a CloudFormation stack with the template.
+* In subsequent deployments, update the deployed CloudFormation stack with an updated task definition
 
 The followed instructions can be used to configure the `Deploy Amazon ECS Service` step. We have chosen not to document some fields here as they map directly to ECS settings and are well documented in the AWS documentation (a link to the relevant documentation section is typically provided in each fields' notes in the Octopus UI). 
 


### PR DESCRIPTION
Adds some more information to help users choose between the "deploy an ECS service" step and the "update an ECS service" step.

Context: https://octopusdeploy.slack.com/archives/C27FNL3QW/p1657783176320749