### PR TITLE
Remove limited permissions from cloud community limits

### DIFF
--- a/docs/shared-content/octopus-cloud/octopus-cloud-community-plan-instance-limits.include.md
+++ b/docs/shared-content/octopus-cloud/octopus-cloud-community-plan-instance-limits.include.md
@@ -1,5 +1,5 @@
 - Deploy to 5 targets
-- Limit of 5 users with limited permissions
+- Limit of 5 users
 - Limit of 5 projects
 - Limit of 20 worker hours per month
 - Technical support included


### PR DESCRIPTION
This is no longer enforced due to unexpected behaviour on the instance when enabled.

See https://octopusdeploy.slack.com/archives/C033BH95WRE/p1658971200437169?thread_ts=1658970807.681289&cid=C033BH95WRE