### PR TITLE
Update creditsfilegenerator to 1.0.678

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "octopus.creditsfilegenerator.tool": {
-      "version": "1.0.434",
+      "version": "1.0.678",
       "commands": [
         "octopus-creditsfilegenerator"
       ]


### PR DESCRIPTION
Version 1.0.678 has some fixes to generate credits for the latest OctopusDeploy codebase