### PR TITLE
Remove UserVoice links

### DIFF
--- a/docs/deployments/azure/index.md
+++ b/docs/deployments/azure/index.md
@@ -14,7 +14,8 @@ Out-of-the-box, Octopus provides built-in steps to deploy to the following Azure
 - [Azure Cloud Services](/docs/deployments/azure/cloud-services/index.md).
 - [Service Fabric](/docs/deployments/azure/service-fabric/index.md).
 - [Executing PowerShell scripts using the Azure cmdlets](/docs/deployments/custom-scripts/azure-powershell-scripts.md). Follow our guide on [running Azure PowerShell scripts](/docs/deployments/azure/running-azure-powershell/index.md).
-- The one you are looking for is not here? Leave us a feature request in [UserVoice](https://octopusdeploy.uservoice.com/).
+- The one you are looking for is not here? [Share your product feedback](https://roadmap.octopus.com/submit-idea) to let us know how we can help you have happy deployments.
+
 
 With [runbooks](/docs/runbooks/index.md), Octopus provides built-in steps to help manage your infrastructure in Azure:
 - [Resource Group Templates](/docs/runbooks/runbook-examples/azure/resource-groups/index.md).

--- a/docs/packaging-applications/build-servers/troubleshooting-integrations-with-build-servers.md
+++ b/docs/packaging-applications/build-servers/troubleshooting-integrations-with-build-servers.md
@@ -80,4 +80,4 @@ Make sure to set the ticket as **private** before attaching any kind of log, as 
 
 If you are using a custom step/plugin/extension to hook up your Build server with Octopus, then all we can recommend you is to know your `octo` game very well.
 
-If you are using a build server technology [that's not in our supported list](/docs/octopus-rest-api/index.md), then we encourage you to go to our [UserVoice page](https://octopusdeploy.uservoice.com/) and log a feature request asking us to support it. If enough users vote for it, It'll show up in our radar and we might be able to do something about it.
+If you are using a build server technology [that's not in our supported list](/docs/octopus-rest-api/index.md) [share your product feedback](https://roadmap.octopus.com/submit-idea) to let us know how we can help you have happy deployments.


### PR DESCRIPTION
We're replacing UserVoice with a new roadmap portal. Two documentation pages have had their links replaced.