### PR TITLE
Add section on restricted permissions

### DIFF
--- a/docs/administration/managing-licenses/community/index.md
+++ b/docs/administration/managing-licenses/community/index.md
@@ -57,4 +57,4 @@ From the [Octopus Control Center](https://octopus.com/control-center/) dashboard
 
 ## Restricted permissions
 
-The community edition of Octopus Server uses a restricted permissions mode. This means that all users within the instance are granted system-wide administrator-level permissions. While Users and Teams can still be configured, any changes to these settings will be ignored.
+The community edition of Octopus runs in a restricted permissions mode. This means that all users within the instance are granted system-wide administrator-level permissions. While Users and Teams can still be configured, any changes to these settings will be ignored.

--- a/docs/administration/managing-licenses/community/index.md
+++ b/docs/administration/managing-licenses/community/index.md
@@ -54,3 +54,7 @@ The Octopus Cloud Community plan has limits that apply.
 From the [Octopus Control Center](https://octopus.com/control-center/) dashboard, navigate to **{{Cloud Instances, View}}**, select your instance and click on the **Finance** pane. Once there, click on the **Change Plan** button, and you'll be presented with an option at the bottom of the page. To complete the switch to Community Cloud, click on the **Switch to community plan** link.
 
 ![](images/octopus-cloud-community.png "width=500")
+
+## Restricted permissions
+
+The community edition of Octopus uses a restricted permissions mode. This means that all users within the instance are granted system-wide administrator-level permissions. While Users and Teams can still be configured, any changes to these settings will be ignored.

--- a/docs/administration/managing-licenses/community/index.md
+++ b/docs/administration/managing-licenses/community/index.md
@@ -57,4 +57,4 @@ From the [Octopus Control Center](https://octopus.com/control-center/) dashboard
 
 ## Restricted permissions
 
-The community edition of Octopus uses a restricted permissions mode. This means that all users within the instance are granted system-wide administrator-level permissions. While Users and Teams can still be configured, any changes to these settings will be ignored.
+The community edition of Octopus Server uses a restricted permissions mode. This means that all users within the instance are granted system-wide administrator-level permissions. While Users and Teams can still be configured, any changes to these settings will be ignored.

--- a/docs/shared-content/octopus-cloud/octopus-cloud-community-plan-instance-limits.include.md
+++ b/docs/shared-content/octopus-cloud/octopus-cloud-community-plan-instance-limits.include.md
@@ -1,5 +1,5 @@
 - Deploy to 5 targets
-- Limit of 5 users with limited permissions
+- Limit of 5 users with [restricted permissions](https://octopus.com/docs/administration/managing-licenses/community#restricted-permissions)
 - Limit of 5 projects
 - Limit of 20 worker hours per month
 - Technical support included

--- a/docs/shared-content/octopus-server/octopus-server-community-limits.include.md
+++ b/docs/shared-content/octopus-server/octopus-server-community-limits.include.md
@@ -1,5 +1,5 @@
 - Deploy to 5 targets
-- Limit of 5 users with [restricted permissions](https://octopus.com/docs/administration/managing-licenses/community#restricted-permissions)
+- Limit of 5 users with [restricted permissions](/docs/administration/managing-licenses/community/index.md#restricted-permissions)
 - Limit of 5 projects
 - Valid for 12 months, extend anytime for free
 - Technical support included

--- a/docs/shared-content/octopus-server/octopus-server-community-limits.include.md
+++ b/docs/shared-content/octopus-server/octopus-server-community-limits.include.md
@@ -1,5 +1,5 @@
 - Deploy to 5 targets
-- Limit of 5 users with limited permissions
+- Limit of 5 users with [restricted permissions](https://octopus.com/docs/administration/managing-licenses/community#restricted-permissions)
 - Limit of 5 projects
 - Valid for 12 months, extend anytime for free
 - Technical support included


### PR DESCRIPTION
We have a link in Octopus https://g.octopushq.com/RestrictedPermissions which redirects to https://octopus.com/start. This isn't very helpful, so this PR adds a section in the docs to link out to.

![image](https://user-images.githubusercontent.com/11970672/181393093-91f45b90-a93c-491f-a202-7c877673eb48.png)
