### PR TITLE
Adds deprecations page

### DIFF
--- a/docs/deprecations/index.md
+++ b/docs/deprecations/index.md
@@ -1,0 +1,23 @@
+---
+title: Deprecations
+description: Upcoming and past deprecations by version for Octopus Server
+position: 300
+---
+
+## Overview
+
+From time to time, Octopus will deprecate features that are no longer going to be supported, and will eventually be removed.
+
+Deprecations have the following lifecycle:
+
+- Announce deprecation
+- (+6 months) Toggle off deprecated functionality
+- (+1 year) Remove deprecated functionality
+
+:::warning
+Deprecations are subject to change in detail or timeframe. If you need help assessing the impact of a deprecation on your particular Octopus Server configuration, please please [email our support team](mailto:support@octopus.com)
+:::
+
+## Deprecations for 2023.1
+
+None.

--- a/docs/deprecations/index.md
+++ b/docs/deprecations/index.md
@@ -15,7 +15,7 @@ Deprecations have the following lifecycle:
 - (+1 year) Remove deprecated functionality
 
 :::warning
-Deprecations are subject to change in detail or timeframe. If you need help assessing the impact of a deprecation on your particular Octopus Server configuration, please please [email our support team](mailto:support@octopus.com)
+Deprecations are subject to change in detail or timeframe. If you need help assessing the impact of deprecation of a feature on your particular Octopus Server configuration, please contact our [support team](https://octopus.com/support).
 :::
 
 ## Deprecations for 2023.1


### PR DESCRIPTION
As a part of [RFC: Managing deprecations for Octopus Server](https://docs.google.com/document/d/1z6kP9YUPh_GGhrAacQaNtloKq9LnNJ8ARBU-ofWAR2w), we need a place to publish deprecation announcements.

This page will serve as the source of truth for deprecation announcements for Octopus Server.

We will at some point arrange a redirect from octopus.com/deprecations to this page.