### PR TITLE
changed section of core design decision to warning

### DIFF
--- a/src/pages/docs/projects/version-control/unsupported-config-as-code-scenarios.md
+++ b/src/pages/docs/projects/version-control/unsupported-config-as-code-scenarios.md
@@ -24,7 +24,9 @@ That scaffolding data includes (but is not limited to):
 
 That data is not stored in source control because it is shared across multiple projects.
 
+:::div{.warning}
 An error will occur when Octopus Deploy attempts to load a process from source control with one or more of those items missing. You'll be unable to create releases until those errors are resolved.
+:::
 
 ## Syncing Multiple Instances
 


### PR DESCRIPTION
Based on [this ticket ](https://help.octopus.com/t/entitynotfoundexception-when-transferring-project-between-servers/29107/9)and [this RND thread](https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1685931595843349)