### PR TITLE
Updated version number of OSX

### DIFF
--- a/docs/infrastructure/deployment-targets/linux/index.md
+++ b/docs/infrastructure/deployment-targets/linux/index.md
@@ -40,7 +40,7 @@ The following platforms are explicitly supported (we run automated tests against
 - Amazon Linux 2
 - Debian 9.12
 - Fedora 23
-- MacOS 10.15.3
+- MacOS 12.6.3
 - openSUSE 15.1
 - SUSE LES 12 SP5
 - FreeBSD 11.3


### PR DESCRIPTION
After updating the version of OSX used in our build chain, we need to update the version references in our documentation to match.

See https://octopusdeploy.slack.com/archives/C04UP41MCCW