### PR TITLE
Harmonise icons for auth provider compatibility page

### DIFF
--- a/src/pages/docs/security/authentication/auth-provider-compatibility.md
+++ b/src/pages/docs/security/authentication/auth-provider-compatibility.md
@@ -19,14 +19,14 @@ The following table shows login support for each authentication provider in Octo
 
 |                                       | Octopus Server     | Octopus Cloud   | Octopus Linux Container |
 |---------------------------------------|:------------------:|:---------------:|:-----------------------:|
-| Username and Password                 | :white_check_mark: | :white_check_mark: **\*** | :white_check_mark: |
-| Active Directory Authentication       | :white_check_mark: | :x:&nbsp;&nbsp;&nbsp; | :x: |
-| Azure Active Directory Authentication | :white_check_mark: | :white_check_mark:&nbsp;&nbsp;&nbsp; | :white_check_mark: |
-| GoogleApps Authentication             | :white_check_mark: | :white_check_mark:&nbsp;&nbsp;&nbsp; | :white_check_mark: |
-| LDAP Authentication (**2021.2+**)| :white_check_mark: | :x:&nbsp;&nbsp;&nbsp; | :white_check_mark: |
-| Okta Authentication                   | :white_check_mark: | :white_check_mark:&nbsp;&nbsp;&nbsp; | :white_check_mark: |
-| GitHub                                | :x: | :white_check_mark: **\*** | :x: |
-| Guest Login                           | :white_check_mark: | :white_check_mark:&nbsp;&nbsp;&nbsp; | :white_check_mark: |
+| Username and Password                 | <i class="fa-circle-check"></i> | <i class="fa-circle-check"></i> **\*** | <i class="fa-circle-check"></i> |
+| Active Directory Authentication       | <i class="fa-circle-check"></i> | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i> |
+| Azure Active Directory Authentication | <i class="fa-circle-check"></i> | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-circle-check"></i> |
+| GoogleApps Authentication             | <i class="fa-circle-check"></i> | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-circle-check"></i> |
+| LDAP Authentication (**2021.2+**)| <i class="fa-circle-check"></i> | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-circle-check"></i> |
+| Okta Authentication                   | <i class="fa-circle-check"></i> | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-circle-check"></i> |
+| GitHub                                | <i class="fa-solid fa-circle-xmark"></i> | <i class="fa-circle-check"></i> **\*** | <i class="fa-solid fa-circle-xmark"></i> |
+| Guest Login                           | <i class="fa-circle-check"></i> | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-circle-check"></i> |
 
 **Note:** Entries marked with **\*** are only supported via [Octopus ID](/docs/security/authentication/octopusid-authentication).
 
@@ -36,14 +36,14 @@ Octopus allows [external groups and roles](/docs/security/users-and-teams/extern
 
 |                                         | Octopus Server     | Octopus Cloud   | Octopus Linux Container |
 |-----------------------------------------|:------------------:|:---------------:|:-----------------------:|
-| Username and Password                   | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; |
-| Active Directory Authentication         | :white_check_mark:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; |
-| Azure Active Directory Authentication   | :white_check_mark: **\*** | :white_check_mark: **\*** | :white_check_mark: **\*** |
-| GoogleApps Authentication               | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; |
-| LDAP Authentication (**2021.2+**)  | :white_check_mark:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; | :white_check_mark:&nbsp;&nbsp;&nbsp; |
-| Okta Authentication                     | :white_check_mark: **†**| :white_check_mark: **†** | :white_check_mark: **†**|
-| GitHub                                  | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; |
-| Guest Login                             | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; | :x:&nbsp;&nbsp;&nbsp; |
+| Username and Password                   | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; |
+| Active Directory Authentication         | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; |
+| Azure Active Directory Authentication   | <i class="fa-circle-check"></i> **\*** | <i class="fa-circle-check"></i> **\*** | <i class="fa-circle-check"></i> **\*** |
+| GoogleApps Authentication               | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; |
+| LDAP Authentication (**2021.2+**)  | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-circle-check"></i>&nbsp;&nbsp;&nbsp; |
+| Okta Authentication                     | <i class="fa-circle-check"></i> **†**| <i class="fa-circle-check"></i> **†** | <i class="fa-circle-check"></i> **†**|
+| GitHub                                  | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; |
+| Guest Login                             | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; | <i class="fa-solid fa-circle-xmark"></i>&nbsp;&nbsp;&nbsp; |
 
 **\*** For Azure Active Directory (AAD) users and groups, these must also be mapped in the Azure App Registration. Please read the [Mapping AAD users into Octopus teams](/docs/security/authentication/azure-ad-authentication/#mapping-aad-users-into-octopus-teams-optional) section for more details. For Octopus Cloud, external groups and roles cannot be configured for Azure AD when using [Octopus ID](/docs/security/authentication/octopusid-authentication).
 


### PR DESCRIPTION
This one might need reviewing manually on the staging site as there are `nbsp;` to help with the spacing in the table (they might not be needed now thanks to the CSS)