### PR TITLE
Use new registry

### DIFF
--- a/docs/deployments/kubernetes/deploy-container/index.md
+++ b/docs/deployments/kubernetes/deploy-container/index.md
@@ -346,7 +346,7 @@ metadata:
   name: test-ebs
 spec:
   containers:
-  - image: k8s.gcr.io/test-webserver
+  - image: registry.k8s.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-ebs


### PR DESCRIPTION
https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

The reference is probably not real anyway, however we should probably update this just in case.