### PR TITLE
Clarifying cloud target removal conditions.

### DIFF
--- a/docs/infrastructure/deployment-targets/cloud-target-discovery/index.md
+++ b/docs/infrastructure/deployment-targets/cloud-target-discovery/index.md
@@ -161,7 +161,7 @@ We recommend not manually adding targets when using Cloud Target Discovery to av
 When targets are created via Cloud Target Discovery, they are monitored by Octopus. When the cloud resources are removed, Octopus will detect unhealthy targets and remove them periodically.
 
 :::hint
-Server will not remove unhealthy targets immediately. Targets need to fail multiple health checks over a period of at least one hour before they are removed.
+Server will not remove unhealthy targets immediately. Once a target is found to be unhealthy, Server will perform a health check once a minute.  Targets need to fail five health checks in a row before they are removed.   
 :::
 
 ## Examples


### PR DESCRIPTION
Updates the cloud target removal hint with clarifying information regarding what conditions need to be met before removal.