### PR TITLE
Update .NET version in example script in github-actions.md

### DIFF
--- a/docs/packaging-applications/build-servers/github-actions.md
+++ b/docs/packaging-applications/build-servers/github-actions.md
@@ -174,7 +174,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.207
+        dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
Ran into errors with .NET version when trying to run the example build script (https://octopus.com/docs/packaging-applications/build-servers/github-actions#example.net-core-build) This change will update the version to allow it to build successfully.