### PR TITLE
Update octopus-cloud-storage-limits.include.md

### DIFF
--- a/docs/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
+++ b/docs/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
@@ -1,4 +1,4 @@
 - Maximum File Storage for artifacts, task logs, packages and package cache is limited to `1 TB`.
-- Maximum Database Size for configuration data (e.g. projects, deployment processes and inline scripts) is limited to `1 TB`.
+- Maximum Database Size for configuration data (e.g. projects, deployment processes and inline scripts) is limited to `100 GB`.
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies/index.md) are *defaulted* to 30 days, but this figure can be changed as required.


### PR DESCRIPTION
Changed the Cloud database limit to 100 GB which is an operational limit rather than a db limit