### PR TITLE
minor changes to clarify base64 requirement on license and masterkey 

### DIFF
--- a/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
+++ b/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
@@ -451,10 +451,10 @@ spec:
           - name: ADMIN_EMAIL
             value: admin@example.org
           - name: OCTOPUS_SERVER_BASE64_LICENSE
-            # Your license key goes here. When using more than one node, a HA license is required. Without a HA license, the stateful set can have a replica count of 1.
+            # Your base64 encoded license key goes here. When using more than one node, a HA license is required. Without a HA license, the stateful set can have a replica count of 1.
             value: <License-goes-here>
           - name: MASTER_KEY
-            # Replace this, as this value protects secrets in Octopus
+            # The Master Key to use to connect to an existing database. If not supplied, and the database does not exist, it will generate a new one. The Master Key is mandatory if the database exists.
             value: <MasterKey-goes-here>
         ports:
         - containerPort: 8080

--- a/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
+++ b/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
@@ -454,7 +454,7 @@ spec:
             # Your base64 encoded license key goes here. When using more than one node, a HA license is required. Without a HA license, the stateful set can have a replica count of 1.
             value: <License-goes-here>
           - name: MASTER_KEY
-            # The Master Key to use to connect to an existing database. If not supplied, and the database does not exist, it will generate a new one. The Master Key is mandatory if the database exists.
+            # The base64 Master Key to use to connect to an existing database. If not supplied, and the database does not exist, it will generate a new one.
             value: <MasterKey-goes-here>
         ports:
         - containerPort: 8080


### PR DESCRIPTION
@harrisonmeister 

Have had several customers hit issues with trying to use the entire licence or wrong masterkey, just wanted to make it a little clearer that both need to be base64 encoded