### PR TITLE
Adds documentation for Polling Tentacles over port 443

### DIFF
--- a/docs/infrastructure/deployment-targets/polling-tentacles.md
+++ b/docs/infrastructure/deployment-targets/polling-tentacles.md
@@ -1,0 +1,54 @@
+---
+title: Polling Tentacles over port 443
+description: Octopus Polling Tentacles open a connection to the Octopus Server over port 443 to ask what to do.
+position: 130
+---
+
+[Polling Tentacles](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you may be able to configure Tentacle to use port 443 (HTTPS).
+
+Based upon your chosen method of hosting Octopus Server, 
+
+## Octopus Cloud
+
+To setup a Polling Tentacle for an Octopus Cloud instance, omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your Octopus Cloud instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`) 
+
+### Registering a new Tentacle
+```powershell
+.\Tentacle register-with --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --environment "Test" --role "Web"
+```
+
+### Changing an existing Tentacle
+
+```powershell
+.\Tentacle service --instance MyInstance --stop
+.\Tentacle configure --reset-trust
+.\Tentacle register-with --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --environment "Test" --role "Web"
+.\Tentacle service --instance MyInstance --start
+```
+
+### Registering a new Worker
+```powershell
+.\Tentacle register-worker --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --workerpool MyWorkerPool
+```
+
+### Changing an existing Worker
+```powershell
+.\Tentacle service --instance MyInstance --stop
+.\Tentacle configure --reset-trust
+.\Tentacle register-worker --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --workerpool MyWorkerPool
+.\Tentacle service --instance MyInstance --start
+```
+
+
+## Self-hosted
+
+For self-hosted installations of Octopus Server, additional network configuration and/or services are required to support the use of Polling Tentacles over port 443 alongside the Octopus Server UI and API.
+
+:::warning
+This document requires additional network configuration... (ie. Reverse Proxy) or the use of [Octopus Cloud](/docs/octopus-cloud/index.md).
+:::
+
+New hostname/DNS record pointing at the same IP as the Server URL
+Reverse proxy to redirect inbound traffic on port 443 to port 10943 on the Octopus Server.
+ - Reverse proxy must pass-through all Tentacle traffic and not attempt SSL offloading
+

--- a/docs/infrastructure/deployment-targets/windows-targets/azure-virtual-machines/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/azure-virtual-machines/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure virtual machines
 description: The Azure VM Tentacle extension makes it easy to automatically download, install and register a Tentacle with your Octopus Server.
-position: 70
+position: 80
 hideInThisSectionHeader: true
 ---
 

--- a/docs/infrastructure/deployment-targets/windows-targets/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/index.md
@@ -64,7 +64,7 @@ use the remaining port for polling Tentacle connections.
 Even if you do use port **80** for Polling Tentacles, the communication is still secure.
 - Use a reverse proxy to redirect incoming connections to the Tentacle listening port on Octopus Server by differentiating the connection based on Hostname (TLS SNI) or IP Address
   - The polling endpoint Tentacle uses can be [changed from the command line](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md#self-hosted) using the `--server-comms-address` option. 
-  - You can learn about this configuration on the [Polling Tentacles over port 443](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443) page.
+  - You can learn about this configuration on the [Polling Tentacles over port 443](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md) page.
 
 Note that the port used to poll Octopus for jobs is different to the port used by your team to access the Octopus Deploy web interface;
 this is on purpose, and it means you can use different firewall conditions to allow Tentacles to access the Octopus Server by IP address.

--- a/docs/infrastructure/deployment-targets/windows-targets/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/index.md
@@ -58,8 +58,7 @@ If the Tentacle isn't connecting, try the steps on the [troubleshooting page](/d
 To allow Tentacle to connect to your Octopus Server, you'll need to allow access to port **10943** on the Octopus Server (or the port you selected during the installation wizard - port 10943 is just the default). You will also need to allow Tentacle to access the HTTP Octopus Web Portal (typically port **80** or **443** - these bindings are selected when you [install the Octopus Server](/docs/installation/index.md)).
 
 If your network rules only allow port **80** and **443** to the Octopus Server, you can either:
-- Change the server bindings to either HTTP or HTTPS and
-use the remaining port for polling Tentacle connections.
+- Change the server bindings to either HTTP or HTTPS and use the remaining port for polling Tentacle connections.
   - The listening port Octopus Server uses can be [changed from the command line](/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md) using the `--commsListenPort` option.
 Even if you do use port **80** for Polling Tentacles, the communication is still secure.
 - Use a reverse proxy to redirect incoming connections to the Tentacle listening port on Octopus Server by differentiating the connection based on Hostname (TLS SNI) or IP Address

--- a/docs/infrastructure/deployment-targets/windows-targets/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/index.md
@@ -57,9 +57,14 @@ If the Tentacle isn't connecting, try the steps on the [troubleshooting page](/d
 
 To allow Tentacle to connect to your Octopus Server, you'll need to allow access to port **10943** on the Octopus Server (or the port you selected during the installation wizard - port 10943 is just the default). You will also need to allow Tentacle to access the HTTP Octopus Web Portal (typically port **80** or **443** - these bindings are selected when you [install the Octopus Server](/docs/installation/index.md)).
 
-If your network rules only allow port **80** and **443** to the Octopus Server, you can change the server bindings to either HTTP or HTTPS and
-use the remaining port for polling Tentacle connections. The listening port Octopus Server uses can be [changed from the command line](/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md) using the `--commsListenPort` option.
+If your network rules only allow port **80** and **443** to the Octopus Server, you can either:
+- Change the server bindings to either HTTP or HTTPS and
+use the remaining port for polling Tentacle connections.
+  - The listening port Octopus Server uses can be [changed from the command line](/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md) using the `--commsListenPort` option.
 Even if you do use port **80** for Polling Tentacles, the communication is still secure.
+- Use a reverse proxy to redirect incoming connections to the Tentacle listening port on Octopus Server by differentiating the connection based on Hostname (TLS SNI) or IP Address
+  - The polling endpoint Tentacle uses can be [changed from the command line](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md#self-hosted) using the `--server-comms-address` option. 
+  - You can learn about this configuration on the [Polling Tentacles over port 443](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443) page.
 
 Note that the port used to poll Octopus for jobs is different to the port used by your team to access the Octopus Deploy web interface;
 this is on purpose, and it means you can use different firewall conditions to allow Tentacles to access the Octopus Server by IP address.

--- a/docs/infrastructure/deployment-targets/windows-targets/index.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/index.md
@@ -65,7 +65,7 @@ Even if you do use port **80** for Polling Tentacles, the communication is still
   - The polling endpoint Tentacle uses can be [changed from the command line](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md#self-hosted) using the `--server-comms-address` option. 
   - You can learn about this configuration on the [Polling Tentacles over port 443](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md) page.
 
-Note that the port used to poll Octopus for jobs is different to the port used by your team to access the Octopus Deploy web interface;
+Note that the port (or address) used to poll Octopus for jobs is different from the port (or address) used by your team to access the Octopus Deploy web interface;
 this is on purpose, and it means you can use different firewall conditions to allow Tentacles to access the Octopus Server by IP address.
 
 Using polling mode, you won't typically need to make any firewall changes on the Tentacle machine.

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -10,7 +10,10 @@ The procedure for doing so varies based upon your chosen method of hosting Octop
 
 ## Octopus Cloud
 
-The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except for the `register-with` and `register-worker` commands, omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`).
+The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except when registering the Tentacle. Change the `register-with` and `register-worker` commands:
+ * Omit the `--server-comms-port` parameter.
+ * Specify the `--server-comms-address <address>` parameter.
+   * The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`).
 
 ### Registering a new Tentacle
 ```powershell

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -52,7 +52,7 @@ The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index
 
 For self-hosted installations of Octopus Server, you will require additional network configuration and/or services to support the use of Polling Tentacles, Octopus Web Portal and REST API all over port 443. 
 
-A reverse proxy can be set up either on the machine or a machine/appliance that fronts it. The reverse proxy would inspect connections coming in on the same port and decide which backend port to forward them to.
+A reverse proxy (e.g. NGINX) can be set up either on the machine or a machine/appliance that fronts it. The reverse proxy would inspect connections coming in on the same port and decide which backend port to forward them to.
 
 The proxy could differentiate the connections based on:
 - Hostname (TLS SNI)

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -1,16 +1,16 @@
 ---
 title: Polling Tentacles over port 443
 description: Octopus Polling Tentacles open a connection to the Octopus Server over port 443 to ask what to do.
-position: 130
+position: 65
 ---
 
 [Polling Tentacles](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you may be able to configure Tentacle to use port 443 (HTTPS).
 
-Based upon your chosen method of hosting Octopus Server, 
+The procedure for doing so varies based upon your chosen method of hosting Octopus Server.
 
 ## Octopus Cloud
 
-To setup a Polling Tentacle for an Octopus Cloud instance, omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your Octopus Cloud instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`) 
+The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`) 
 
 ### Registering a new Tentacle
 ```powershell

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -4,7 +4,7 @@ description: Octopus Polling Tentacles open a connection to the Octopus Server o
 position: 65
 ---
 
-[Polling Tentacles](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over TCP port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you can configure Tentacle to use port 443 (HTTPS).
+[Polling Tentacles](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over TCP port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you can configure Tentacle to use port 443 (HTTPS).
 
 The procedure for doing so varies based upon your chosen method of hosting Octopus Server.
 
@@ -53,7 +53,7 @@ The proxy could differentiate the connections based on:
 
 This reverse proxy must pass-through all Tentacle traffic as [SSL offloading is not supported](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#ssl-offloading-is-not-supported).
 
-For example with TLS SNI you will require:
+For example, using TLS SNI you will require:
 - A new DNS record dedicated for Polling Tentacle traffic. 
   - This will be used when registering your Workers and Tentacles (i.e. `--server-comms-address https://<your-polling-url>`) 
 - A reverse proxy rule to redirect inbound traffic on port 443 on the new DNS record to port 10943 on your Octopus Server.
@@ -62,3 +62,13 @@ The setup of a Polling Tentacle for your self-hosted instance over port 443 is t
  - Omit the `--server-comms-port` parameter.
  - Specify the `--server-comms-address <address>` parameter.
    - The address to use is your new DNS record (e.g. `https://<your-polling-url>/`).
+
+## Further reading
+For further reading on the installation and configuration of Tentacle:
+
+- [Polling Tentacles](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles)
+- [Windows Tentacles](/docs/infrastructure/deployment-targets/windows-targets/index.md)
+- [Linux Tentacles](/docs/infrastructure/deployment-targets/linux/tentacle/index.md)
+- [Tentacle command line](/docs/octopus-rest-api/tentacle.exe-command-line/index.md)
+  - [register-with](/docs/octopus-rest-api/tentacle.exe-command-line/register-with.md)
+  - [register-worker](/docs/octopus-rest-api/tentacle.exe-command-line/register-worker.md)

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -11,9 +11,9 @@ The procedure for doing so varies based upon your chosen method of hosting Octop
 ## Octopus Cloud
 
 The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except when registering the Tentacle. Change the `register-with` and `register-worker` commands:
- * Omit the `--server-comms-port` parameter.
- * Specify the `--server-comms-address <address>` parameter.
-   * The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`).
+ - Omit the `--server-comms-port` parameter.
+ - Specify the `--server-comms-address <address>` parameter.
+   - The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`).
 
 ### Registering a new Tentacle
 ```powershell
@@ -46,12 +46,19 @@ The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index
 
 For self-hosted installations of Octopus Server, you will require additional network configuration and/or services to support the use of Polling Tentacles, Octopus Web Portal and REST API all over port 443. 
 
-For example:
+A reverse proxy can be set up either on the machine or a machine/appliance that fronts it. The reverse proxy would inspect connections coming in on the same port and decide which backend port to forward them to.
+The proxy could differentiate the connections based on:
+- Hostname (TLS SNI)
+- IP Address
 
+This reverse proxy must pass-through all Tentacle traffic as [SSL offloading is not supported](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#ssl-offloading-is-not-supported).
+
+For example with TLS SNI you will require:
 - A new DNS record dedicated for Polling Tentacle traffic. 
   - This will be used when registering your Workers and Tentacles (i.e. `--server-comms-address https://<your-polling-url>`) 
-- A reverse proxy to redirect inbound traffic on port 443 on the new DNS record to port 10943 on your Octopus Server.
-  - This reverse proxy must pass-through all Tentacle traffic as [SSL offloading is not supported](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#ssl-offloading-is-not-supported).
+- A reverse proxy rule to redirect inbound traffic on port 443 on the new DNS record to port 10943 on your Octopus Server.
 
-
-The setup of a Polling Tentacle for your self-hosted instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except for the `register-with` and `register-worker` commands, omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your new DNS record (e.g. `https://<your-polling-url>/`).
+The setup of a Polling Tentacle for your self-hosted instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except when registering the Tentacle. Change the `register-with` and `register-worker` commands:
+ - Omit the `--server-comms-port` parameter.
+ - Specify the `--server-comms-address <address>` parameter.
+   - The address to use is your new DNS record (e.g. `https://<your-polling-url>/`).

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -1,23 +1,29 @@
 ---
 title: Polling Tentacles over port 443
-description: Octopus Polling Tentacles open a connection to the Octopus Server over port 443 to ask what to do.
+description: Octopus Polling Tentacles open a connection to the Octopus Server over port 443 to ask the Server if there is any work to do.
 position: 65
 ---
 
 [Polling Tentacles](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over TCP port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you can configure Tentacle to use port 443 (HTTPS).
 
-The procedure for doing so varies based upon your chosen method of hosting Octopus Server.
+:::hint
+Note: Configuring polling tentacles over port 443 via HTTPS described here does **not use WebSockets**. For more information on that topic, see [Polling Tentacles over WebSockets](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-web-sockets.md).
+:::
+
+The procedure for configuring Polling Tentacles to use port 443 varies based upon your chosen method of hosting Octopus Server.
 
 ## Octopus Cloud
 
 The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except when registering the Tentacle. Change the `register-with` and `register-worker` commands:
+
  - Omit the `--server-comms-port` parameter.
  - Specify the `--server-comms-address <address>` parameter.
    - The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`).
 
 ### Registering a new Tentacle
+
 ```powershell
-.\Tentacle register-with --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --environment "Test" --role "Web"
+.\Tentacle register-with --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-YOURKEY" --environment "Test" --role "Web"
 ```
 
 ### Changing an existing Tentacle
@@ -25,20 +31,20 @@ The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index
 ```powershell
 .\Tentacle service --instance MyInstance --stop
 .\Tentacle configure --reset-trust
-.\Tentacle register-with --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --environment "Test" --role "Web"
+.\Tentacle register-with --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-YOURKEY" --environment "Test" --role "Web"
 .\Tentacle service --instance MyInstance --start
 ```
 
 ### Registering a new Worker
 ```powershell
-.\Tentacle register-worker --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --workerpool MyWorkerPool
+.\Tentacle register-worker --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-YOURKEY" --workerpool MyWorkerPool
 ```
 
 ### Changing an existing Worker
 ```powershell
 .\Tentacle service --instance MyInstance --stop
 .\Tentacle configure --reset-trust
-.\Tentacle register-worker --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-CS0SW5SQJNLUBQCUBPK8LZY3KYO" --workerpool MyWorkerPool
+.\Tentacle register-worker --instance MyInstance --server "https://<yoururl>.octopus.app" --server-comms-address "https://polling.<yoururl>.octopus.app" --comms-style TentacleActive --apiKey "API-YOURKEY" --workerpool MyWorkerPool
 .\Tentacle service --instance MyInstance --start
 ```
 
@@ -47,6 +53,7 @@ The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index
 For self-hosted installations of Octopus Server, you will require additional network configuration and/or services to support the use of Polling Tentacles, Octopus Web Portal and REST API all over port 443. 
 
 A reverse proxy can be set up either on the machine or a machine/appliance that fronts it. The reverse proxy would inspect connections coming in on the same port and decide which backend port to forward them to.
+
 The proxy could differentiate the connections based on:
 - Hostname (TLS SNI)
 - IP Address
@@ -63,7 +70,8 @@ The setup of a Polling Tentacle for your self-hosted instance over port 443 is t
  - Specify the `--server-comms-address <address>` parameter.
    - The address to use is your new DNS record (e.g. `https://<your-polling-url>/`).
 
-## Further reading
+## Learn more
+
 For further reading on the installation and configuration of Tentacle:
 
 - [Polling Tentacles](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles)

--- a/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md
@@ -4,13 +4,13 @@ description: Octopus Polling Tentacles open a connection to the Octopus Server o
 position: 65
 ---
 
-[Polling Tentacles](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you may be able to configure Tentacle to use port 443 (HTTPS).
+[Polling Tentacles](docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles) usually communicate with Octopus Server over TCP port 10943. If your network configuration prevents outbound connections from your Tentacles on non-standard ports, you can configure Tentacle to use port 443 (HTTPS).
 
 The procedure for doing so varies based upon your chosen method of hosting Octopus Server.
 
 ## Octopus Cloud
 
-The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`) 
+The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index.md) instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except for the `register-with` and `register-worker` commands, omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your [Octopus Cloud](/docs/octopus-cloud/index.md) instance URL prefixed with `polling.` (e.g. `https://polling.<yoururl>.octopus.app`).
 
 ### Registering a new Tentacle
 ```powershell
@@ -39,16 +39,16 @@ The setup of a Polling Tentacle for an [Octopus Cloud](/docs/octopus-cloud/index
 .\Tentacle service --instance MyInstance --start
 ```
 
-
 ## Self-hosted
 
-For self-hosted installations of Octopus Server, additional network configuration and/or services are required to support the use of Polling Tentacles over port 443 alongside the Octopus Server UI and API.
+For self-hosted installations of Octopus Server, you will require additional network configuration and/or services to support the use of Polling Tentacles, Octopus Web Portal and REST API all over port 443. 
 
-:::warning
-This document requires additional network configuration... (ie. Reverse Proxy) or the use of [Octopus Cloud](/docs/octopus-cloud/index.md).
-:::
+For example:
 
-New hostname/DNS record pointing at the same IP as the Server URL
-Reverse proxy to redirect inbound traffic on port 443 to port 10943 on the Octopus Server.
- - Reverse proxy must pass-through all Tentacle traffic and not attempt SSL offloading
+- A new DNS record dedicated for Polling Tentacle traffic. 
+  - This will be used when registering your Workers and Tentacles (i.e. `--server-comms-address https://<your-polling-url>`) 
+- A reverse proxy to redirect inbound traffic on port 443 on the new DNS record to port 10943 on your Octopus Server.
+  - This reverse proxy must pass-through all Tentacle traffic as [SSL offloading is not supported](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#ssl-offloading-is-not-supported).
 
+
+The setup of a Polling Tentacle for your self-hosted instance over port 443 is the same as a [Polling Tentacle over port 10943](/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md#polling-tentacles), except for the `register-with` and `register-worker` commands, omit the `--server-comms-port` parameter and specify the `--server-comms-address <address>` parameter. The address to use is your new DNS record (e.g. `https://<your-polling-url>/`).

--- a/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/tentacle-communication.md
@@ -22,7 +22,9 @@ To install and configure Tentacles in listening mode, see the [Windows Targets (
 
 ## Polling Tentacles
 
-In **polling** mode, Tentacle will *poll* the Octopus Server periodically, connecting over a TCP port (**10943** by default) to check if there are any tasks for it to perform. The port Octopus Server uses can be [changed from the command line](/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md) using the `--commsListenPort` option. Polling mode is the opposite of **Listening mode**.
+In **polling** mode, Tentacle will *poll* the Octopus Server periodically, connecting over a TCP port (**10943** by default) to check if there are any tasks for it to perform. Polling mode is the opposite of **Listening mode**.
+
+For self-hosted, the port Octopus Server uses can be [changed from the command line](/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md) using the `--commsListenPort` option. For [Octopus Cloud](/docs/octopus-cloud/index.md), port 443 can be specified when [registering the Tentacle with the command line](/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-over-port-443.md) `--server-comms-address` option.
 
 In polling mode, Octopus is the TCP server, and Tentacle is the TCP client.
 

--- a/docs/infrastructure/deployment-targets/windows-targets/troubleshooting-tentacles.md
+++ b/docs/infrastructure/deployment-targets/windows-targets/troubleshooting-tentacles.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting Tentacles
 description: How to troubleshoot problems with Octopus Tentacles.
-position: 63
+position: 70
 ---
 
 All of the 'classic' problems of TCP networking: firewalls, proxies, timeouts, DNS issues, and so-on can affect Octopus Tentacles. This guide will help to track down these issues when either a machine cannot be "Discovered" (Listening Tentacles) or "Registered" (Polling Tentacles) with the Octopus Server, or a previously working machine fails a health-check with errors from the networking stack.


### PR DESCRIPTION
This PR adds a new page to guide users when using the new `--server-comms-address` argument added in: https://github.com/OctopusDeploy/OctopusTentacle/pull/440

We're mainly focusing the usage in Octopus Cloud at this stage because self-hosted instances need more server-side configuration work, but we've included some high-level guidance for now.

We've based the new page on https://www.octopus.com/docs/infrastructure/deployment-targets/windows-targets/polling-tentacles-web-sockets

This PR should not be merged until Tentacle 6.3.341 is available to download on octopus.com