### PR TITLE
EventExports Directory Documentation

### DIFF
--- a/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
@@ -63,7 +63,7 @@ After the Octopus Server has been configured, from Octopus Manager copy the Mast
 
 Finally, you need to tell Octopus to store artifacts, packages, task logs, imports, and event exports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -94,7 +94,7 @@ Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
 Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
 ```
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
@@ -90,9 +90,6 @@ Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
 Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
 Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 ```
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 Note that all paths are not required to be in the same file share(s).
 

--- a/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
@@ -63,10 +63,6 @@ After the Octopus Server has been configured, from Octopus Manager copy the Mast
 
 Finally, you need to tell Octopus to store artifacts, packages, task logs, imports, and event exports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ### Configure shared storage
 
 There are two options for configuring shared storage: 

--- a/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
@@ -91,8 +91,8 @@ Octopus.Server.exe path --artifacts \\Octoshared\OctopusData\Artifacts
 Octopus.Server.exe path --taskLogs \\Octoshared\OctopusData\TaskLogs
 Octopus.Server.exe path --nugetRepository \\Octoshared\OctopusData\Packages
 Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
-Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
+Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 ```
 :::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.

--- a/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-with-active-directory.md
@@ -61,7 +61,11 @@ After the Octopus Server has been configured, from Octopus Manager copy the Mast
 ![](/docs/administration/high-availability/configure/images/wizard-master-key.png "width=500")
 :::
 
-Finally, you need to tell Octopus to store artifacts, packages, task logs, and imports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line.
+Finally, you need to tell Octopus to store artifacts, packages, task logs, imports, and event exports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ### Configure shared storage
 
@@ -88,7 +92,11 @@ Octopus.Server.exe path --taskLogs \\Octoshared\OctopusData\TaskLogs
 Octopus.Server.exe path --nugetRepository \\Octoshared\OctopusData\Packages
 Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
 Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
+Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
 ```
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Note that all paths are not required to be in the same file share(s).
 

--- a/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
@@ -61,7 +61,11 @@ After the Octopus Server has been configured, from Octopus Manager copy the Mast
 ![](/docs/administration/high-availability/configure/images/wizard-master-key.png "width=500")
 :::
 
-Finally, you need to tell Octopus to store artifacts, packages, task logs, and imports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line:
+Finally, you need to tell Octopus to store artifacts, packages, task logs, imports, and event exports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line:
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ### Configure shared storage
 
@@ -87,7 +91,11 @@ Octopus.Server.exe path --taskLogs \\Octoshared\OctopusData\TaskLogs
 Octopus.Server.exe path --nugetRepository \\Octoshared\OctopusData\Packages
 Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
 Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
+Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
 ```
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Note that all paths are not required to be in the same file share(s).
 

--- a/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
@@ -90,8 +90,8 @@ Octopus.Server.exe path --artifacts \\Octoshared\OctopusData\Artifacts
 Octopus.Server.exe path --taskLogs \\Octoshared\OctopusData\TaskLogs
 Octopus.Server.exe path --nugetRepository \\Octoshared\OctopusData\Packages
 Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
-Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
+Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 ```
 :::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.

--- a/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
@@ -63,10 +63,6 @@ After the Octopus Server has been configured, from Octopus Manager copy the Mast
 
 Finally, you need to tell Octopus to store artifacts, packages, task logs, imports, and event exports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line:
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ### Configure shared storage
 
 There are two options for configuring shared storage: 

--- a/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
@@ -63,7 +63,7 @@ After the Octopus Server has been configured, from Octopus Manager copy the Mast
 
 Finally, you need to tell Octopus to store artifacts, packages, task logs, imports, and event exports in the shared storage that you provisioned, that way each Octopus node can see the same files. To do this, you need to use the command-line:
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -93,7 +93,7 @@ Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
 Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
 ```
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
+++ b/src/pages/docs/administration/high-availability/configure/octopus-without-active-directory.md
@@ -89,9 +89,6 @@ Octopus.Server.exe path --imports \\Octoshared\OctopusData\Imports
 Octopus.Server.exe path --eventExports \\Octoshared\OctopusData\EventExports
 Octopus.Server.exe path --telemetry \\Octoshared\OctopusData\Telemetry
 ```
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 Note that all paths are not required to be in the same file share(s).
 

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
@@ -78,10 +78,6 @@ If your Octopus Server is running in Microsoft Azure, there is only one solution
 
 After you have created your File Share, the best option is to add the Azure File Share as a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\Octopus\` for the Artifacts, Packages, TaskLogs, Imports and EventExports which need to be available to all nodes.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 Run the PowerShell below before installing Octopus, substituting the placeholders with your own values:
 
 ```powershell

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
@@ -97,10 +97,6 @@ New-Item -Path C:\Octopus\Packages -ItemType SymbolicLink -Value \\octostorage.f
 New-Item -Path C:\Octopus\Imports -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\Imports
 New-Item -Path C:\Octopus\EventExports -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\EventExports
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ```
 :::div{.hint}
 It's worth noting that you need to have created the folders within the Azure File Share first before trying to create the Symbolic Links. 
@@ -116,10 +112,6 @@ It's worth noting that you need to have created the folders within the Azure Fil
 & 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --imports "C:\Octopus\Imports"
 & 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --eventExports "C:\Octopus\EventExports"
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 ### Load balancing in Azure
 

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
@@ -78,7 +78,7 @@ If your Octopus Server is running in Microsoft Azure, there is only one solution
 
 After you have created your File Share, the best option is to add the Azure File Share as a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\Octopus\` for the Artifacts, Packages, TaskLogs, Imports and EventExports which need to be available to all nodes.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -101,7 +101,7 @@ New-Item -Path C:\Octopus\Packages -ItemType SymbolicLink -Value \\octostorage.f
 New-Item -Path C:\Octopus\Imports -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\Imports
 New-Item -Path C:\Octopus\EventExports -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\EventExports
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -121,7 +121,7 @@ It's worth noting that you need to have created the folders within the Azure Fil
 & 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --eventExports "C:\Octopus\EventExports"
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-azure.mdx
@@ -76,7 +76,11 @@ If your Octopus Server is running in Microsoft Azure, you can use [Azure Files](
 
 If your Octopus Server is running in Microsoft Azure, there is only one solution unless you have a [DFS Replica](https://docs.microsoft.com/windows-server/storage/dfs-replication/dfsr-overview) in Azure. That solution is [Azure Files](https://docs.microsoft.com/azure/storage/files/storage-files-introduction) which presents a file share over SMB 3.0 that can be shared across all of your Octopus servers.
 
-After you have created your File Share, the best option is to add the Azure File Share as a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\Octopus\` for the Artifacts, Packages, TaskLogs and Imports which need to be available to all nodes.
+After you have created your File Share, the best option is to add the Azure File Share as a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\Octopus\` for the Artifacts, Packages, TaskLogs, Imports and EventExports which need to be available to all nodes.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Run the PowerShell below before installing Octopus, substituting the placeholders with your own values:
 
@@ -95,6 +99,11 @@ New-Item -Path C:\Octopus\TaskLogs -ItemType SymbolicLink -Value \\octostorage.f
 New-Item -Path C:\Octopus\Artifacts -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\Artifacts
 New-Item -Path C:\Octopus\Packages -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\Packages
 New-Item -Path C:\Octopus\Imports -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\Imports
+New-Item -Path C:\Octopus\EventExports -ItemType SymbolicLink -Value \\octostorage.file.core.windows.net\octoha\EventExports
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ```
 :::div{.hint}
@@ -109,7 +118,12 @@ It's worth noting that you need to have created the folders within the Azure Fil
 & 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --taskLogs "C:\Octopus\TaskLogs"
 & 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --nugetRepository "C:\Octopus\Packages"
 & 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --imports "C:\Octopus\Imports"
+& 'C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe' path --eventExports "C:\Octopus\EventExports"
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ### Load balancing in Azure
 

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
@@ -150,10 +150,7 @@ Before installing Octopus, follow the steps below *on each* Compute engine insta
        New-Item -Path $EventExportsFolder -ItemType SymbolicLink -Value "$SmbShare\EventExports"
    }
    ```
-   :::div{.hint}
-   EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-   :::
-
+   
    :::div{.hint}
    Remember to create the folders in the SMB share before trying to create the symbolic links.
    :::
@@ -168,10 +165,6 @@ Once you've completed those steps, [install Octopus](/docs/installation/) and th
 --imports "C:\OctopusShared\Imports" `
 --eventExports "C:\OctopusShared\EventExports"
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 :::div{.hint}
 Changing the path only needs to be done once, and not on each node as the values are stored in the database.
@@ -332,10 +325,7 @@ Before installing Octopus, follow the steps below *on each* Compute engine insta
        New-Item -Path $EventExportsFolder -ItemType SymbolicLink -Value "$NfsShare\EventExports"
    }
    ```
-   :::div{.hint}
-   EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-   :::
-
+   
    :::div{.hint}
    Remember to create the folders in the NFS share before trying to create the symbolic links.
    :::
@@ -350,9 +340,6 @@ Once you've completed those steps, [install Octopus](/docs/installation/) and th
 --imports "C:\OctopusShared\Imports" `
 --eventExports "C:\OctopusShared\EventExports"
 ```
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 :::div{.hint}
 Changing the path only needs to be done once, and not on each node as the values are stored in the database.

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
@@ -92,7 +92,7 @@ To successfully create a NetApp Cloud SMB Volume in Google Cloud, you must have 
 
 Once you have configured your NetApp Cloud SMB Volume, the best option is to mount the SMB share and then create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\OctopusShared\` for the Artifacts, Packages, TaskLogs, Imports, and EventExports folders which need to be available to all nodes.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -354,7 +354,7 @@ Once you've completed those steps, [install Octopus](/docs/installation/) and th
 --imports "C:\OctopusShared\Imports" `
 --eventExports "C:\OctopusShared\EventExports"
 ```
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
@@ -92,10 +92,6 @@ To successfully create a NetApp Cloud SMB Volume in Google Cloud, you must have 
 
 Once you have configured your NetApp Cloud SMB Volume, the best option is to mount the SMB share and then create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\OctopusShared\` for the Artifacts, Packages, TaskLogs, Imports, and EventExports folders which need to be available to all nodes.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 Before installing Octopus, follow the steps below *on each* Compute engine instance to mount your SMB share.
 
 1. In the Google Cloud Console, go to the [Volumes](https://console.cloud.google.com/netapp/cloud-volumes/volumes) page.

--- a/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
+++ b/src/pages/docs/administration/high-availability/design/octopus-for-high-availability-on-gcp.mdx
@@ -90,7 +90,11 @@ You can see the different file server options Google Cloud has in their [File St
 To successfully create a NetApp Cloud SMB Volume in Google Cloud, you must have an Active Directory service that can be used to connect to the SMB volume. Please see the [creating and managing SMB volumes](https://cloud.google.com/architecture/partners/netapp-cloud-volumes/creating-smb-volumes) for further information. It's also worth reviewing the [security considerations for SMB access](https://cloud.google.com/architecture/partners/netapp-cloud-volumes/security-considerations) too.
 :::
 
-Once you have configured your NetApp Cloud SMB Volume, the best option is to mount the SMB share and then create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\OctopusShared\` for the Artifacts, Packages, TaskLogs, and Imports folders which need to be available to all nodes.
+Once you have configured your NetApp Cloud SMB Volume, the best option is to mount the SMB share and then create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\OctopusShared\` for the Artifacts, Packages, TaskLogs, Imports, and EventExports folders which need to be available to all nodes.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Before installing Octopus, follow the steps below *on each* Compute engine instance to mount your SMB share.
 
@@ -102,11 +106,11 @@ Before installing Octopus, follow the steps below *on each* Compute engine insta
 
 4. Follow the instructions in the **Mount Instructions for SMB window** that appears.
 
-5. Create folders in your **SMB share** for the Artifacts, Packages, TaskLogs, and Imports.
+5. Create folders in your **SMB share** for the Artifacts, Packages, TaskLogs, Imports, and EventExports.
 
    ![Create folders in your SMB share](/docs/administration/high-availability/design/images/smb-create-folders.png "width=500")
 
-6. Create the symbolic links for the Artifacts, Packages, TaskLogs, and Imports folders.
+6. Create the symbolic links for the Artifacts, Packages, TaskLogs, Imports, and EventExports folders.
 
    Run the following PowerShell script, substituting the placeholder values with your own:
 
@@ -144,7 +148,16 @@ Before installing Octopus, follow the steps below *on each* Compute engine insta
    if (-not (Test-Path -Path $ImportsFolder)) {
        New-Item -Path $ImportsFolder -ItemType SymbolicLink -Value "$SmbShare\Imports"
    }
+
+   $EventExportsFolder = Join-Path -Path $LocalFolder -ChildPath "EventExports"
+   if (-not (Test-Path -Path $EventExportsFolder)) {
+       New-Item -Path $EventExportsFolder -ItemType SymbolicLink -Value "$SmbShare\EventExports"
+   }
    ```
+   :::div{.hint}
+   EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+   :::
+
    :::div{.hint}
    Remember to create the folders in the SMB share before trying to create the symbolic links.
    :::
@@ -156,8 +169,13 @@ Once you've completed those steps, [install Octopus](/docs/installation/) and th
 --artifacts "C:\OctopusShared\Artifacts" `
 --nugetRepository "C:\OctopusShared\Packages" `
 --taskLogs "C:\OctopusShared\TaskLogs" `
---imports "C:\OctopusShared\Imports"
+--imports "C:\OctopusShared\Imports" `
+--eventExports "C:\OctopusShared\EventExports"
 ```
+
+:::div{.hint}
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 :::div{.hint}
 Changing the path only needs to be done once, and not on each node as the values are stored in the database.
@@ -165,7 +183,7 @@ Changing the path only needs to be done once, and not on each node as the values
 
 #### Filestore using NFS
 
-Once you have [created a Filestore instance](https://cloud.google.com/filestore/docs/creating-instances), the best option is to mount the NFS share using the `LocalSystem` account, and then create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\OctopusShared\` for the Artifacts, Packages, TaskLogs, and Imports folders which need to be available to all nodes.
+Once you have [created a Filestore instance](https://cloud.google.com/filestore/docs/creating-instances), the best option is to mount the NFS share using the `LocalSystem` account, and then create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link) pointing at a local folder, for example `C:\OctopusShared\` for the Artifacts, Packages, TaskLogs, Imports, and EventExports folders which need to be available to all nodes.
 
 Before installing Octopus, follow the steps below *on each* Compute engine instance to mount your NFS share.
 
@@ -276,9 +294,9 @@ Before installing Octopus, follow the steps below *on each* Compute engine insta
    This is in effect the same when using the [watchdog](/docs/octopus-rest-api/octopus.server.exe-command-line/watchdog) command to configure a scheduled task to monitor the Octopus Server service.
    :::
 
-6. Create folders in your **NFS share** for the Artifacts, Packages, TaskLogs, and Imports.
+6. Create folders in your **NFS share** for the Artifacts, Packages, TaskLogs, Imports, and EventExports.
 
-7. Create the symbolic links for the Artifacts, Packages, TaskLogs, and Imports folders.
+7. Create the symbolic links for the Artifacts, Packages, TaskLogs, Imports, and EventExports folders.
 
    Run the following PowerShell script, substituting the placeholder values with your own:
    
@@ -312,7 +330,16 @@ Before installing Octopus, follow the steps below *on each* Compute engine insta
    if (-not (Test-Path -Path $ImportsFolder)) {
        New-Item -Path $ImportsFolder -ItemType SymbolicLink -Value "$NfsShare\Imports"
    }
+
+   $EventExportsFolder = Join-Path -Path $LocalFolder -ChildPath "EventExports"
+   if (-not (Test-Path -Path $EventExportsFolder)) {
+       New-Item -Path $EventExportsFolder -ItemType SymbolicLink -Value "$NfsShare\EventExports"
+   }
    ```
+   :::div{.hint}
+   EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+   :::
+
    :::div{.hint}
    Remember to create the folders in the NFS share before trying to create the symbolic links.
    :::
@@ -324,8 +351,12 @@ Once you've completed those steps, [install Octopus](/docs/installation/) and th
 --artifacts "C:\OctopusShared\Artifacts" `
 --nugetRepository "C:\OctopusShared\Packages" `
 --taskLogs "C:\OctopusShared\TaskLogs" `
---imports "C:\OctopusShared\Imports"
+--imports "C:\OctopusShared\Imports" `
+--eventExports "C:\OctopusShared\EventExports"
 ```
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 :::div{.hint}
 Changing the path only needs to be done once, and not on each node as the values are stored in the database.

--- a/src/pages/docs/administration/high-availability/migrate/index.mdx
+++ b/src/pages/docs/administration/high-availability/migrate/index.mdx
@@ -13,7 +13,7 @@ import LoadBalancerEndpointInfo from 'src/shared-content/administration/load-bal
 You may already have an existing Octopus Server that you wish to make highly available. The process to migrate to Octopus High Availability is the same as the process detailed in [Configuring High Availability for Octopus](/docs/administration/high-availability/configure), except your existing server will be the **first node** in the cluster.  Migrating to HA will involve:
 
 1. Moving the SQL Server Database to a dedicated SQL Server.
-1. Moving all the task logs, packages, artifacts, imports etc., to a shared storage folder (BLOB data).
+1. Moving all the task logs, packages, artifacts, imports, event exports etc., to a shared storage folder (BLOB data).
 1. Configuring a load balancer.
 
 This guide is generic and purposely avoids mentioning specific technologies such as Azure File Storage, AWS RDS SQL Server, etc.  Please refer to the guide matching your hosting solution for specifics.
@@ -67,7 +67,7 @@ You can run that script using the Octopus Deploy [script console](/docs/administ
 
 ### Moving BLOB data
 
-Most of the BLOB data (task logs, artifacts, packages, imports etc) stored on the file system can be copied to the new location prior to the outage window.  Doing so will reduce the amount of copying you have to do during the outage windows.  In addition, you can make sure your Octopus Deploy instance can use that shared location by running a test script to create and delete a file.  
+Most of the BLOB data (task logs, artifacts, packages, imports, event exports etc) stored on the file system can be copied to the new location prior to the outage window.  Doing so will reduce the amount of copying you have to do during the outage windows.  In addition, you can make sure your Octopus Deploy instance can use that shared location by running a test script to create and delete a file.  
 
 - Provision the shared storage folder.
 - If you are going to create a symbolic link to that shared folder, do that now.
@@ -88,7 +88,11 @@ robocopy C:\Octopus\TaskLogs \\YOURFILESHARE\OctopusHA\TaskLogs /mir /r:5
 robocopy C:\Octopus\Artifacts \\YOURFILESHARE\OctopusHA\Artifacts /mir /r:5
 robocopy C:\Octopus\Packages \\YOURFILESHARE\OctopusHA\Packages /mir /r:5
 robocopy C:\Octopus\Imports \\YOURFILESHARE\OctopusHA\Imports /mir /r:5
+robocopy C:\Octopus\EventExports \\YOURFILESHARE\OctopusHA\EventExports /mir /r:5
 ```
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ### Configure load balancer
 
@@ -138,7 +142,12 @@ $filePath = "YOUR ROOT DIRECTORY"
 & .\Octopus.Server.exe path --nugetRepository "$filePath\Packages"
 & .\Octopus.Server.exe path --imports "$filePath\Imports"
 & .\Octopus.Server.exe path --telemetry "$filePath\Telemetry"
+& .\Octopus.Server.exe path --eventExports "$filePath\EventExports"
 ```
+
+:::div{.hint}
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 :::div{.hint}
 Your version might not have all the above paths.  Remove them from the script if you are running an older version of Octopus.

--- a/src/pages/docs/administration/high-availability/migrate/index.mdx
+++ b/src/pages/docs/administration/high-availability/migrate/index.mdx
@@ -141,8 +141,8 @@ $filePath = "YOUR ROOT DIRECTORY"
 & .\Octopus.Server.exe path --taskLogs "$filePath\TaskLogs"
 & .\Octopus.Server.exe path --nugetRepository "$filePath\Packages"
 & .\Octopus.Server.exe path --imports "$filePath\Imports"
-& .\Octopus.Server.exe path --telemetry "$filePath\Telemetry"
 & .\Octopus.Server.exe path --eventExports "$filePath\EventExports"
+& .\Octopus.Server.exe path --telemetry "$filePath\Telemetry"
 ```
 
 :::div{.hint}

--- a/src/pages/docs/administration/high-availability/migrate/index.mdx
+++ b/src/pages/docs/administration/high-availability/migrate/index.mdx
@@ -90,9 +90,6 @@ robocopy C:\Octopus\Packages \\YOURFILESHARE\OctopusHA\Packages /mir /r:5
 robocopy C:\Octopus\Imports \\YOURFILESHARE\OctopusHA\Imports /mir /r:5
 robocopy C:\Octopus\EventExports \\YOURFILESHARE\OctopusHA\EventExports /mir /r:5
 ```
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 ### Configure load balancer
 
@@ -144,10 +141,6 @@ $filePath = "YOUR ROOT DIRECTORY"
 & .\Octopus.Server.exe path --eventExports "$filePath\EventExports"
 & .\Octopus.Server.exe path --telemetry "$filePath\Telemetry"
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 :::div{.hint}
 Your version might not have all the above paths.  Remove them from the script if you are running an older version of Octopus.

--- a/src/pages/docs/administration/high-availability/migrate/index.mdx
+++ b/src/pages/docs/administration/high-availability/migrate/index.mdx
@@ -90,7 +90,7 @@ robocopy C:\Octopus\Packages \\YOURFILESHARE\OctopusHA\Packages /mir /r:5
 robocopy C:\Octopus\Imports \\YOURFILESHARE\OctopusHA\Imports /mir /r:5
 robocopy C:\Octopus\EventExports \\YOURFILESHARE\OctopusHA\EventExports /mir /r:5
 ```
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
@@ -34,7 +34,7 @@ Below are instructions on how to move your Octopus Server and SQL Database.
    - Task Logs
    - Packages
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
-   - Event Exports (available from Octopus **2023.3**)
+   - Event Exports
 
 :::div{.warning}
 The database stores the locations for these directories. After you connect to the database, your settings will be the same as they were in your original server. You can change the locations for these directories, but we recommend first moving the directories to there original location and then pointing to the new location. This process is outlined in the [moving the home directory](/docs/administration/managing-infrastructure/moving-your-octopus/move-the-home-directory) page.

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
@@ -40,7 +40,7 @@ Below are instructions on how to move your Octopus Server and SQL Database.
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
    - Event Exports
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
@@ -14,10 +14,6 @@ You may need to move your Octopus installation of Server and database. The follo
 - Data that is stored in the file system needs to be moved over to the new server. These are your packages stored in the built-in package repository, your artifacts (includes project logos), your Task Logs, and your Event Exports.
 - Tentacle thumbprints are stored in the database. If you're using the same database, you won't need to re-configure your Tentacles.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 :::div{.warning}
 **You can only move your Octopus Server installation to the same Octopus version, you cannot move to an upgraded version.** Either upgrade your existing Octopus Server version, then move the Server and files, or move and then upgrade on the new server. Please refer to our [upgrading guides](/docs/administration/upgrading) for applicable information for your scenario.
 :::

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
@@ -14,6 +14,10 @@ You may need to move your Octopus installation of Server and database. The follo
 - Data that is stored in the file system needs to be moved over to the new server. These are your packages stored in the built-in package repository, your artifacts (includes project logos), and your Task Logs.
 - Tentacle thumbprints are stored in the database. If you're using the same database, you won't need to re-configure your Tentacles.
 
+:::div{.hint}
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
+
 :::div{.warning}
 **You can only move your Octopus Server installation to the same Octopus version, you cannot move to an upgraded version.** Either upgrade your existing Octopus Server version, then move the Server and files, or move and then upgrade on the new server. Please refer to our [upgrading guides](/docs/administration/upgrading) for applicable information for your scenario.
 :::
@@ -34,6 +38,11 @@ Below are instructions on how to move your Octopus Server and SQL Database.
    - Task Logs
    - Packages
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
+   - Event Exports
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 :::div{.warning}
 The database stores the locations for these directories. After you connect to the database, your settings will be the same as they were in your original server. You can change the locations for these directories, but we recommend first moving the directories to there original location and then pointing to the new location. This process is outlined in the [moving the home directory](/docs/administration/managing-infrastructure/moving-your-octopus/move-the-home-directory) page.

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
@@ -36,10 +36,6 @@ Below are instructions on how to move your Octopus Server and SQL Database.
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
    - Event Exports (available from Octopus **2023.3**)
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 :::div{.warning}
 The database stores the locations for these directories. After you connect to the database, your settings will be the same as they were in your original server. You can change the locations for these directories, but we recommend first moving the directories to there original location and then pointing to the new location. This process is outlined in the [moving the home directory](/docs/administration/managing-infrastructure/moving-your-octopus/move-the-home-directory) page.
 :::

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-database-and-server.md
@@ -11,7 +11,7 @@ You may need to move your Octopus installation of Server and database. The follo
 
 ## Before you move your Octopus instance
 - You will need your Master Key in order for your new Octopus installation to connect to your existing database. You can retrieve and save a copy of the [Master Key](/docs/security/data-encryption) in the Octopus Manager.
-- Data that is stored in the file system needs to be moved over to the new server. These are your packages stored in the built-in package repository, your artifacts (includes project logos), and your Task Logs.
+- Data that is stored in the file system needs to be moved over to the new server. These are your packages stored in the built-in package repository, your artifacts (includes project logos), your Task Logs, and your Event Exports.
 - Tentacle thumbprints are stored in the database. If you're using the same database, you won't need to re-configure your Tentacles.
 
 :::div{.hint}

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
@@ -32,7 +32,7 @@ You may want to move only the Octopus Server itself, and continue using your exi
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
    - Event Exports
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
@@ -11,7 +11,7 @@ You may want to move only the Octopus Server itself, and continue using your exi
 
 ## Before you move your Octopus instance
 - You will need your Master Key in order for your new Octopus installation to connect to your existing database. You can retrieve and save a copy of the [Master Key](/docs/security/data-encryption) in the Octopus Manager.
-- Data that is stored in the file system needs to be moved over to the new server. These are your packages stored in the built-in package repository, your artifacts (includes project logos), and your Task Logs.
+- Data that is stored in the file system needs to be moved over to the new server. These are your packages stored in the built-in package repository, your artifacts (includes project logos), your archived events, and your Task Logs.
 - Tentacle thumbprints are stored in the database. If you're using the same database, you won't need to re-configure your Tentacles.
 
 :::div{.warning}
@@ -30,6 +30,12 @@ You may want to move only the Octopus Server itself, and continue using your exi
    - Task Logs
    - Packages
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
+   - Event Exports
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
+
 6. Finally, restart your new Octopus instance to index the packages. You can restart either in your Octopus Manager, or via the command line with the following command.
 ```
 Octopus.Server.exe service --stop

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
@@ -30,7 +30,7 @@ You may want to move only the Octopus Server itself, and continue using your exi
    - Task Logs
    - Packages
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
-   - Event Exports (available from Octopus **2023.3**)
+   - Event Exports
 6. Finally, restart your new Octopus instance to index the packages. You can restart either in your Octopus Manager, or via the command line with the following command.
 ```
 Octopus.Server.exe service --stop

--- a/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
+++ b/src/pages/docs/administration/managing-infrastructure/moving-your-octopus/move-the-server.md
@@ -31,11 +31,6 @@ You may want to move only the Octopus Server itself, and continue using your exi
    - Packages
       - This folder only needs to be moved if using the built-in package repository. External feed details are stored in the database, and they will connect automatically.
    - Event Exports (available from Octopus **2023.3**)
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 6. Finally, restart your new Octopus instance to index the packages. You can restart either in your Octopus Manager, or via the command line with the following command.
 ```
 Octopus.Server.exe service --stop

--- a/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
@@ -46,11 +46,9 @@ The Octopus Server stores files in the following folders by default:
     - This is where all performance and other temporal telemetry files are stored.
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Telemetry) on how to move the Octopus Server telemetry folder
 - `C:\Octopus\Imports`
-    - This folder was added in **Octopus 2021.1**
     - This is where imported zip files are stored when using the [Export/Import Projects feature](/docs/projects/export-import).
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Imports) on how to move the Octopus Server imports folder
 - `C:\Octopus\EventExports`
-    - This folder was added in **Octopus 2023.3**
     - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/security/users-and-teams/auditing/#archived-audit-events).
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-EventExports) on how to move the Octopus Server event exports folder
 

--- a/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
@@ -47,21 +47,12 @@ The Octopus Server stores files in the following folders by default:
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Telemetry) on how to move the Octopus Server telemetry folder
 - `C:\Octopus\Imports`
     - This folder was added in **Octopus 2021.1**
-<<<<<<< HEAD:src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
     - This is where imported zip files are stored when using the [Export/Import Projects feature](/docs/projects/export-import).
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Imports) on how to move the Octopus Server imports folder
 - `C:\Octopus\EventExports`
     - This folder was added in **Octopus 2023.3**
     - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-EventExports) on how to move the Octopus Server event exports folder
-=======
-    - This is where imported zip files are stored when using the [Export/Import Projects feature](/docs/projects/export-import/index.md).
-    - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders.md#MovingOctopusServerfolders-Imports) on how to move the Octopus Server imports folder
-- `C:\Octopus\EventExports`
-    - This folder was added in **Octopus 2023.3**
-    - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
-    - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders.md#MovingOctopusServerfolders-EventExports) on how to move the Octopus Server event exports folder
->>>>>>> 37c515d99 (First cut at adding event exports):docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
 
 ## Clean up post-2.6 migration {#ServerconfigurationandFilestorage-CleanUpCleanuppost-2.6migration}
 

--- a/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
@@ -51,7 +51,7 @@ The Octopus Server stores files in the following folders by default:
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Imports) on how to move the Octopus Server imports folder
 - `C:\Octopus\EventExports`
     - This folder was added in **Octopus 2023.3**
-    - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
+    - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/security/users-and-teams/auditing/#archived-audit-events).
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-EventExports) on how to move the Octopus Server event exports folder
 
 ## Clean up post-2.6 migration {#ServerconfigurationandFilestorage-CleanUpCleanuppost-2.6migration}

--- a/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
@@ -47,8 +47,21 @@ The Octopus Server stores files in the following folders by default:
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Telemetry) on how to move the Octopus Server telemetry folder
 - `C:\Octopus\Imports`
     - This folder was added in **Octopus 2021.1**
+<<<<<<< HEAD:src/pages/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
     - This is where imported zip files are stored when using the [Export/Import Projects feature](/docs/projects/export-import).
     - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-Imports) on how to move the Octopus Server imports folder
+- `C:\Octopus\EventExports`
+    - This folder was added in **Octopus 2023.3**
+    - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
+    - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders/#MovingOctopusServerfolders-EventExports) on how to move the Octopus Server event exports folder
+=======
+    - This is where imported zip files are stored when using the [Export/Import Projects feature](/docs/projects/export-import/index.md).
+    - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders.md#MovingOctopusServerfolders-Imports) on how to move the Octopus Server imports folder
+- `C:\Octopus\EventExports`
+    - This folder was added in **Octopus 2023.3**
+    - This is where audit log archive zip files are stored when using the [Archived audit logs feature](/docs/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
+    - See this [page](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/moving-octopus-server-folders.md#MovingOctopusServerfolders-EventExports) on how to move the Octopus Server event exports folder
+>>>>>>> 37c515d99 (First cut at adding event exports):docs/administration/managing-infrastructure/server-configuration-and-file-storage/index.md
 
 ## Clean up post-2.6 migration {#ServerconfigurationandFilestorage-CleanUpCleanuppost-2.6migration}
 

--- a/src/pages/docs/administration/private-cloud-migration/index.md
+++ b/src/pages/docs/administration/private-cloud-migration/index.md
@@ -133,6 +133,7 @@ A complete migration involves:
 1. Copying task logs to the cloud based file storage.
 1. Copying built-in feed packages to the cloud based file storage.
 1. Copying artifacts to the cloud based file storage.
+1. Copying archived events to the cloud based file storage.
 1. Installing Octopus on your chosen hosting platform (e.g. a virtual machine or container orchestration platform).
 1. Pointing the cloud Octopus instance to the cloud based database.
 1. Reindexing the packages in the built-in feed.
@@ -140,6 +141,10 @@ A complete migration involves:
     1. Reregistering polling tentacles to point to the cloud instance.
     1. Pointing CI servers and external scripts to the cloud instance.
     1. Updating firewall rules to allow the cloud instance to connect to listening tentacles.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 This process is documented in more detail under [Moving your Octopus components to other servers](/docs/administration/managing-infrastructure/moving-your-octopus).
 

--- a/src/pages/docs/administration/private-cloud-migration/index.md
+++ b/src/pages/docs/administration/private-cloud-migration/index.md
@@ -142,10 +142,6 @@ A complete migration involves:
     1. Pointing CI servers and external scripts to the cloud instance.
     1. Updating firewall rules to allow the cloud instance to connect to listening tentacles.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 This process is documented in more detail under [Moving your Octopus components to other servers](/docs/administration/managing-infrastructure/moving-your-octopus).
 
 Choose a complete migration when:

--- a/src/pages/docs/administration/private-cloud-migration/index.md
+++ b/src/pages/docs/administration/private-cloud-migration/index.md
@@ -142,7 +142,7 @@ A complete migration involves:
     1. Pointing CI servers and external scripts to the cloud instance.
     1. Updating firewall rules to allow the cloud instance to connect to listening tentacles.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/upgrading/guide/automate-upgrades.mdx
+++ b/src/pages/docs/administration/upgrading/guide/automate-upgrades.mdx
@@ -163,10 +163,6 @@ Write-Output "Server MSI installer returned exit code $msiExitCode"
 Remove-Item "$downloadDirectory\$msiFilename"
 ```
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ## Upgrading High Availability Octopus Deploy instances
 
 Automating the upgrade of a Highly Available Octopus Deploy instance requires more than a single script.  A degree of coordination is required to update all the nodes.  In addition, specific actions, backing up the database, upgrading the database, enabling / disabling maintenance mode should only happen once.   
@@ -328,10 +324,6 @@ if ($versionSplit[0] -ne $upgradeSplit[1])
     }
 }
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 **4. Stop all nodes (HAServer).**
 

--- a/src/pages/docs/administration/upgrading/guide/automate-upgrades.mdx
+++ b/src/pages/docs/administration/upgrading/guide/automate-upgrades.mdx
@@ -104,6 +104,12 @@ if ($versionSplit[0] -ne $upgradeSplit[0])
     {
         Throw "Unable to copy files to $fileBackupLocation\Packages"
     }
+
+    $msiExitCode = (Start-Process -FilePath "robocopy" -ArgumentList "$($serverFolders.EventExportsDirectory) $fileBackupLocation\EventExports /mir" -Wait -Passthru).ExitCode
+    if ($msiExitCode -ge 8) 
+    {
+        Throw "Unable to copy files to $fileBackupLocation\EventExports"
+    }
 }
 
 # Finish any remaining tasks and stop the service
@@ -156,6 +162,10 @@ Write-Output "Server MSI installer returned exit code $msiExitCode"
 
 Remove-Item "$downloadDirectory\$msiFilename"
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ## Upgrading High Availability Octopus Deploy instances
 
@@ -310,8 +320,18 @@ if ($versionSplit[0] -ne $upgradeSplit[1])
     {
         Throw "Unable to copy files to $filebackUpFolder\Packages"
     }
+
+    $msiExitCode = (Start-Process -FilePath "robocopy" -ArgumentList "$($serverFolders.EventExportsDirectory) $filebackUpFolder\EventExports /mir" -Wait -Passthru).ExitCode
+    if ($msiExitCode -ge 8) 
+    {
+        Throw "Unable to copy files to $filebackUpFolder\EventExports"
+    }
 }
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 **4. Stop all nodes (HAServer).**
 

--- a/src/pages/docs/administration/upgrading/guide/automate-upgrades.mdx
+++ b/src/pages/docs/administration/upgrading/guide/automate-upgrades.mdx
@@ -163,7 +163,7 @@ Write-Output "Server MSI installer returned exit code $msiExitCode"
 Remove-Item "$downloadDirectory\$msiFilename"
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -329,7 +329,7 @@ if ($versionSplit[0] -ne $upgradeSplit[1])
 }
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/upgrading/index.mdx
+++ b/src/pages/docs/administration/upgrading/index.mdx
@@ -55,9 +55,13 @@ The Windows Service is split across multiple folders to make upgrading easy and 
 - **SQL Server Database**: Since `Octopus Deploy 3.x`, the back-end database has been SQL Server.  Each update can contain 0 to N database scripts embedded in a .dll in the install location.  The **Octopus Manager** invokes those database scripts automatically.
 - **Home Folder**: The home folder stores configuration, logs, and other items unique to your instance.  The home folder is separate from the install location to make it easier to upgrade, downgrade, uninstall/reinstall without affecting your instance.  The default location of the home folder is `C:\Octopus`.  Except in rare cases, this folder is left unchanged by the upgrade process.
 - **Instance Information**: The Octopus Deploy Manager allows you to configure 1 to N instances per Windows Server.  The **Octopus Manager** stores a list of all the instances in the `C:\ProgramData\Octopus\OctopusServer\Instances` folder.   Except in rare cases, this folder is left unchanged by the upgrade process.  
-- **Server Folders**: Logs, artifacts, and packages are too big for Octopus Deploy to store in a SQL Server database.  The server folders are subfolders in `C:\Octopus\`.  Except in rare cases, these folders are left unchanged by an upgrade.  
+- **Server Folders**: Logs, artifacts, packages, and event exports are too big for Octopus Deploy to store in a SQL Server database.  The server folders are subfolders in `C:\Octopus\`.  Except in rare cases, these folders are left unchanged by an upgrade.  
 - **Tentacles**: Octopus Deploy connects to deployment targets via the Tentacle service.  Each version of Octopus Deploy includes a specific Tentacle version.  Tentacle upgrades do not occur until _after_ the Octopus Deploy server is upgraded.  Tentacle upgrades are optional; any Tentacle greater than 4.x will work [with any modern version of Octopus Deploy](/docs/support/compatibility).  We recommend you upgrade them to get the latest bug fixes and security patches when convenient.  
 - **Calamari**: The Tentacles facilitate communication between Octopus Deploy and the deployment targets.  Calamari is the software that does the actual deployments.  Calamari and Octopus Deploy are coupled together.  Calamari is upgraded automatically during the first deployment to a target.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ## Octopus Deploy Server release schedule
 

--- a/src/pages/docs/administration/upgrading/index.mdx
+++ b/src/pages/docs/administration/upgrading/index.mdx
@@ -59,7 +59,7 @@ The Windows Service is split across multiple folders to make upgrading easy and 
 - **Tentacles**: Octopus Deploy connects to deployment targets via the Tentacle service.  Each version of Octopus Deploy includes a specific Tentacle version.  Tentacle upgrades do not occur until _after_ the Octopus Deploy server is upgraded.  Tentacle upgrades are optional; any Tentacle greater than 4.x will work [with any modern version of Octopus Deploy](/docs/support/compatibility).  We recommend you upgrade them to get the latest bug fixes and security patches when convenient.  
 - **Calamari**: The Tentacles facilitate communication between Octopus Deploy and the deployment targets.  Calamari is the software that does the actual deployments.  Calamari and Octopus Deploy are coupled together.  Calamari is upgraded automatically during the first deployment to a target.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/administration/upgrading/index.mdx
+++ b/src/pages/docs/administration/upgrading/index.mdx
@@ -59,10 +59,6 @@ The Windows Service is split across multiple folders to make upgrading easy and 
 - **Tentacles**: Octopus Deploy connects to deployment targets via the Tentacle service.  Each version of Octopus Deploy includes a specific Tentacle version.  Tentacle upgrades do not occur until _after_ the Octopus Deploy server is upgraded.  Tentacle upgrades are optional; any Tentacle greater than 4.x will work [with any modern version of Octopus Deploy](/docs/support/compatibility).  We recommend you upgrade them to get the latest bug fixes and security patches when convenient.  
 - **Calamari**: The Tentacles facilitate communication between Octopus Deploy and the deployment targets.  Calamari is the software that does the actual deployments.  Calamari and Octopus Deploy are coupled together.  Calamari is upgraded automatically during the first deployment to a target.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ## Octopus Deploy Server release schedule
 
 <OctopusReleases />

--- a/src/pages/docs/getting-started/best-practices/configuring-microsoft-dfs-with-octopus-server.md
+++ b/src/pages/docs/getting-started/best-practices/configuring-microsoft-dfs-with-octopus-server.md
@@ -10,10 +10,6 @@ hideInThisSection: true
 
 Microsoft DFS is a [distributed file system](https://en.wikipedia.org/wiki/Clustered_file_system#Distributed_file_systems), which is important to consider when configuring Octopus Deploy with a DFS file share. Octopus Server makes specific assumptions about the performance and consistency of the file system when accessing log files, performing log retention, storing deployment packages and other deployment artifacts, exported events, and temporary storage when communicating with Tentacles.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 :::div{.warning}
 **DFS in the standard configuration (i.e., accessed through a DFS Namespace Root) is _not_ suitable for use as a shared file store with Octopus Deploy.**
 

--- a/src/pages/docs/getting-started/best-practices/configuring-microsoft-dfs-with-octopus-server.md
+++ b/src/pages/docs/getting-started/best-practices/configuring-microsoft-dfs-with-octopus-server.md
@@ -8,7 +8,11 @@ navOrder: 120
 hideInThisSection: true
 ---
 
-Microsoft DFS is a [distributed file system](https://en.wikipedia.org/wiki/Clustered_file_system#Distributed_file_systems), which is important to consider when configuring Octopus Deploy with a DFS file share. Octopus Server makes specific assumptions about the performance and consistency of the file system when accessing log files, performing log retention, storing deployment packages and other deployment artifacts, and temporary storage when communicating with Tentacles.
+Microsoft DFS is a [distributed file system](https://en.wikipedia.org/wiki/Clustered_file_system#Distributed_file_systems), which is important to consider when configuring Octopus Deploy with a DFS file share. Octopus Server makes specific assumptions about the performance and consistency of the file system when accessing log files, performing log retention, storing deployment packages and other deployment artifacts, exported events, and temporary storage when communicating with Tentacles.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 :::div{.warning}
 **DFS in the standard configuration (i.e., accessed through a DFS Namespace Root) is _not_ suitable for use as a shared file store with Octopus Deploy.**

--- a/src/pages/docs/getting-started/best-practices/configuring-microsoft-dfs-with-octopus-server.md
+++ b/src/pages/docs/getting-started/best-practices/configuring-microsoft-dfs-with-octopus-server.md
@@ -10,7 +10,7 @@ hideInThisSection: true
 
 Microsoft DFS is a [distributed file system](https://en.wikipedia.org/wiki/Clustered_file_system#Distributed_file_systems), which is important to consider when configuring Octopus Deploy with a DFS file share. Octopus Server makes specific assumptions about the performance and consistency of the file system when accessing log files, performing log retention, storing deployment packages and other deployment artifacts, exported events, and temporary storage when communicating with Tentacles.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
+++ b/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
@@ -180,10 +180,6 @@ If you plan on having external [polling Tentacles](/docs/infrastructure/deployme
 
 Octopus Deploy stores BLOB items such as task logs (generated during deployments), deployment artifacts, packages, project images, event exports on a file share instead of in the database.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 The kind of file storage will depend on where you are hosting Octopus Deploy.
 - On-premise data center: Any SMB-based file storage technology will work.  If running Octopus Deploy as a specific Active Directory account, limit permissions to the file share to that account and system administrators.
 - AWS Windows EC2 instance: [Use AWS FSx](/docs/administration/high-availability/design/octopus-for-high-availability-on-aws)

--- a/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
+++ b/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
@@ -180,7 +180,7 @@ If you plan on having external [polling Tentacles](/docs/infrastructure/deployme
 
 Octopus Deploy stores BLOB items such as task logs (generated during deployments), deployment artifacts, packages, project images, event exports on a file share instead of in the database.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
+++ b/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
@@ -178,7 +178,11 @@ If you plan on having external [polling Tentacles](/docs/infrastructure/deployme
 
 ### File Storage
 
-Octopus Deploy stores BLOB items such as task logs (generated during deployments), deployment artifacts, packages, project images on a file share instead of in the database.
+Octopus Deploy stores BLOB items such as task logs (generated during deployments), deployment artifacts, packages, project images, event exports on a file share instead of in the database.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 The kind of file storage will depend on where you are hosting Octopus Deploy.
 - On-premise data center: Any SMB-based file storage technology will work.  If running Octopus Deploy as a specific Active Directory account, limit permissions to the file share to that account and system administrators.

--- a/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
+++ b/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
@@ -64,10 +64,6 @@ volumes:
   sqlvolume:
 ```
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 We will provide some of the environment variables to run this container with an additional `.env` file:
 
 ```

--- a/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
+++ b/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
@@ -64,7 +64,7 @@ volumes:
   sqlvolume:
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
+++ b/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
@@ -53,14 +53,20 @@ services:
       - taskLogs:/taskLogs
       - cache:/cache
       - import:/import
+      - eventExports:/eventExports
 volumes:
   repository:
   artifacts:
   taskLogs:
   cache:
   import:
+  eventExports:
   sqlvolume:
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 We will provide some of the environment variables to run this container with an additional `.env` file:
 

--- a/src/pages/docs/installation/octopus-server-linux-container/index.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/index.mdx
@@ -108,9 +108,7 @@ Read the Docker [docs](https://docs.docker.com/engine/reference/commandline/run/
 
 :::div{.hint}
 **Note:** We recommend using shared storage when mounting the volumes for files that need to be shared between multiple octopus container nodes, e.g. artifacts, packages, task logs, and event exports.
-:::
 
-:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/installation/octopus-server-linux-container/index.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/index.mdx
@@ -103,10 +103,15 @@ Read the Docker [docs](https://docs.docker.com/engine/reference/commandline/run/
 |**/repository**| Package path for the built-in package repository | Shared storage |
 |**/artifacts**| Path where artifacts are stored | Shared storage |
 |**/taskLogs**| Path where task logs are stored | Shared storage |
+|**/eventExports**| Path where event audit logs are exported | Shared storage |
 |**/cache**| Path where cached files e.g. signature and delta files (used for package acquisition) are stored | Host filesystem or container |
 
 :::div{.hint}
-**Note:** We recommend using shared storage when mounting the volumes for files that need to be shared between multiple octopus container nodes, e.g. artifacts, packages and task logs.
+**Note:** We recommend using shared storage when mounting the volumes for files that need to be shared between multiple octopus container nodes, e.g. artifacts, packages, task logs, and event exports.
+:::
+
+:::div{.hint}
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
 ## Upgrading

--- a/src/pages/docs/installation/octopus-server-linux-container/index.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/index.mdx
@@ -108,8 +108,6 @@ Read the Docker [docs](https://docs.docker.com/engine/reference/commandline/run/
 
 :::div{.hint}
 **Note:** We recommend using shared storage when mounting the volumes for files that need to be shared between multiple octopus container nodes, e.g. artifacts, packages, task logs, and event exports.
-
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
 ## Upgrading

--- a/src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
@@ -19,9 +19,13 @@ Since [Octopus High Availability](/docs/administration/high-availability) (HA) a
 Whether you are running Octopus in a Container using Docker or Kubernetes, or running it on Windows Server, there are a number of items to consider when creating an Octopus High Availability cluster:
 
 - A Highly available [SQL Server database](/docs/installation/sql-server-database)
-- A shared file system for [Artifacts, Packages, and Task Logs](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/#ServerconfigurationandFilestorage-FileStorageFilestorage)
+- A shared file system for [Artifacts, Packages, Task Logs, and Event Exports](/docs/administration/managing-infrastructure/server-configuration-and-file-storage/#ServerconfigurationandFilestorage-FileStorageFilestorage)
 - A [Load balancer](/docs/administration/high-availability/load-balancing) for traffic to the Octopus Web Portal 
 - Access to each Octopus Server node for [Polling Tentacles](/docs/administration/high-availability/maintain/polling-tentacles-with-ha)
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 The following sections describe these in more detail.
 
@@ -208,6 +212,11 @@ To share common files between the Octopus Server nodes, we need access to a mini
 - Artifacts
 - Packages
 - Task Logs
+- Event Exports
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 These are created via [persistent volume claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes) with an [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) of `ReadWriteMany` to indicate they are shared between multiple pods. 
 
@@ -223,7 +232,7 @@ The next sections describe how to create file storage for use with Octopus runni
 
 #### AKS storage \{#aks-storage}
 
-The following YAML creates the shared persistent volume claims that will host the artifacts, built-in feed packages, and the task logs using the `azurefile` storage class, which is specific to Azure AKS:
+The following YAML creates the shared persistent volume claims that will host the artifacts, built-in feed packages, the task logs, and event exports using the `azurefile` storage class, which is specific to Azure AKS:
 
 ```yaml
 kind: PersistentVolumeClaim
@@ -261,11 +270,27 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: event-exports-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile
+  resources:
+    requests:
+      storage: 1Gi
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 #### GKE storage \{#gke-storage}
 
-The following YAML creates the shared persistent volume claims that will host the artifacts, built-in feed packages, and the task logs using the `standard-rwx` storage class from the Google [Filestore CSI driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/filestore-csi-driver).
+The following YAML creates the shared persistent volume claims that will host the artifacts, built-in feed packages, the task logs, and event exports using the `standard-rwx` storage class from the Google [Filestore CSI driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/filestore-csi-driver).
 
 :::div{.hint}
 **GKE Cluster version pre-requisite:**
@@ -308,7 +333,23 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: event-exports-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: standard-rwx
+  resources:
+    requests:
+      storage: 1Gi
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 If you are running a GKE cluster in a non-default VPC network in Google Cloud, you may need to define your own storage class specifying the network name. The following YAML shows creating a storage class that can be used with a non-default VPC network in GKE called `my-custom-network-name`:
 
@@ -376,7 +417,14 @@ volumeMounts:
 - name: octopus-storage-vol
     mountPath: /taskLogs
     subPath: taskLogs
+- name: octopus-storage-vol
+    mountPath: /eventExports
+    subPath: eventExports
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ## Deploying the Octopus Server 
 
@@ -406,7 +454,7 @@ This functionality works very nicely when deploying Octopus, as we need to ensur
 
 The following YAML below creates a Stateful Set with two pods. These pods will be called `octopus-0` and `octopus-1`, which will also be the value assigned to the `statefulset.kubernetes.io/pod-name` label. This is how we can link services exposing individual pods. 
 
-The pods then mount a single shared volume for the artifacts, built-in feed packages, task logs and the server task logs for each pod.
+The pods then mount a single shared volume for the artifacts, built-in feed packages, task logs, the server task logs, and event exports for each pod.
 
 ```yaml
 apiVersion: apps/v1
@@ -484,6 +532,9 @@ spec:
         - name: octopus-storage-vol
           mountPath: /taskLogs
           subPath: taskLogs
+        - name: octopus-storage-vol                                                  
+          mountPath: /eventExports
+          subPath: eventExports
         - name: octopus-storage-vol
           mountPath: /home/octopus/.octopus/OctopusServer/Server/Logs
           subPathExpr: serverLogs/$(OCTOPUS_SERVER_NODE_NAME)
@@ -530,7 +581,15 @@ spec:
           periodSeconds: 60
 ```
 
+<<<<<<< HEAD:src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
 :::div{.hint}
+=======
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
+
+:::hint
+>>>>>>> 37c515d99 (First cut at adding event exports):docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
 **Change the Default values:**
 If you use the YAML definition above, remember to change the default values entered including the Admin Username, Admin Password, and the version of the `octopusdeploy/octopusdeploy` image to use. You also need to provide values for the License Key and database Master Key.
 :::
@@ -564,7 +623,11 @@ affinity:
 
 ### Octopus Server Pod logs \{#server-pod-logs}
 
-In addition to the shared folders that are mounted for Packages, Artifacts and Task Logs, each Octopus Server node (Pod) also writes logs to a local folder in each running container.
+In addition to the shared folders that are mounted for Packages, Artifacts, Task Logs, and Event Exports, each Octopus Server node (Pod) also writes logs to a local folder in each running container.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 To mount the same volume used for the shared folders for the server logs, we need a way to create a sub-folder on the external volume that's unique to each Octopus Server node running in a Pod. 
 

--- a/src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
@@ -23,10 +23,6 @@ Whether you are running Octopus in a Container using Docker or Kubernetes, or ru
 - A [Load balancer](/docs/administration/high-availability/load-balancing) for traffic to the Octopus Web Portal 
 - Access to each Octopus Server node for [Polling Tentacles](/docs/administration/high-availability/maintain/polling-tentacles-with-ha)
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 The following sections describe these in more detail.
 
 ### SQL Server Database \{#sql-database}
@@ -214,10 +210,6 @@ To share common files between the Octopus Server nodes, we need access to a mini
 - Task Logs
 - Event Exports
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 These are created via [persistent volume claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes) with an [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) of `ReadWriteMany` to indicate they are shared between multiple pods. 
 
 Most of the YAML in this guide can be used with any Kubernetes provider. However, the YAML describing file storage can have differences between each Kubernetes provider as they typically expose different names for their shared filesystems via the `storageClassName` property. 
@@ -284,10 +276,6 @@ spec:
       storage: 1Gi
 ```
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 #### GKE storage \{#gke-storage}
 
 The following YAML creates the shared persistent volume claims that will host the artifacts, built-in feed packages, the task logs, and event exports using the `standard-rwx` storage class from the Google [Filestore CSI driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/filestore-csi-driver).
@@ -346,10 +334,6 @@ spec:
     requests:
       storage: 1Gi
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 If you are running a GKE cluster in a non-default VPC network in Google Cloud, you may need to define your own storage class specifying the network name. The following YAML shows creating a storage class that can be used with a non-default VPC network in GKE called `my-custom-network-name`:
 
@@ -421,10 +405,6 @@ volumeMounts:
     mountPath: /eventExports
     subPath: eventExports
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 ## Deploying the Octopus Server 
 
@@ -582,10 +562,6 @@ spec:
 ```
 
 :::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
-:::div{.hint}
 **Change the Default values:**
 If you use the YAML definition above, remember to change the default values entered including the Admin Username, Admin Password, and the version of the `octopusdeploy/octopusdeploy` image to use. You also need to provide values for the License Key and database Master Key.
 :::
@@ -620,10 +596,6 @@ affinity:
 ### Octopus Server Pod logs \{#server-pod-logs}
 
 In addition to the shared folders that are mounted for Packages, Artifacts, Task Logs, and Event Exports, each Octopus Server node (Pod) also writes logs to a local folder in each running container.
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 To mount the same volume used for the shared folders for the server logs, we need a way to create a sub-folder on the external volume that's unique to each Octopus Server node running in a Pod. 
 

--- a/src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
@@ -23,7 +23,7 @@ Whether you are running Octopus in a Container using Docker or Kubernetes, or ru
 - A [Load balancer](/docs/administration/high-availability/load-balancing) for traffic to the Octopus Web Portal 
 - Access to each Octopus Server node for [Polling Tentacles](/docs/administration/high-availability/maintain/polling-tentacles-with-ha)
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -214,7 +214,7 @@ To share common files between the Octopus Server nodes, we need access to a mini
 - Task Logs
 - Event Exports
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -284,7 +284,7 @@ spec:
       storage: 1Gi
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -347,7 +347,7 @@ spec:
       storage: 1Gi
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -422,7 +422,7 @@ volumeMounts:
     subPath: eventExports
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -581,15 +581,11 @@ spec:
           periodSeconds: 60
 ```
 
-<<<<<<< HEAD:src/pages/docs/installation/octopus-server-linux-container/octopus-in-kubernetes.mdx
 :::div{.hint}
-=======
-:::hint
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
-:::hint
->>>>>>> 37c515d99 (First cut at adding event exports):docs/installation/octopus-server-linux-container/octopus-in-kubernetes.md
+:::div{.hint}
 **Change the Default values:**
 If you use the YAML definition above, remember to change the default values entered including the Admin Username, Admin Password, and the version of the `octopusdeploy/octopusdeploy` image to use. You also need to provide values for the License Key and database Master Key.
 :::
@@ -625,7 +621,7 @@ affinity:
 
 In addition to the shared folders that are mounted for Packages, Artifacts, Task Logs, and Event Exports, each Octopus Server node (Pod) also writes logs to a local folder in each running container.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/octopus-cloud/migrations.md
+++ b/src/pages/docs/octopus-cloud/migrations.md
@@ -36,7 +36,7 @@ The deployments will **not** include:
 - Event Exports
 :::
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/octopus-cloud/migrations.md
+++ b/src/pages/docs/octopus-cloud/migrations.md
@@ -36,10 +36,6 @@ The deployments will **not** include:
 - Event Exports
 :::
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ## Prep Work
 
 Before starting your migration to Octopus Cloud, you will need to address the following:

--- a/src/pages/docs/octopus-cloud/migrations.md
+++ b/src/pages/docs/octopus-cloud/migrations.md
@@ -33,6 +33,11 @@ The deployments will **not** include:
     - Guided Failure logs
     - Manual Intervention logs
 - Audit History
+- Event Exports
+:::
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
 ## Prep Work

--- a/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -36,8 +36,8 @@ Where [<options>] is any of:
       --artifacts=VALUE      Set the path where artifacts are stored
       --imports=VALUE        Set the path where imported zip files are stored
       --taskLogs=VALUE       Set the path where task logs are stored
-      --telemetry=VALUE      Set the path where telemetry is stored
       --eventExports=VALUE   Set the path where event audit logs are exported
+      --telemetry=VALUE      Set the path where telemetry is stored
 
 Or one of the common options:
 
@@ -57,8 +57,8 @@ octopus.server path --artifacts Artifacts
 octopus.server path --taskLogs TaskLogs
 octopus.server path --nugetRepository Packages
 octopus.server path --imports Imports
-octopus.server path --telemetry Telemetry
 octopus.server path --eventExports EventExports
+octopus.server path --telemetry Telemetry
 ```
 
 This example configures the paths for the different components individually:
@@ -67,8 +67,8 @@ octopus.server path --artifacts \\Octoshared\OctopusData\Artifacts
 octopus.server path --taskLogs \\Octoshared\OctopusData\TaskLogs
 octopus.server path --nugetRepository \\Octoshared\OctopusData\Packages
 octopus.server path --imports \\Octoshared\OctopusData\Imports
-octopus.server path --telemetry \\Octoshared\OctopusData\Telemetry
 octopus.server path --eventExports \\Octoshared\OctopusData\EventExports
+octopus.server path --telemetry \\Octoshared\OctopusData\Telemetry
 ```
 
 :::div{.hint}

--- a/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -44,7 +44,7 @@ Or one of the common options:
       --help                 Show detailed help for this command
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -71,6 +71,6 @@ octopus.server path --telemetry \\Octoshared\OctopusData\Telemetry
 octopus.server path --eventExports \\Octoshared\OctopusData\EventExports
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::

--- a/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -70,7 +70,3 @@ octopus.server path --imports \\Octoshared\OctopusData\Imports
 octopus.server path --eventExports \\Octoshared\OctopusData\EventExports
 octopus.server path --telemetry \\Octoshared\OctopusData\Telemetry
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::

--- a/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -44,10 +44,6 @@ Or one of the common options:
       --help                 Show detailed help for this command
 ```
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ## Basic examples
 This example configures all paths (artifacts, task logs, packages, imports, and telemetry) to a network share:
 ```

--- a/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
+++ b/src/pages/docs/octopus-rest-api/octopus.server.exe-command-line/path.md
@@ -37,11 +37,16 @@ Where [<options>] is any of:
       --imports=VALUE        Set the path where imported zip files are stored
       --taskLogs=VALUE       Set the path where task logs are stored
       --telemetry=VALUE      Set the path where telemetry is stored
+      --eventExports=VALUE   Set the path where event audit logs are exported
 
 Or one of the common options:
 
       --help                 Show detailed help for this command
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ## Basic examples
 This example configures all paths (artifacts, task logs, packages, imports, and telemetry) to a network share:
@@ -53,6 +58,7 @@ octopus.server path --taskLogs TaskLogs
 octopus.server path --nugetRepository Packages
 octopus.server path --imports Imports
 octopus.server path --telemetry Telemetry
+octopus.server path --eventExports EventExports
 ```
 
 This example configures the paths for the different components individually:
@@ -62,4 +68,9 @@ octopus.server path --taskLogs \\Octoshared\OctopusData\TaskLogs
 octopus.server path --nugetRepository \\Octoshared\OctopusData\Packages
 octopus.server path --imports \\Octoshared\OctopusData\Imports
 octopus.server path --telemetry \\Octoshared\OctopusData\Telemetry
+octopus.server path --eventExports \\Octoshared\OctopusData\EventExports
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::

--- a/src/pages/docs/security/exposing-octopus/use-nginx-as-reverse-proxy.md
+++ b/src/pages/docs/security/exposing-octopus/use-nginx-as-reverse-proxy.md
@@ -157,7 +157,7 @@ services:
       - db
       - octopus      
 ```
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/pages/docs/security/exposing-octopus/use-nginx-as-reverse-proxy.md
+++ b/src/pages/docs/security/exposing-octopus/use-nginx-as-reverse-proxy.md
@@ -146,6 +146,7 @@ services:
       - ./taskLogs:/taskLogs
       - ./artifacts:/artifacts
       - ./repository:/repository
+      - ./eventExports:/eventExports
   nginx:
     image: ${NGINX_IMAGE}
     environment:
@@ -156,6 +157,9 @@ services:
       - db
       - octopus      
 ```
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 The .env file will look something like this:
 ```

--- a/src/pages/docs/security/exposing-octopus/use-nginx-as-reverse-proxy.md
+++ b/src/pages/docs/security/exposing-octopus/use-nginx-as-reverse-proxy.md
@@ -157,9 +157,6 @@ services:
       - db
       - octopus      
 ```
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 The .env file will look something like this:
 ```

--- a/src/shared-content/administration/high-availability-shared-storage-overview.include.md
+++ b/src/shared-content/administration/high-availability-shared-storage-overview.include.md
@@ -4,7 +4,7 @@ Octopus stores several files that are not suitable to store in the database. The
 - [Artifacts](/docs/projects/deployment-process/artifacts) collected during a deployment. Teams using Octopus sometimes use this feature to collect large log files and other files from machines during a deployment.
 - Task logs are text files that store all of the log output from deployments and other tasks.
 - Imported zip files used by the [Export/Import Projects feature](/docs/projects/export-import).
-- Archived audit logs by the [Archived audit logs feature](/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
+- Archived audit logs by the [Archived audit logs feature](/docs/security/users-and-teams/auditing/#archived-audit-events).
 
 :::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.

--- a/src/shared-content/administration/high-availability-shared-storage-overview.include.md
+++ b/src/shared-content/administration/high-availability-shared-storage-overview.include.md
@@ -6,7 +6,7 @@ Octopus stores several files that are not suitable to store in the database. The
 - Imported zip files used by the [Export/Import Projects feature](/docs/projects/export-import).
 - Archived audit logs by the [Archived audit logs feature](/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/shared-content/administration/high-availability-shared-storage-overview.include.md
+++ b/src/shared-content/administration/high-availability-shared-storage-overview.include.md
@@ -6,10 +6,6 @@ Octopus stores several files that are not suitable to store in the database. The
 - Imported zip files used by the [Export/Import Projects feature](/docs/projects/export-import).
 - Archived audit logs by the [Archived audit logs feature](/docs/security/users-and-teams/auditing/#archived-audit-events).
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 As with the database, you'll tell the Octopus Servers where to store them as a file path within your operating system. The shared storage needs to be accessible by all Octopus nodes. Each of these three types of data can be stored in a different location.
 
 Whichever way you provide the shared storage, there are a few considerations to keep in mind:

--- a/src/shared-content/administration/high-availability-shared-storage-overview.include.md
+++ b/src/shared-content/administration/high-availability-shared-storage-overview.include.md
@@ -4,6 +4,11 @@ Octopus stores several files that are not suitable to store in the database. The
 - [Artifacts](/docs/projects/deployment-process/artifacts) collected during a deployment. Teams using Octopus sometimes use this feature to collect large log files and other files from machines during a deployment.
 - Task logs are text files that store all of the log output from deployments and other tasks.
 - Imported zip files used by the [Export/Import Projects feature](/docs/projects/export-import).
+- Archived audit logs by the [Archived audit logs feature](/docs/security/users-and-teams/auditing/index.md#archived-audit-events).
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 As with the database, you'll tell the Octopus Servers where to store them as a file path within your operating system. The shared storage needs to be accessible by all Octopus nodes. Each of these three types of data can be stored in a different location.
 

--- a/src/shared-content/administration/moving-octopus-server-folders.include.md
+++ b/src/shared-content/administration/moving-octopus-server-folders.include.md
@@ -66,6 +66,7 @@ Where `[<options>]` is any of:
       --artifacts=VALUE      Set the path where artifacts are stored
       --imports=VALUE        Set the path where imported zip files are stored
       --taskLogs=VALUE       Set the path where task logs are stored
+      --eventExports=VALUE   Set the path where event audit logs are exported
       --telemetry=VALUE      Set the path where telemetry is stored
 
 Or one of the common options:
@@ -73,6 +74,10 @@ Or one of the common options:
                                user is non-interactive
       --nologo               Don't print title or version information
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ## Move NuGet repository folder {#MovingOctopusServerfolders-NuGetRepository}
 
@@ -130,6 +135,26 @@ mv $oldTaskLogs $newTaskLogs
 & "$octopus" path --taskLogs="$newTaskLogs"
 & "$octopus" service --start
 ```
+
+## Move the event exports folder {#MovingOctopusServerfolders-EventExports}
+
+A PowerShell script showing the steps is set out below. You need to change the variables to match your Octopus installation, and you may wish to run each step separately to deal with any issues like locked files.
+
+```powershell
+$oldEventExports = "C:\Octopus\EventExports"
+$newEventExports = "C:\YourNewHomeDir\EventExports"
+$octopus = "C:\Program Files\Octopus Deploy\Octopus\Octopus.Server.exe"
+
+& "$octopus" service --stop
+mv $oldEventExports $newEventExports
+
+& "$octopus" path --eventExports="$newEventExports"
+& "$octopus" service --start
+```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ## Move the telemetry folder {#MovingOctopusServerfolders-Telemetry}
 

--- a/src/shared-content/administration/moving-octopus-server-folders.include.md
+++ b/src/shared-content/administration/moving-octopus-server-folders.include.md
@@ -75,7 +75,7 @@ Or one of the common options:
       --nologo               Don't print title or version information
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -152,7 +152,7 @@ mv $oldEventExports $newEventExports
 & "$octopus" service --start
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/shared-content/administration/moving-octopus-server-folders.include.md
+++ b/src/shared-content/administration/moving-octopus-server-folders.include.md
@@ -75,10 +75,6 @@ Or one of the common options:
       --nologo               Don't print title or version information
 ```
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ## Move NuGet repository folder {#MovingOctopusServerfolders-NuGetRepository}
 
 A PowerShell script showing the steps is set out below. You need to change the variables to match your Octopus installation, and you may wish to run each step separately to deal with any issues like locked files. The new path will apply to existing packages in the repository, so it is important to move the packages.
@@ -151,10 +147,6 @@ mv $oldEventExports $newEventExports
 & "$octopus" path --eventExports="$newEventExports"
 & "$octopus" service --start
 ```
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 ## Move the telemetry folder {#MovingOctopusServerfolders-Telemetry}
 

--- a/src/shared-content/administration/octopus-instance-mixed-os-warning.include.md
+++ b/src/shared-content/administration/octopus-instance-mixed-os-warning.include.md
@@ -1,7 +1,3 @@
 :::div{.warning}
 Due to how Octopus stores the paths to various BLOB data (task logs, artifacts, packages, imports, event exports etc.), you cannot run a mix of both Windows Servers, and Octopus Linux containers connected to the same Octopus Deploy instance.  A single instance should only be hosted using one method.
 :::
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::

--- a/src/shared-content/administration/octopus-instance-mixed-os-warning.include.md
+++ b/src/shared-content/administration/octopus-instance-mixed-os-warning.include.md
@@ -2,6 +2,6 @@
 Due to how Octopus stores the paths to various BLOB data (task logs, artifacts, packages, imports, event exports etc.), you cannot run a mix of both Windows Servers, and Octopus Linux containers connected to the same Octopus Deploy instance.  A single instance should only be hosted using one method.
 :::
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::

--- a/src/shared-content/administration/octopus-instance-mixed-os-warning.include.md
+++ b/src/shared-content/administration/octopus-instance-mixed-os-warning.include.md
@@ -1,3 +1,7 @@
 :::div{.warning}
-Due to how Octopus stores the paths to various BLOB data (task logs, artifacts, packages, imports etc.), you cannot run a mix of both Windows Servers, and Octopus Linux containers connected to the same Octopus Deploy instance.  A single instance should only be hosted using one method.
+Due to how Octopus stores the paths to various BLOB data (task logs, artifacts, packages, imports, event exports etc.), you cannot run a mix of both Windows Servers, and Octopus Linux containers connected to the same Octopus Deploy instance.  A single instance should only be hosted using one method.
+:::
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::

--- a/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
+++ b/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
@@ -103,10 +103,6 @@ Octopus Deploy stores all the BLOB data (deployment logs, runbook logs, packages
 - Packages
 - EventExports (available from Octopus **2023.3**)
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 If you are moving from a Windows VM, the default path for those folders is: `C:\Octopus`.  For example, the task logs folder would be `C:\Octopus\TaskLogs`.  If you are unsure of the path, you can find it in the Octopus Deploy UI by navigating to **Configuration ➜ Settings ➜ Server Folders**.
 
 :::div{.warning}

--- a/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
+++ b/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
@@ -96,11 +96,16 @@ Our recommendation is to keep that risk to a minimum.
 
 ### Copy Files
 
-Octopus Deploy stores all the BLOB data (deployment logs, runbook logs, packages, artifacts, etc.) on a file share.  If you are moving from a single server, be it hosting Octopus in a Windows Container or directly on a Windows VM, you will need to copy files to your new storage provider.  Once your shared storage provider has been created, you'll want to copy files over from these folders:
+Octopus Deploy stores all the BLOB data (deployment logs, runbook logs, packages, artifacts, event exports etc.) on a file share.  If you are moving from a single server, be it hosting Octopus in a Windows Container or directly on a Windows VM, you will need to copy files to your new storage provider.  Once your shared storage provider has been created, you'll want to copy files over from these folders:
 
 - TaskLogs
 - Artifacts
 - Packages
+- EventExports
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 If you are moving from a Windows VM, the default path for those folders is: `C:\Octopus`.  For example, the task logs folder would be `C:\Octopus\TaskLogs`.  If you are unsure of the path, you can find it in the Octopus Deploy UI by navigating to **Configuration ➜ Settings ➜ Server Folders**.
 
@@ -141,8 +146,12 @@ The Dockerfile runs the Octopus Server installer each time the Octopus Server Wi
 For example:
 
 ```
-./Octopus.Server path --instance OctopusServer --nugetRepository "/repository" --artifacts "/artifacts" --taskLogs "/taskLogs" --cacheDirectory="/cache" --skipDatabaseCompatibilityCheck --skipDatabaseSchemaUpgradeCheck
+./Octopus.Server path --instance OctopusServer --nugetRepository "/repository" --artifacts "/artifacts" --taskLogs "/taskLogs" --eventExports "/eventExports" --cacheDirectory="/cache" --skipDatabaseCompatibilityCheck --skipDatabaseSchemaUpgradeCheck
 ```
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Just like the Octopus Server Windows Container, you will want to provide the following volume mounts.
 
@@ -152,6 +161,11 @@ Just like the Octopus Server Windows Container, you will want to provide the fol
 |**/artifacts**|Path where artifacts are stored|
 |**/taskLogs**|Path where task logs are stored|
 |**/cache**|Path where cached files are stored|
+|**/eventExports**|Path where event audit logs are exported|
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 If you are running Octopus Server directly on Docker, read the Docker [docs](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only) about mounting volumes.  You will need to update your Docker compose or Docker run command to point your existing folders to the new volume mounts.  
 

--- a/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
+++ b/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
@@ -101,7 +101,7 @@ Octopus Deploy stores all the BLOB data (deployment logs, runbook logs, packages
 - TaskLogs
 - Artifacts
 - Packages
-- EventExports (available from Octopus **2023.3**)
+- EventExports
 
 If you are moving from a Windows VM, the default path for those folders is: `C:\Octopus`.  For example, the task logs folder would be `C:\Octopus\TaskLogs`.  If you are unsure of the path, you can find it in the Octopus Deploy UI by navigating to **Configuration ➜ Settings ➜ Server Folders**.
 
@@ -145,10 +145,6 @@ For example:
 ./Octopus.Server path --instance OctopusServer --nugetRepository "/repository" --artifacts "/artifacts" --taskLogs "/taskLogs" --eventExports "/eventExports" --cacheDirectory="/cache" --skipDatabaseCompatibilityCheck --skipDatabaseSchemaUpgradeCheck
 ```
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 Just like the Octopus Server Windows Container, you will want to provide the following volume mounts.
 
 |  Name       |    |
@@ -158,10 +154,6 @@ Just like the Octopus Server Windows Container, you will want to provide the fol
 |**/taskLogs**|Path where task logs are stored|
 |**/cache**|Path where cached files are stored|
 |**/eventExports**|Path where event audit logs are exported|
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
 
 If you are running Octopus Server directly on Docker, read the Docker [docs](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only) about mounting volumes.  You will need to update your Docker compose or Docker run command to point your existing folders to the new volume mounts.  
 

--- a/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
+++ b/src/shared-content/installation/migrate-from-windows-to-linux-container.include.md
@@ -103,7 +103,7 @@ Octopus Deploy stores all the BLOB data (deployment logs, runbook logs, packages
 - Packages
 - EventExports
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -149,7 +149,7 @@ For example:
 ./Octopus.Server path --instance OctopusServer --nugetRepository "/repository" --artifacts "/artifacts" --taskLogs "/taskLogs" --eventExports "/eventExports" --cacheDirectory="/cache" --skipDatabaseCompatibilityCheck --skipDatabaseSchemaUpgradeCheck
 ```
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 
@@ -163,7 +163,7 @@ Just like the Octopus Server Windows Container, you will want to provide the fol
 |**/cache**|Path where cached files are stored|
 |**/eventExports**|Path where event audit logs are exported|
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/shared-content/octopus-cloud/octopus-cloud-community-plan-storage-limits.include.md
+++ b/src/shared-content/octopus-cloud/octopus-cloud-community-plan-storage-limits.include.md
@@ -1,4 +1,8 @@
-- Maximum File Storage for artifacts, task logs, packages and package cache is limited to `20 GB`.
+- Maximum File Storage for artifacts, task logs, packages, package cache, and event exports is limited to `20 GB`.
 - Maximum Database Size for configuration data (e.g. projects, deployment processes and inline scripts) is limited to `5 GB`.
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies) can be configured up to a **maximum** of `30 Days`.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::

--- a/src/shared-content/octopus-cloud/octopus-cloud-community-plan-storage-limits.include.md
+++ b/src/shared-content/octopus-cloud/octopus-cloud-community-plan-storage-limits.include.md
@@ -3,6 +3,6 @@
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies) can be configured up to a **maximum** of `30 Days`.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::

--- a/src/shared-content/octopus-cloud/octopus-cloud-community-plan-storage-limits.include.md
+++ b/src/shared-content/octopus-cloud/octopus-cloud-community-plan-storage-limits.include.md
@@ -2,7 +2,3 @@
 - Maximum Database Size for configuration data (e.g. projects, deployment processes and inline scripts) is limited to `5 GB`.
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies) can be configured up to a **maximum** of `30 Days`.
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::

--- a/src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
+++ b/src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
@@ -3,6 +3,6 @@
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies) are *defaulted* to 30 days, but this figure can be changed as required.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::

--- a/src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
+++ b/src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
@@ -1,4 +1,8 @@
-- Maximum File Storage for artifacts, task logs, packages and package cache is limited to `1 TB`.
+- Maximum File Storage for artifacts, task logs, packages, package cache, and event exports is limited to `1 TB`.
 - Maximum Database Size for configuration data (e.g. projects, deployment processes and inline scripts) is limited to `100 GB`.
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies) are *defaulted* to 30 days, but this figure can be changed as required.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::

--- a/src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
+++ b/src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md
@@ -2,7 +2,3 @@
 - Maximum Database Size for configuration data (e.g. projects, deployment processes and inline scripts) is limited to `100 GB`.
 - Maximum size for any single package is `5 GB`.
 - [Retention policies](/docs/administration/retention-policies) are *defaulted* to 30 days, but this figure can be changed as required.
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::

--- a/src/shared-content/upgrade/upgrade-copy-files-for-cloned-instance.include.md
+++ b/src/shared-content/upgrade/upgrade-copy-files-for-cloned-instance.include.md
@@ -5,9 +5,15 @@ After the instance has been created, copy all the contents from the following fo
 - _Artifacts_, the default is `C:\Octopus\Artifacts`
 - _Packages_, the default is `C:\Octopus\Packages`
 - _Tasklogs_, the default is `C:\Octopus\Tasklogs`
+- _EventExports_, the default is `C:\Octopus\EventExports`
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Failure to copy over files will result in:
 - Empty deployment screens
 - Missing packages on the internal package feed
 - Missing project or tenant images
+- Missing archived events
 - And more

--- a/src/shared-content/upgrade/upgrade-copy-files-for-cloned-instance.include.md
+++ b/src/shared-content/upgrade/upgrade-copy-files-for-cloned-instance.include.md
@@ -7,7 +7,7 @@ After the instance has been created, copy all the contents from the following fo
 - _Tasklogs_, the default is `C:\Octopus\Tasklogs`
 - _EventExports_, the default is `C:\Octopus\EventExports`
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/shared-content/upgrade/upgrade-copy-files-for-cloned-instance.include.md
+++ b/src/shared-content/upgrade/upgrade-copy-files-for-cloned-instance.include.md
@@ -7,10 +7,6 @@ After the instance has been created, copy all the contents from the following fo
 - _Tasklogs_, the default is `C:\Octopus\Tasklogs`
 - _EventExports_, the default is `C:\Octopus\EventExports`
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 Failure to copy over files will result in:
 - Empty deployment screens
 - Missing packages on the internal package feed

--- a/src/shared-content/upgrade/upgrade-inplace-upgrade.include.md
+++ b/src/shared-content/upgrade/upgrade-inplace-upgrade.include.md
@@ -12,7 +12,7 @@ The Windows Service is split across multiple folders to make upgrading easy and 
 - **Tentacles**: Octopus Deploy connects to deployment targets via the Tentacle service.  Each version of Octopus Deploy includes a specific Tentacle version.  Tentacle upgrades do not occur until _after_ the Octopus Deploy server is upgraded.  Tentacle upgrades are optional; any Tentacle greater than 4.x will work [with any modern version of Octopus Deploy](/docs/support/compatibility).  We recommend you upgrade them to get the latest bug fixes and security patches when convenient.  
 - **Calamari**: The Tentacles facilitate communication between Octopus Deploy and the deployment targets.  Calamari is the software that does the actual deployments.  Calamari and Octopus Deploy are coupled together.  Calamari is upgraded automatically during the first deployment to a target.components.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/shared-content/upgrade/upgrade-inplace-upgrade.include.md
+++ b/src/shared-content/upgrade/upgrade-inplace-upgrade.include.md
@@ -8,9 +8,13 @@ The Windows Service is split across multiple folders to make upgrading easy and 
 - **SQL Server Database**: Since `Octopus Deploy 3.x`, the back-end database has been SQL Server.  Each update can contain 0 to N database scripts embedded in a .dll in the install location.  The `Octopus Manager` invokes those database scripts automatically.
 - **Home Folder**: The home folder stores configuration, logs, and other items unique to your instance.  The home folder is separate from the install location to make it easier to upgrade, downgrade, uninstall/reinstall without affecting your instance.  The default location of the home folder is `C:\Octopus`.  Except in rare cases, this folder is left unchanged by the upgrade process.
 - **Instance Information**: The Octopus Deploy Manager allows you to configure 1 to N instances per Windows Server.  The `Octopus Manager` stores a list of all the instances in the `C:\ProgramData\Octopus\OctopusServer\Instances` folder.   Except in rare cases, this folder is left unchanged by the upgrade process.  
-- **Server Folders**: Logs, artifacts, and packages are too big for Octopus Deploy to store in a SQL Server database.  The server folders are subfolders in `C:\Octopus\`.  Except in rare cases, these folders are left unchanged by an upgrade.  
+- **Server Folders**: Logs, artifacts, packages, and event exports are too big for Octopus Deploy to store in a SQL Server database.  The server folders are subfolders in `C:\Octopus\`.  Except in rare cases, these folders are left unchanged by an upgrade.  
 - **Tentacles**: Octopus Deploy connects to deployment targets via the Tentacle service.  Each version of Octopus Deploy includes a specific Tentacle version.  Tentacle upgrades do not occur until _after_ the Octopus Deploy server is upgraded.  Tentacle upgrades are optional; any Tentacle greater than 4.x will work [with any modern version of Octopus Deploy](/docs/support/compatibility).  We recommend you upgrade them to get the latest bug fixes and security patches when convenient.  
 - **Calamari**: The Tentacles facilitate communication between Octopus Deploy and the deployment targets.  Calamari is the software that does the actual deployments.  Calamari and Octopus Deploy are coupled together.  Calamari is upgraded automatically during the first deployment to a target.components.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 ### Install the newer version of Octopus Deploy
 

--- a/src/shared-content/upgrade/upgrade-inplace-upgrade.include.md
+++ b/src/shared-content/upgrade/upgrade-inplace-upgrade.include.md
@@ -12,10 +12,6 @@ The Windows Service is split across multiple folders to make upgrading easy and 
 - **Tentacles**: Octopus Deploy connects to deployment targets via the Tentacle service.  Each version of Octopus Deploy includes a specific Tentacle version.  Tentacle upgrades do not occur until _after_ the Octopus Deploy server is upgraded.  Tentacle upgrades are optional; any Tentacle greater than 4.x will work [with any modern version of Octopus Deploy](/docs/support/compatibility).  We recommend you upgrade them to get the latest bug fixes and security patches when convenient.  
 - **Calamari**: The Tentacles facilitate communication between Octopus Deploy and the deployment targets.  Calamari is the software that does the actual deployments.  Calamari and Octopus Deploy are coupled together.  Calamari is upgraded automatically during the first deployment to a target.components.
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 ### Install the newer version of Octopus Deploy
 
 Installing a newer version of Octopus Deploy is as simple as running MSI and following the wizard.  The MSI will copy all the binaries to the install location.  Once the MSI is complete, it will automatically launch the `Octopus Manager`.

--- a/src/shared-content/upgrade/upgrade-octopus-backup-folders.include.md
+++ b/src/shared-content/upgrade/upgrade-octopus-backup-folders.include.md
@@ -7,8 +7,4 @@ The server folders store large binary data outside of the database.  By default,
 - **Tasklogs**: The default location is `C:\Octopus\Tasklogs`. It stores all the deployment logs.  
 - **EventExports**: The default location is `C:\Octopus\EventExports`. It stores all the exported event audit logs.  
 
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::
-
 Any standard file-backup tool will work, even [RoboCopy](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy).  Very rarely will an upgrade change these folders.  The release notes will indicate if these folders are going to be modified.

--- a/src/shared-content/upgrade/upgrade-octopus-backup-folders.include.md
+++ b/src/shared-content/upgrade/upgrade-octopus-backup-folders.include.md
@@ -7,7 +7,7 @@ The server folders store large binary data outside of the database.  By default,
 - **Tasklogs**: The default location is `C:\Octopus\Tasklogs`. It stores all the deployment logs.  
 - **EventExports**: The default location is `C:\Octopus\EventExports`. It stores all the exported event audit logs.  
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::
 

--- a/src/shared-content/upgrade/upgrade-octopus-backup-folders.include.md
+++ b/src/shared-content/upgrade/upgrade-octopus-backup-folders.include.md
@@ -5,5 +5,10 @@ The server folders store large binary data outside of the database.  By default,
 - **Packages**: The default location is `C:\Octopus\Packages\`. It stores all the packages in the internal feed.
 - **Artifacts**: The default location is `C:\Octopus\Artifacts`. It stores all the artifacts collected during a deployment along with project images.  
 - **Tasklogs**: The default location is `C:\Octopus\Tasklogs`. It stores all the deployment logs.  
+- **EventExports**: The default location is `C:\Octopus\EventExports`. It stores all the exported event audit logs.  
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::
 
 Any standard file-backup tool will work, even [RoboCopy](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy).  Very rarely will an upgrade change these folders.  The release notes will indicate if these folders are going to be modified.

--- a/src/shared-content/upgrade/upgrade-rollback-folders.include.md
+++ b/src/shared-content/upgrade/upgrade-rollback-folders.include.md
@@ -7,6 +7,6 @@ Octopus Deploy expects the artifacts, packages, tasklog, and event export folder
 3. Copy the contents of the existing folders from the backup.
 4. Once the rollback is complete, delete the copy from the first step.
 
-:::hint
+:::div{.hint}
 EventExports is available from **2023.3** onwards as part of the audit log retention feature.
 :::

--- a/src/shared-content/upgrade/upgrade-rollback-folders.include.md
+++ b/src/shared-content/upgrade/upgrade-rollback-folders.include.md
@@ -1,8 +1,12 @@
 ### Restore Octopus Folders
 
-Octopus Deploy expects the artifacts, packages, and tasklog folders to be in a specific format.  The best chance of success is to:
+Octopus Deploy expects the artifacts, packages, tasklog, and event export folders to be in a specific format.  The best chance of success is to:
 
 1. Copy the existing folders to a safe location.
 2. Delete the contents of the existing folders.
 3. Copy the contents of the existing folders from the backup.
 4. Once the rollback is complete, delete the copy from the first step.
+
+:::hint
+EventExports is available from **2023.3** onwards as part of the audit log retention feature.
+:::

--- a/src/shared-content/upgrade/upgrade-rollback-folders.include.md
+++ b/src/shared-content/upgrade/upgrade-rollback-folders.include.md
@@ -6,7 +6,3 @@ Octopus Deploy expects the artifacts, packages, tasklog, and event export folder
 2. Delete the contents of the existing folders.
 3. Copy the contents of the existing folders from the backup.
 4. Once the rollback is complete, delete the copy from the first step.
-
-:::div{.hint}
-EventExports is available from **2023.3** onwards as part of the audit log retention feature.
-:::


### PR DESCRIPTION
[sc-42885]

# Background
With audit log retention almost finished, it will be ready for on-prem customers soon (although it missed the 2023.2 boat 😞). 

Let's update the docs!

# Purpose of PR
When looking deeper into this, I found quite a lot of candidate places to update in our docs.

This raised my questions about what should be updated etc.

To start these conversations, this PR was created.

# What Was Done
To spark conversation, I found all the places that reference the directories we use (I searched for "artifacts"), and simply updated it to also include event exports.

I'm not saying all these places should be updated. But this highlights all the candidate locations.

# Questions/Issues
Following are the points I wish answered in this PR. Please review these questions and issues, so we can resolve each one.

## Directories are Everywhere
There are lots of places we reference core directories (e.g. artifacts, task logs etc.). 

**Surely we want these to reflect eventExports, right?**

## Directories are Inconsistent
I noticed that we are quite inconsistent with which directories we reference. Although I added `eventExports` everywhere I could find, I noticed often we would not have other directories I know we use.

**Should we also review all these locations in respects to all our directories?**

Here is a list of all our directories (sourced from the code itself):

- cacheDirectory
- clusterShared
- nugetRepository
- artifacts
- imports
- taskLogs
- eventExports
- telemetry

## Many Scripts Were Updated
I updated lots of scripts in this PR. I tried my best to ensure they were updated correctly. Please review these and ensure they are indeed updated correctly.

**Is it worth reaching out to the owners of these scripts to ensure they are correct?**

## When to Merge PR
We are finishing audit log retention soon. But we missed the 2023.2 cut off. 

So we could merge the PR now with version hints everywhere (and not forget to do this when we are on other projects next quarter)

Or we could wait until 2023.3 is released, and not have the version hints.

**Should we delay merging this PR?**

## Version Hints
I purposely went overboard with version hints, just to show where we could put them. But there would be better, more concise places that we could use.

Also, I did wonder whether our docs should always reflect the latest version. I.e. once 2023.3 is released with the feature toggle removed, should we remove all version hints?

**What should we do with version hints?** 

## Version Hints Everywhere
To reduce version hints further, we _could_ delete them entirely, even with 2023.2 not including event retention by default.

For example, the docker compose scripts that mount a volume. We could just silently add `eventExports` to that script. Sure, it would be useless, but it also wouldn't harm anyone.

**Can we remove hints in places where event export setup is not going to cause errors?**

