### PR TITLE
Typos and amendments with regard to auto-deploys

### DIFF
--- a/docs/deployments/patterns/elastic-and-transient-environments/immutable-infrastructure.md
+++ b/docs/deployments/patterns/elastic-and-transient-environments/immutable-infrastructure.md
@@ -14,7 +14,7 @@ In this example we will create an infrastructure project and an application proj
 
 ## Machine Policy {#ImmutableInfrastructure-Machinepolicy}
 
-The Tentacles provisioned in this guide belong the to **Immutable Infrastructure** machine policy. For now, create a new machine policy called **Immutable Infrastructure** and leave all of the settings at their default value.
+The Tentacles provisioned in this guide belong to the **Immutable Infrastructure** machine policy. For now, create a new machine policy called **Immutable Infrastructure** and leave all of the settings at their default value.
 
 ## Application Project {#ImmutableInfrastructure-Applicationproject}
 
@@ -36,7 +36,7 @@ The infrastructure project runs a script that provisions two new Tentacles and r
 
    ![](images/5865670.png "width=500")
 
-7. Add a step that runs **Teminate.ps1** from the package **HelloWorldInfrastructure** on the Octopus Server on behalf of all roles.
+7. Add a step that runs **Terminate.ps1** from the package **HelloWorldInfrastructure** on the Octopus Server on behalf of all roles.
 
 ## Intermission {#ImmutableInfrastructure-Intermission}
 

--- a/docs/projects/project-triggers/deployment-target-triggers.md
+++ b/docs/projects/project-triggers/deployment-target-triggers.md
@@ -113,7 +113,6 @@ There are a number of reasons why automatic deployments may not work the way you
 Octopus will attempt to automatically deploy the current releases for the environments that are appropriate for a machine. The current release is the one that was most recently *successfully* deployed as shown on the project dashboard.
 
 - Octopus will not automatically deploy a release if the deployment for that release was not successful (this can be a failed deployment or even a canceled deployment)
-- If the initial deployment of a release was successful but an automatic deployment of that release fails, **Octopus will stop automatically deploying that release**.
 
 You will need you to complete a successful deployment again before auto-deployments can continue for the given release, or configure an [Auto Deploy Override](/docs/octopus-rest-api/octopus-cli/create-autodeployoverride.md).
 


### PR DESCRIPTION
Some typo fixes.

Validated the following behaviour and confirmed the following is no longer true
```
If the initial deployment of a release was successful but an automatic deployment of that release fails, **Octopus will stop automatically deploying that release**.
```
Auto-deploys still get triggered after an automatic deployment failure for a given release.

[sc-29412]