### PR TITLE
removing the extra wording to avoid confusion

### DIFF
--- a/docs/deprecations/index.md
+++ b/docs/deprecations/index.md
@@ -24,4 +24,4 @@ Deprecations are subject to change in detail or timeframe. If you need help asse
 
 ## Deprecations for 2022.4
 
-* Server extensibility is deprecated and no longer maintained. It will no longer work at the end of 2023. Some of you may have implemented an extension for Octopus Server, they will keep working as normal, however we would be interested in understanding your requirements better so that we can work towards resolving missing capabilities. Contact us via [support team](https://octopus.com/support) to let us know if this will affect your instance.
+* Server extensibility is deprecated and no longer maintained. It will no longer work at the end of 2023. Some of you may have implemented an extension for Octopus Server, however we would be interested in understanding your requirements better so that we can work towards resolving missing capabilities. Contact us via [support team](https://octopus.com/support) to let us know if this will affect your instance.

--- a/docs/deprecations/index.md
+++ b/docs/deprecations/index.md
@@ -24,4 +24,4 @@ Deprecations are subject to change in detail or timeframe. If you need help asse
 
 ## Deprecations for 2022.4
 
-* Server extensibility is deprecated and no longer maintained. It will no longer work at the end of 2023. Some of you may have implemented an extension for Octopus Server, however we would be interested in understanding your requirements better so that we can work towards resolving missing capabilities. Contact us via [support team](https://octopus.com/support) to let us know if this will affect your instance.
+* Server extensibility is deprecated and no longer maintained. It will no longer work at the end of 2023. Some of you may have implemented an extension for Octopus Server, however, we would be interested in understanding your requirements better to work towards resolving missing capabilities. Contact us via [support team](https://octopus.com/support) to let us know if this will affect your instance.


### PR DESCRIPTION
Extensions will keep working... but only until the end of the year when we start removing/planning to remove the extensibility framework.

This wording suggests things will keep working even after end of this year