### PR TITLE
changed release_version to release_number

### DIFF
--- a/docs/packaging-applications/build-servers/github-actions.md
+++ b/docs/packaging-applications/build-servers/github-actions.md
@@ -430,7 +430,7 @@ steps:
       OCTOPUS_SPACE: 'Outer Space'
     with:
       project: 'MyProject'
-      release_version: '1.0.0'
+      release_number: '1.0.0'
       environments: |
         Dev
         Test
@@ -454,7 +454,7 @@ steps:
       OCTOPUS_SPACE: 'Outer Space'
     with:
       project: 'MyProject'
-      release_version: '1.0.0'
+      release_number: '1.0.0'
       environment: 'Dev'
       tenants: |
         'Some Tenant A'


### PR DESCRIPTION
For the Deploy a Release step (Tenanted and Untenanted) release_version isn't a valid parameter and it should be release_number instead

> valid inputs are ['project', 'release_number', 'environments', 'use_guided_failure', 'variables', 'server', 'api_key', 'space']