### PR TITLE
Fixed audit archive wording to match naming in the web portal

### DIFF
--- a/docs/security/users-and-teams/auditing.md
+++ b/docs/security/users-and-teams/auditing.md
@@ -54,7 +54,7 @@ To grant a user access to audit logs you can make use of a built-in User Role th
 In **Octopus 2019.1** we removed **AuditView** in an effort to simplify permissions so only **EventView** is now required.
 
 ### Accessing archived logs {#accessing-archived-logs}
-Audit entries older than the configured retention period (defaults to 90 days, configurable up to 365 days) are archived and can be accessed via the overflow menu (`...`) in the top right corner of the audit page by selecting the **Manage archived events** option.
+Audit entries older than the configured retention period (defaults to 90 days, configurable up to 365 days) are archived and can be accessed via the overflow menu (`...`) in the top right corner of the audit page by selecting the **Manage archived audit logs** option.
 
 ![Manage Archived Audit Logs Menu](images/manage-archived-audit-logs-menu.png "width=500")
 


### PR DESCRIPTION
# Before
Mismatched naming

# After
Naming in the docs consistent with the Web Portal

<img width="174" alt="image" src="https://user-images.githubusercontent.com/108677358/185533375-2701df98-8bf6-4935-baf8-0f5a1fc37549.png">
