### PR TITLE
Fixing gh actions serverTaskId retreival

### DIFF
--- a/docs/packaging-applications/build-servers/github-actions.md
+++ b/docs/packaging-applications/build-servers/github-actions.md
@@ -483,7 +483,7 @@ steps:
       OCTOPUS_URL: ${{ secrets.SERVER }}
       OCTOPUS_SPACE: 'Outer Space'
     with:
-      server_task_id: {{ steps.some_previous_deployment_step.outputs.server_tasks[0].server_task_id }}
+      server_task_id: ${{ fromJson(steps.some_previous_deployment_step.outputs.server_tasks)[0].serverTaskId }}
 ```
 
 ### Create Nuget Package


### PR DESCRIPTION
Currently the docs recommend fetching the server_task_id via `{{steps.some_previous_deployment_step.outputs.server_tasks[0].server_task_id }}`. This fails retrieving the task id
![image](https://user-images.githubusercontent.com/101079287/231608429-eb9990c8-bf9f-42a6-9985-8fd015894eb2.png)

The original [GitHub actions blog post](https://octopus.com/blog/github-actions-for-octopus-deploy-v3#all-in-one) recommends the approach below:
`${{fromJson(steps.some_previous_deployment_step.outputs.server_tasks)[0].serverTaskId }}` which works. 

[sc-45926]
https://github.com/OctopusDeploy/await-task-action/pull/19