### PR TITLE
Update JSM request trial method

### DIFF
--- a/docs/approvals/jira-service-management/index.md
+++ b/docs/approvals/jira-service-management/index.md
@@ -4,10 +4,9 @@ description: Octopus Deploy can integrate with your Jira Service Management inst
 position: 10
 ---
 
-:::warning
-The Jira Service Management (JSM) Integration feature is only available as an EAP for Octopus 
-**2022.3.12101** or later, and it requires a specific feature license to use it. To request a 
-license register for the [JSM Early Access Program](https://octopusdeploy.typeform.com/jsm-eap)
+:::hint
+The Jira Service Management (JSM) Integration Early-Access Program (EAP)  is available in Octopus 
+**2022.3.12101** or later. [Contact us](https://octopus.com/company/contact) to request access to this feature. 
 :::
 
 ## Overview

--- a/docs/approvals/service-now/index.md
+++ b/docs/approvals/service-now/index.md
@@ -4,8 +4,9 @@ description: Octopus Deploy can integrate with your ServiceNow instance for depl
 position: 10
 ---
 
-:::warning
+:::hint
 The ServiceNow Integration feature is available from Octopus **2022.3** onwards and requires an [enterprise subscription](https://octopus.com/pricing).
+[Contact us](https://octopus.com/company/contact) to request a trial.
 :::
 
 ## Overview


### PR DESCRIPTION
Updating Jira Service Management page to point to `/contact` page, rather than typeform. 

Also updated these callouts to be `hint` rather than `warning`; The warnings looked angry.

 