### PR TITLE
Updating cli docs for octopus.server.exe

### DIFF
--- a/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/configure.md
@@ -102,6 +102,8 @@ Where [<options>] is any of:
                                Defaults to 'no-referrer'.
       --webServer=VALUE      Web server to use when running Octopus (HttpSys,
                                Kestrel)
+      --trustedProxies=VALUE Comma-separated list of IP addresses of trusted
+                               proxies
       --webTrustedRedirectUrls=VALUE
                              Comma-seperated list of URLs that are trusted
                                for redirection

--- a/docs/octopus-rest-api/octopus.server.exe-command-line/rotate-master-key.md
+++ b/docs/octopus-rest-api/octopus.server.exe-command-line/rotate-master-key.md
@@ -33,6 +33,7 @@ Where [<options>] is any of:
                                load and save data in the expected format.
       --skipLicenseCheck     Skips the license check when performing a schema
                                upgrade
+      --masterKey=VALUE      The new master key that should be used
 
 Or one of the common options:
 


### PR DESCRIPTION
An automated update of the command line docs for octopus.server.exe version 2023.1.9672.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 383