### PR TITLE
Updated event retention released version

### DIFF
--- a/docs/administration/retention-policies/index.md
+++ b/docs/administration/retention-policies/index.md
@@ -63,7 +63,7 @@ When configuring the repository retention policy, it's also worth making note of
 Some items in Octopus are not affected by Retention policies, and are never deleted. One example of this is [Audit logs](/docs/security/users-and-teams/auditing/index.md). Octopus actively [prevents modifying or deleting audit logs](/docs/security/users-and-teams/auditing/index.md#modifying-and-deleting-audit-logs-is-prevented).
 
 :::hint
-From version **Octopus 2022.3** the [Audit Retention functionality](/docs/security/users-and-teams/auditing/index.md#archived-audit-events) will start being rolled out. This **does not** delete audit records. It just moves them from the database to the file system.
+From version **Octopus 2023.1** the [Audit Retention functionality](/docs/security/users-and-teams/auditing/index.md#archived-audit-events) will start being rolled out. This **does not** delete audit records. It just moves them from the database to the file system.
 :::
 
 ## When the retention policies are applied {#when-retention-policies-applied}

--- a/docs/security/users-and-teams/auditing/index.md
+++ b/docs/security/users-and-teams/auditing/index.md
@@ -6,7 +6,7 @@ description: Octopus Deploy captures audit information whenever significant even
 For team members to collaborate in the deployment of software, there needs to be trust and accountability. Octopus Deploy captures audit information whenever significant events happen in the system.
 
 :::hint
-The [Audit Retention functionality](#archived-audit-events) was introduced in **Octopus 2022.3** and will be made available to Cloud customers soon. We will make this available to the on-prem customers later in 2023.
+The [Audit Retention functionality](#archived-audit-events) was introduced in **Octopus 2023.1**.
 :::
 
 ## What does Octopus capture? {#Auditing-WhatdoesOctopuscapture?}
@@ -81,7 +81,7 @@ We take the sensitive value and hash it using an irreversible hash algorithm. We
 ### Archived audit logs {#archived-audit-events}
 
 :::hint
-Audit Retention functionality was introduced in **Octopus 2022.3** and will be made available to Cloud customers soon. We will make this available to the on-prem customers later in 2023.
+Audit Retention functionality was introduced in **Octopus 2023.1**.
 :::
 
 Audit log entries can require a significant amount of database space to store, degrading overall system performance. For this reason, Octopus Server applies a retention policy to automatically archive audit log entries older than the configured number of days and remove them from the database. The retention period can be configured via **{{Configuration, Settings, Event Retention}}**. The location of the archived audit log files can be changed via **{{Configuration, Settings, Server Folders}}**.


### PR DESCRIPTION
Adjust the following small things in the public facing documentation for event retention:

Reduce all references to 'event retention coming soon' or 'in v2022.3' to a version that just references the target version. E.g. "Audit Retention functionality was introduced in Octopus 2023.1"

[sc-38724]