### PR TITLE
Specify Tentacle compatibility for 2022.2

### DIFF
--- a/docs/support/compatibility.md
+++ b/docs/support/compatibility.md
@@ -4,6 +4,8 @@ description: Backward compatibility between Octopus Server and related component
 position: 190
 ---
 
+## Octopus Server compatibility
+
 The table below outlines the backward compatibility between Octopus Server and related components
 
 | Octopus Server    | Octopus.Client & Octopus CLI (octo) | Calamari         | Tentacle      | TeamCity Plugin  |
@@ -17,7 +19,7 @@ The table below outlines the backward compatibility between Octopus Server and r
 | 2019.2* ➜ 2022.1 | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
 | 2022.2** ➜ latest | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 6.2 ➜ latest | 5.0 ➜ latest    |
 
-**&ast; Partial forwards compatibility**
+### **&ast; Partial forwards compatibility**
 
 Older versions of some libraries and plugins _may_ work with **2019.1** and higher _only if_ the [default space](https://oc.to/default-space) is enabled and such integrations are only used against that space. To make use of other spaces, please upgrade.
 
@@ -29,7 +31,7 @@ The table below outlines partially forwards compatible scenarios between Octopus
 | --------------    | ----------------------------------- | --------     | --------    | --------------- |
 | 2019.1  ➜ latest | 4.30.7 ➜ 4.47.0                    | 3.5 ➜ 4.12.0 | 3.0 ➜ 3.25 | 3.3 ➜ latest   |
 
-**&ast;&ast; Partial forwards compatibility with older Tentacles**
+### **&ast;&ast; Partial forwards compatibility with older Tentacles**
 
 Versions of Tentacle older than **6.2** will still work with Octopus **2022.2** and higher. However, you may experience longer wait times when running tasks. We recommend upgrading all Tentacles to ensure your deployments run at optimum performance. 
 

--- a/docs/support/compatibility.md
+++ b/docs/support/compatibility.md
@@ -14,9 +14,10 @@ The table below outlines the backward compatibility between Octopus Server and r
 | 3.5 ➜ 2018.2     | 3.3 ➜ 4.30.3                       | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 2018.2 ➜ 2018.12 | 4.30.7 ➜ 4.47.0                    | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 2019.1*           | 5.0.0 ➜ 5.2.7                      | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
-| 2019.2* ➜ latest | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
+| 2019.2* ➜ 2022.1 | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
+| 2022.2** ➜ latest | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 6.2 ➜ latest | 5.0 ➜ latest    |
 
-## &ast; Partial forwards compatibility
+### &ast; Partial forwards compatibility
 
 Older versions of some libraries and plugins _may_ work with **2019.1** and higher _only if_ the [default space](https://oc.to/default-space) is enabled and such integrations are only used against that space. To make use of other spaces, please upgrade.
 
@@ -27,6 +28,10 @@ The table below outlines partially forwards compatible scenarios between Octopus
 | Octopus Server    | Octopus.Client & Octopus CLI (octo) | Calamari     | Tentacle    | TeamCity Plugin |
 | --------------    | ----------------------------------- | --------     | --------    | --------------- |
 | 2019.1  ➜ latest | 4.30.7 ➜ 4.47.0                    | 3.5 ➜ 4.12.0 | 3.0 ➜ 3.25 | 3.3 ➜ latest   |
+
+### &ast;&ast; Partial forwards compatibility with older Tentacles
+
+Versions of Tentacle older than **6.2** will still work with Octopus **2022.2** and higher, however may experience longer wait times when running tasks. It is recommended to upgrade all Tentacles to ensure your deployments run at optimum performance.
 
 ## Operating System compatibility
 

--- a/docs/support/compatibility.md
+++ b/docs/support/compatibility.md
@@ -17,7 +17,7 @@ The table below outlines the backward compatibility between Octopus Server and r
 | 2019.2* ➜ 2022.1 | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
 | 2022.2** ➜ latest | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 6.2 ➜ latest | 5.0 ➜ latest    |
 
-## &ast; Partial forwards compatibility
+**&ast; Partial forwards compatibility**
 
 Older versions of some libraries and plugins _may_ work with **2019.1** and higher _only if_ the [default space](https://oc.to/default-space) is enabled and such integrations are only used against that space. To make use of other spaces, please upgrade.
 
@@ -29,7 +29,7 @@ The table below outlines partially forwards compatible scenarios between Octopus
 | --------------    | ----------------------------------- | --------     | --------    | --------------- |
 | 2019.1  ➜ latest | 4.30.7 ➜ 4.47.0                    | 3.5 ➜ 4.12.0 | 3.0 ➜ 3.25 | 3.3 ➜ latest   |
 
-### &ast;&ast; Partial forwards compatibility with older Tentacles
+**&ast;&ast; Partial forwards compatibility with older Tentacles**
 
 Versions of Tentacle older than **6.2** will still work with Octopus **2022.2** and higher. However, you may experience longer wait times when running tasks. We recommend upgrading all Tentacles to ensure your deployments run at optimum performance. 
 

--- a/docs/support/compatibility.md
+++ b/docs/support/compatibility.md
@@ -17,7 +17,7 @@ The table below outlines the backward compatibility between Octopus Server and r
 | 2019.2* ➜ 2022.1 | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
 | 2022.2** ➜ latest | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 6.2 ➜ latest | 5.0 ➜ latest    |
 
-### &ast; Partial forwards compatibility
+## &ast; Partial forwards compatibility
 
 Older versions of some libraries and plugins _may_ work with **2019.1** and higher _only if_ the [default space](https://oc.to/default-space) is enabled and such integrations are only used against that space. To make use of other spaces, please upgrade.
 
@@ -31,7 +31,9 @@ The table below outlines partially forwards compatible scenarios between Octopus
 
 ### &ast;&ast; Partial forwards compatibility with older Tentacles
 
-Versions of Tentacle older than **6.2** will still work with Octopus **2022.2** and higher, however may experience longer wait times when running tasks. It is recommended to upgrade all Tentacles to ensure your deployments run at optimum performance.
+Versions of Tentacle older than **6.2** will still work with Octopus **2022.2** and higher. However, you may experience longer wait times when running tasks. We recommend upgrading all Tentacles to ensure your deployments run at optimum performance. 
+
+For more information, see this [GitHub issue](https://github.com/OctopusDeploy/Issues/issues/6664).
 
 ## Operating System compatibility
 


### PR DESCRIPTION
Package retention on workers https://github.com/OctopusDeploy/Issues/issues/6664 uses a new "feature" of Tentacle which is named mutexes. Older tentacles are still compatible but will wait on retention since the mutex uses a default name on older tentacles.