### PR TITLE
Added the Tools folder for Octopus Server into the Malware Protection for Windows Defender Script

### DIFF
--- a/docs/security/hardening-octopus.md
+++ b/docs/security/hardening-octopus.md
@@ -125,7 +125,11 @@ Write-Output "Setting Windows Update to 'Download updates but let me choose whet
 Write-Output "This value allows Windows Defender to download and install definition updates automatically, but other updates are not automatically installed."
 cscript C:\Windows\System32\Scregedit.wsf /AU 3
 
-Write-Output "Excluding the Tools folder (e.g. Calamari) from Windows Defender..."
+Write-Output "Excluding the Tools folder for Octopus Server (e.g. Calamari) from Windows Defender..."
+Add-MpPreference -ExclusionPath "C:\Octopus\OctopusServer\Tools"
+Add-MpPreference -ExclusionPath "C:\Octopus\OctopusServer\Tools*"
+
+Write-Output "Excluding the Tools folder for Octopus Tentacles/Workers (e.g. Calamari) from Windows Defender..."
 Add-MpPreference -ExclusionPath "C:\Octopus\Tools"
 Add-MpPreference -ExclusionPath "C:\Octopus\Tools\*"
 


### PR DESCRIPTION
The tools folder for windows server is located in `C:\Octopus\OctopusServer\Tools` and for tentacles it's `C:\Octopus\Tools`. I noticed the other day we needed to add the changed folder structure for Octopus Server as it's no longer located in the same folder as the tentacles.