### PR TITLE
Add Jira project type bullet point

### DIFF
--- a/src/pages/docs/approvals/jira-service-management/index.md
+++ b/src/pages/docs/approvals/jira-service-management/index.md
@@ -35,6 +35,7 @@ JSM Integration feature enabled.
 Before you can use the Octopus Deploy/JSM integration, you'll need to:
 
 1. Create a service account in JSM for use by Octopus
+1. In Jira, create or use an existing project of the _IT service management_ type.
 1. Request and install a new Octopus license required to enable the JSM feature.
 1. Configure a connection from Octopus to JSM.
 1. Configure which deployments require an approved CR.


### PR DESCRIPTION
I've added a Jira project type bullet point to the https://octopus.com/docs/approvals/jira-service-management doc based on feedback from Sean Stanway here: https://octopusdeploy.slack.com/archives/C27FNL3QW/p1684744161165749.

If required, I'm happy to edit the wording as I appreciate it could be said differently / better! :-)