### PR TITLE
Ignore pnpm store

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "octopus.creditsfilegenerator.tool": {
-      "version": "1.0.678",
+      "version": "1.0.679",
       "commands": [
         "octopus-creditsfilegenerator"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site/
 .DS_Store
 **/*.dia~
 tmp
+.pnpm-store/


### PR DESCRIPTION
Generating credits with the new pnpm frontend workspace results in the pnpm store being committed to git, which is undesirable.

This PR bumps the credits generator to the latest version and adds the pnpm store to be git ignored.