### PR TITLE
Comma missing from octopusBuildInformation example

### DIFF
--- a/docs/packaging-applications/build-servers/jenkins/pipeline.md
+++ b/docs/packaging-applications/build-servers/jenkins/pipeline.md
@@ -129,7 +129,7 @@ octopusPushBuildInformation \
   verboseLogging: false, \
   additionalArgs: '--debug', \
   gitUrl: 'https://github.com/OctopusSamples/OctoPetShop', \
-  gitBranch: '${GIT_BRANCH}' \
+  gitBranch: '${GIT_BRANCH}', \
   gitCommit: '${GIT_COMMIT}'
 ```
 


### PR DESCRIPTION
A comma was missing in the example script which was causing the jenkinsfile to be malformed.