### PR TITLE
Add hints for creating deployment targets from scripts

### DIFF
--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md
@@ -41,3 +41,5 @@ New-OctopusAzureCloudServiceTarget -name "My Azure Cloud Service Target" `
                                    -octopusDefaultWorkerPoolIdOrName "Azure Worker Pool" `
                                    -octopusRoles "AzureCloudService"
 ```
+
+!include <create-deployment-targets-warning>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-cloud-service-target.md
@@ -42,4 +42,4 @@ New-OctopusAzureCloudServiceTarget -name "My Azure Cloud Service Target" `
                                    -octopusRoles "AzureCloudService"
 ```
 
-!include <create-deployment-targets-warning>
+!include <create-deployment-targets-hint>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md
@@ -67,4 +67,4 @@ New-OctopusAzureServiceFabricTarget -name "My Service Fabric Target 4" `
 
 ```
 
-!include <create-deployment-targets-warning>
+!include <create-deployment-targets-hint>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-service-fabric-target.md
@@ -66,3 +66,5 @@ New-OctopusAzureServiceFabricTarget -name "My Service Fabric Target 4" `
                                    -octopusRoles "Service Fabric Role"
 
 ```
+
+!include <create-deployment-targets-warning>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md
@@ -39,3 +39,5 @@ New-OctopusAzureWebAppTarget -name "My Azure Web Application" `
                              -octopusDefaultWorkerPoolIdOrName "Worker Pool with Azure Access" `
                              -updateIfExisting
 ```
+
+!include <create-deployment-targets-warning>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/azure-web-app-target.md
@@ -40,4 +40,4 @@ New-OctopusAzureWebAppTarget -name "My Azure Web Application" `
                              -updateIfExisting
 ```
 
-!include <create-deployment-targets-warning>
+!include <create-deployment-targets-hint>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -10,7 +10,7 @@ Octopus version 2022.1 has support for discovering and cleaning up supported typ
 
 You can use the [Octopus REST API](/docs/octopus-rest-api/index.md) or the Octopus commands below to create Octopus accounts, targets, and workers dynamically. You can make these requests in the same scripts that create your cloud infrastructure or in following steps.
 
-!include <create-deployment-targets-warning>
+!include <create-deployment-targets-hint>
 
 ## Enable dynamic infrastructure
 

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.md
@@ -10,6 +10,8 @@ Octopus version 2022.1 has support for discovering and cleaning up supported typ
 
 You can use the [Octopus REST API](/docs/octopus-rest-api/index.md) or the Octopus commands below to create Octopus accounts, targets, and workers dynamically. You can make these requests in the same scripts that create your cloud infrastructure or in following steps.
 
+!include <create-deployment-targets-warning>
+
 ## Enable dynamic infrastructure
 
 Dynamic infrastructure can be enabled when a new environment is created, or it can be enabled or disabled for existing environments.

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md
@@ -130,3 +130,5 @@ New-OctopusKubernetesTarget `
     -clusterName mattc-test `
     -updateIfExisting
 ```
+
+!include <create-deployment-targets-warning>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/kubernetes-target.md
@@ -131,4 +131,4 @@ New-OctopusKubernetesTarget `
     -updateIfExisting
 ```
 
-!include <create-deployment-targets-warning>
+!include <create-deployment-targets-hint>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -183,3 +183,5 @@ EOT
 
 new_octopustarget -n "$(get_octopusvariable "target_name")" -t "aws-ecs-target" --inputs "$INPUTS" --roles "$(get_octopusvariable "role")"
 ```
+
+!include <create-deployment-targets-warning>

--- a/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
+++ b/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.md
@@ -184,4 +184,4 @@ EOT
 new_octopustarget -n "$(get_octopusvariable "target_name")" -t "aws-ecs-target" --inputs "$INPUTS" --roles "$(get_octopusvariable "role")"
 ```
 
-!include <create-deployment-targets-warning>
+!include <create-deployment-targets-hint>

--- a/docs/shared-content/infrastructure/create-deployment-targets-hint.include.md
+++ b/docs/shared-content/infrastructure/create-deployment-targets-hint.include.md
@@ -1,0 +1,5 @@
+:::hint
+If your process creates dynamic deployment targets from a script, and then deploys to those targets in a subsequent step, make sure you add a full [health check](/docs/projects/built-in-step-templates/health-check.md) step for the role of the newly created targets after the step that creates and registers the targets.
+
+This allows Octopus to ensure the new targets are ready for deployment by staging packages required by subsequent steps that perform the deployment.
+:::

--- a/docs/shared-content/infrastructure/create-deployment-targets-warning.include.md
+++ b/docs/shared-content/infrastructure/create-deployment-targets-warning.include.md
@@ -1,3 +1,3 @@
 :::warning
-Package acquisition is not performed automatically after a deployment target is dynamically created from scripts. If following steps require packages to be acquired on these new deployment targets, make sure you add a [health check](/docs/projects/built-in-step-templates/health-check.md) step for the corresponding target roles after the target creation step. This will ensure required packages are downloaded for the new targets.
+Package acquisition is not performed automatically after a deployment target is dynamically created from scripts. If subsequent steps require packages to be acquired on these new deployment targets, make sure you add a [health check](/docs/projects/built-in-step-templates/health-check.md) step for the corresponding target roles after the target creation step. This will ensure required packages are downloaded for the new targets.
 :::

--- a/docs/shared-content/infrastructure/create-deployment-targets-warning.include.md
+++ b/docs/shared-content/infrastructure/create-deployment-targets-warning.include.md
@@ -1,3 +1,0 @@
-:::warning
-Package acquisition is not performed automatically after a deployment target is dynamically created from scripts. If subsequent steps require packages to be acquired on these new deployment targets, make sure you add a [health check](/docs/projects/built-in-step-templates/health-check.md) step for the corresponding target roles after the target creation step. This will ensure required packages are downloaded for the new targets.
-:::

--- a/docs/shared-content/infrastructure/create-deployment-targets-warning.include.md
+++ b/docs/shared-content/infrastructure/create-deployment-targets-warning.include.md
@@ -1,0 +1,3 @@
+:::warning
+Package acquisition is not performed automatically after a deployment target is dynamically created from scripts. If following steps require packages to be acquired on these new deployment targets, make sure you add a [health check](/docs/projects/built-in-step-templates/health-check.md) step for the corresponding target roles after the target creation step. This will ensure required packages are downloaded for the new targets.
+:::


### PR DESCRIPTION
This PR adds a hint section for docs on creating new deployment targets to let customer understand the need to add a health check step after creating new deployment targets, if these new targets requires package acquisition.