### PR TITLE
Expand the definition of cloud targets for default worker pool selection

### DIFF
--- a/docs/infrastructure/workers/worker-pools.md
+++ b/docs/infrastructure/workers/worker-pools.md
@@ -66,7 +66,7 @@ The **Octopus Web Portal** is worker pool aware.  If you haven't configured pool
 
 ## Configuring a cloud target to have a Default Worker Pool
 
-Cloud targets can set their own default pool.  If a step is targeted at a cloud target and the worker pool for the step is the default pool, the cloud target's default pool is used.  This allows setting up workers that are co-located with cloud targets.  Another option is locking down cloud targets so the only machines that can deploy are co-located polling workers.
+Cloud targets such as [Cloud regions](/docs/infrastructure/deployment-targets/cloud-regions.md) and [Kubernetes targets](/docs/infrastructure/deployment-targets/kubernetes-target/index.md) can set their own default worker pool, both for deployment steps and [health checks](/docs/infrastructure/deployment-targets/machine-policies.md#health-check).  If a step is targeted at a cloud target and the worker pool selected for the step is the default pool, the cloud target's default pool is used.  This allows setting up workers that are co-located with cloud targets.  Another option is locking down cloud targets so the only machines that can deploy are co-located polling workers. 
 
 ## Variables
 


### PR DESCRIPTION
As per [this discussion in Octopus' Community slack](https://octopususergroup.slack.com/archives/C6UGLUWMQ/p1669645313275079), the default worker pool for cloud targets could do with some clarification about what targets and what things are covered (e.g., health checks)