### PR TITLE
Introduction of Ubuntu 22.04 dynamic worker images

### DIFF
--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -88,6 +88,10 @@ We recommend execution containers as the preferred option for steps requiring ex
 
 ### Ubuntu 18.04
 
+:::warning
+Ubuntu 18.04 workers are deprecated and will be removed in March 2023.
+:::
+
 Each `Ubuntu Server 18.04` worker is provisioned with a baseline of tools including (but not limited to):
 
 - .NET Core (2.1, 3.1)
@@ -96,8 +100,17 @@ Each `Ubuntu Server 18.04` worker is provisioned with a baseline of tools includ
 - Python 3 (latest)
 - GCloud CLI (339.0.0)
 
+### Ubuntu 22.04
+
+Each `Ubuntu Server 22.04` worker is provisioned with a baseline of tools including (but not limited to):
+
+- Docker (latest)
+- Powershell Core (latest)
+- Python 3 (latest)
+- GCloud CLI (367.0.0)
+
 :::hint
-Ubuntu workers are designed to use [execution worker containers](https://octopus.com/blog/execution-containers) for tooling such as kubectl and helm. This makes it much easier to choose the appropriate runtime environment with the tools you need for your use case.
+Ubuntu workers are designed to use [execution worker containers](https://octopus.com/blog/execution-containers) for tooling such as `kubectl` and `helm`. This makes it much easier to choose the appropriate runtime environment with the tools you need for your use case.
 :::
 
 ## kubectl on Windows Images

--- a/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -89,7 +89,7 @@ We recommend execution containers as the preferred option for steps requiring ex
 ### Ubuntu 18.04
 
 :::warning
-Ubuntu 18.04 workers are deprecated and will be removed in March 2023.
+Ubuntu 18.04 workers are deprecated and will be removed on 1 April 2023.
 :::
 
 Each `Ubuntu Server 18.04` worker is provisioned with a baseline of tools including (but not limited to):


### PR DESCRIPTION
Ubuntu 18.04 is reaching EOL in April 2023.

Beginning February 2023:
* An Ubuntu 22.04 based image will be available for Dynamic Workers.
* The existing Ubuntu 18.04 image will be marked as deprecated.

[sc-29252]