### PR TITLE
Support icons in Kubernetes post

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -1357,6 +1357,30 @@ nav.skip-links a:focus {
     display: inline-block;
 }
 
+.fa-spinner:before {
+    content: '\f110';
+    color: var(--blue-500);
+    font-family: fa-solid;
+}
+
+.fa-circle-check:before {
+    content: '\f058';
+    color: var(--green-400);
+    font-family: fa-solid;
+}
+
+.fa-circle-xmark:before {
+    content: '\f057';
+    color: var(--red-500);
+    font-family: fa-solid;
+}
+
+.fa-clock:before {
+    content: '\f017';
+    color: var(--orange-400);
+    font-family: fa-solid;
+}
+
 .fa-share-nodes:before {
     content: '\f1e0'; /* Share Nodes */
     font-family: fa-solid;

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -35,6 +35,12 @@
     --blue-100: #F2F8FD;
     --blue-qqq: #FAFDFF;
 
+    --green-400: #00AB62;
+
+    --red-500: #D63D3D;
+
+    --orange-400: #EA7325;
+
     --blue-midnight-dark: #070E14FF;
     --blue-midnight-darker: #0A202FFF;
     --blue-midnight: #10212FFF;
@@ -72,11 +78,11 @@
 
     --color-hint: #124164;
     --bgcolor-hint: #e5f4ff;
-    --bordercolor-hint: #0d80d8;
+    --bordercolor-hint: var(--blue-500);
 
     --color-info: #124164;
     --bgcolor-info: #e5f4ff;
-    --bordercolor-info: #0d80d8;
+    --bordercolor-info: var(--blue-500);
 
     --color-success: #04502f;
     --bgcolor-success: #e8ffeb;
@@ -96,7 +102,7 @@
     /* To be checked and cleaned */
 
     
-    --octo-blue: #0D79CE; /* Insufficient contrast for #0D80D8FF; */
+    --octo-blue: var(--blue-500);
     --lightest-blue: #E5F4FFFF;
     --octo-blue-lighter: #2F95E3FF;
     --octo-blue-lightest: #1FC0FFFF;

--- a/src/pages/docs/deployments/kubernetes/kubernetes-object-status/index.md
+++ b/src/pages/docs/deployments/kubernetes/kubernetes-object-status/index.md
@@ -66,12 +66,13 @@ Users can also observe live updates from the cluster on the Kubernetes Object St
 Octopus displays resource status in a respected table for each deployed resource. The table is live during the step execution (till the end of the stabilization period). After that, the table will not get any updates and will remain a snapshot for future reference.
 
 At a given point in time, an object can have one of four statuses:
-| Status Icon | Label                |
-|------|:----------------------------|
-| <i class="fas fa-spinner fs-20 fa-fw" style="color:var(--cyan50);"></i>   | In progress                 |
-| <i class="fas fa-check-circle fs-20 fa-fw" style="color:var(--green60);"></i>    | Success                     |
-| <i class="fas fa-times-circle fs-20 fa-fw" style="color:var(--red60);"></i>    | Error                       |
-| <i class="fas fa-clock fs-20 fa-fw" style="color:var(--orange60);"></i>    | Timed out while in progress |
+
+| Label                       | Status Icon                              |
+|:----------------------------|:----------------------------------------:|
+| In progress                 | <i class="fa-solid fa-spinner"></i>      |
+| Success                     | <i class="fa-solid fa-circle-check"></i> |
+| Error                       | <i class="fa-solid fa-circle-xmark"></i> |
+| Timed out while in progress | <i class="fa-solid fa-clock"></i>        |
 
 If there are multiple steps in deploying Kubernetes resources, each step will have a separate section on the tab.
 


### PR DESCRIPTION
Supports the icons on the Kubernetes object status page.

![Icon table](https://github.com/OctopusDeploy/docs/assets/99181436/ed8c04d1-65c1-4016-9d26-2c487f832729)
