### PR TITLE
Fixed missing latest version on Octopus Server

### DIFF
--- a/docs/support/compatibility.md
+++ b/docs/support/compatibility.md
@@ -16,7 +16,7 @@ The table below outlines the backward compatibility between Octopus Server and r
 | 3.5 ➜ 2018.2     | 3.3 ➜ 4.30.3                       | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 2018.2 ➜ 2018.12 | 4.30.7 ➜ 4.47.0                    | 3.5 ➜ latest    | 3.0 ➜ latest | 3.3 ➜ latest    |
 | 2019.1*           | 5.0.0 ➜ 5.2.7                      | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
-| 2019.2* ➜ 2022.1 | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
+| 2019.2* ➜ latest | 6.0.0 ➜ latest                     | 3.5 ➜ latest    | 4.0 ➜ latest | 5.0 ➜ latest    |
 
 ### **&ast; Partial forward compatibility**
 


### PR DESCRIPTION
After the compatibility doc was rolled back the Octopus Server latest version went missing on the compatibility table. This PR brings it back.