### PR TITLE
Adding instructions on how to trust additional CA

### DIFF
--- a/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
+++ b/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
@@ -752,22 +752,24 @@ spec:
 ```
 
 ## Trusting custom/internal Certificate Authority (CA)
-Octopus Server can interface with a number of external sources (feeds, git repos, etc...), those sources are often configured to use SSL/TLS for secure communication.  It is common for organizations to have their own CA servers for their internal networks.  A CA server can issue SSL certificates that can be used on internal resources, such as build servers or internally hosted applications without the need to purchase from a third-party vendor.  Technologies such as Group Policy Objects (GPO) can configure machines (servers and clients) to automatically trust the CA so users don't have trust them manually, however, this is not inherited to Kubernetes containers.  When attempting to configure a connection to an external resource with an untrusted CA, you'll most likley encounter
+Octopus Server can interface with several external sources (feeds, git repos, etc.), and those sources are often configured to use SSL/TLS for secure communication.  It is common for organizations to have their own Certificate Authority (CA) servers for their internal networks.  A CA server can issue SSL certificates for internal resources, such as build servers or internally hosted applications, without purchasing from a third-party vendor.  Technologies such as Group Policy Objects (GPO) can configure machines (servers and clients) to trust the CA automatically, so users don't have to configure trust for them manually. However, this is not inherited in Kubernetes containers.  When attempting to configure a connection to an external resource with an untrusted CA, you'll most likely encounter an error similar to this:
 
+```text
+Could not connect to the package feed. The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
 ```
-Could not connect to the package feed The SSL connection could not be established, see inner exception. The remote certificate is invalid because of errors in the certificate chain: UntrustedRoot
-```
-Kuberntes provides a method to incorporate a certificate without having to modify hosts or having to embed the certificate within the container itself by use of a ConfigMap.
+Kubernetes provides a method to incorporate a certificate without having to modify hosts or embed the certificate within the container by using a ConfigMap.
 
 ### Create ConfigMap
-To apply the certificate to the cluster, you'll need to first get the certificate file itself in either `.pem` or `.crt` format.  Once you have the file, use `kubectl` to create a ConfigMap from it
+
+To apply the certificate to the cluster, you'll need to first get the certificate file in either `.pem` or `.crt` format.  Once you have the file, use `kubectl` to create a ConfigMap from it
 
 ```bash
 kubectl -n <namespace> create configmap ca-pemstore --from-file=my-cert.pem
 ```
 
 ### Add ConfigMap to YAML for Octopus Server
-With the ConfigMap created, add a `volumeMounts` component to the container section of Octopus Server, the following is an abbreviated portion of the YAML
+
+With the ConfigMap created, add a `volumeMounts` component to the container section for Octopus Server. The following is an abbreviated portion of the YAML
 
 ```yaml
 ...


### PR DESCRIPTION
As we enter the Enterprise space, this may come up more often.  I've added instructions on how to configure K8s to use internal or custom certificate authorities so when Octopus Server calls out to resources using internally signed certificates, it doesn't error with an untrusted root ca exception.