### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -41,12 +41,6 @@ Where [<options>] is any of:
                                limit).
       --upgradeCheck=VALUE   Whether checking for upgrades is allowed (true
                                or false)
-      --machineTaskProcessingLimit=VALUE
-                             Maximum number of machines that can be processed
-                               at any given time in machine tasks (ie. Health
-                               Checks, Tentacle Upgrades and Calamari Upgrades-
-                               ). If no value is specified, the limit is based
-                               on the processor count of the server
       --sendTelemetry=VALUE  Whether telemetry data is sent to Octopus (true
                                or false)
       --commsListenPort=VALUE


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2022.3.10483.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 359