### PR TITLE
Remove the "index" suffix from redirects

### DIFF
--- a/src/pages/docs/administration/auditing.md
+++ b/src/pages/docs/administration/auditing.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/users-and-teams/auditing/index
+redirect: https://octopus.com/docs/security/users-and-teams/auditing
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/authentication-providers/active-directory-authentication.md
+++ b/src/pages/docs/administration/authentication-providers/active-directory-authentication.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/authentication/active-directory/index
+redirect: https://octopus.com/docs/security/authentication/active-directory
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/authentication-providers/index.md
+++ b/src/pages/docs/administration/authentication-providers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/authentication/index
+redirect: https://octopus.com/docs/security/authentication
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/authentication/active-directory-authentication/index.md
+++ b/src/pages/docs/administration/authentication/active-directory-authentication/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/authentication/active-directory/index
+redirect: https://octopus.com/docs/security/authentication/active-directory
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/authentication/authentication-providers/active-directory-authentication/index.md
+++ b/src/pages/docs/administration/authentication/authentication-providers/active-directory-authentication/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/authentication/active-directory/index
+redirect: https://octopus.com/docs/security/authentication/active-directory
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/authentication/authentication-providers/index.md
+++ b/src/pages/docs/administration/authentication/authentication-providers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/authentication/index
+redirect: https://octopus.com/docs/security/authentication
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/authentication/index.md
+++ b/src/pages/docs/administration/authentication/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/authentication/index
+redirect: https://octopus.com/docs/security/authentication
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/community/index.md
+++ b/src/pages/docs/administration/community/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-licenses/community/index
+redirect: https://octopus.com/docs/administration/managing-licenses/community
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/configuration/index.md
+++ b/src/pages/docs/administration/configuration/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/configuration/server-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/configuration/server-configuration-and-file-storage/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration-and-file-storage
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/configuration/server-configuration/index.md
+++ b/src/pages/docs/administration/configuration/server-configuration/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/configuration/subscriptions/index.md
+++ b/src/pages/docs/administration/configuration/subscriptions/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/configuration/tentacle-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/configuration/tentacle-configuration-and-file-storage/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/docker/index.md
+++ b/src/pages/docs/administration/docker/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/docker/index
+redirect: https://octopus.com/docs/deployments/docker
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/configure/configuring-ha.md
+++ b/src/pages/docs/administration/high-availability/configure/configuring-ha.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/configure/index
+redirect: https://octopus.com/docs/administration/high-availability/configure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/configuring-octopus-for-high-availability.md
+++ b/src/pages/docs/administration/high-availability/configuring-octopus-for-high-availability.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/configure/index
+redirect: https://octopus.com/docs/administration/high-availability/configure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/designing-high-availability.md
+++ b/src/pages/docs/administration/high-availability/designing-high-availability.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/design/index
+redirect: https://octopus.com/docs/administration/high-availability/design
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/migrate/migrating-to-high-availability.md
+++ b/src/pages/docs/administration/high-availability/migrate/migrating-to-high-availability.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/migrate/index
+redirect: https://octopus.com/docs/administration/high-availability/migrate
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/migrating-to-ha.md
+++ b/src/pages/docs/administration/high-availability/migrating-to-ha.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/migrate/index
+redirect: https://octopus.com/docs/administration/high-availability/migrate
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/migrating-to-ha/migrating-to-high-availability.md
+++ b/src/pages/docs/administration/high-availability/migrating-to-ha/migrating-to-high-availability.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/migrate/index
+redirect: https://octopus.com/docs/administration/high-availability/migrate
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/troubleshoot/index.md
+++ b/src/pages/docs/administration/high-availability/troubleshoot/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/troubleshooting/index
+redirect: https://octopus.com/docs/administration/high-availability/troubleshooting
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/troubleshoot/troubleshooting.md
+++ b/src/pages/docs/administration/high-availability/troubleshoot/troubleshooting.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/troubleshooting/index
+redirect: https://octopus.com/docs/administration/high-availability/troubleshooting
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/troubleshooting-node-limits-exceeded-error.md
+++ b/src/pages/docs/administration/high-availability/troubleshooting-node-limits-exceeded-error.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/troubleshooting/index
+redirect: https://octopus.com/docs/administration/high-availability/troubleshooting
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/high-availability/troubleshooting/troubleshooting.md
+++ b/src/pages/docs/administration/high-availability/troubleshooting/troubleshooting.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/high-availability/troubleshooting/index
+redirect: https://octopus.com/docs/administration/high-availability/troubleshooting
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/managing-infrastructure/workers/index.md
+++ b/src/pages/docs/administration/managing-infrastructure/workers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/managing-users-and-teams/auditing.md
+++ b/src/pages/docs/administration/managing-users-and-teams/auditing.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/users-and-teams/auditing/index
+redirect: https://octopus.com/docs/security/users-and-teams/auditing
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/managing-users-and-teams/index.md
+++ b/src/pages/docs/administration/managing-users-and-teams/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/users-and-teams/index
+redirect: https://octopus.com/docs/security/users-and-teams
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/moving-your-octopus/index.md
+++ b/src/pages/docs/administration/moving-your-octopus/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/moving-your-octopus/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/moving-your-octopus
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/moving-your-octopus/replicating-your-octopus-instance-in-a-test-environment.md
+++ b/src/pages/docs/administration/moving-your-octopus/replicating-your-octopus-instance-in-a-test-environment.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/moving-your-octopus/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/moving-your-octopus
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/octopus-database/index.md
+++ b/src/pages/docs/administration/octopus-database/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/data/octopus-database/index
+redirect: https://octopus.com/docs/administration/data/octopus-database
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/octopus-dsc/index.md
+++ b/src/pages/docs/administration/octopus-dsc/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/octopus-dsc/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/octopus-dsc
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/octopus-server-configuration-file.md
+++ b/src/pages/docs/administration/octopus-server-configuration-file.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration-and-file-storage
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/octopus-tentacle-communication/index.md
+++ b/src/pages/docs/administration/octopus-tentacle-communication/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/octopus-tentacle-communication/index
+redirect: https://octopus.com/docs/security/octopus-tentacle-communication
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/outbound-requests.md
+++ b/src/pages/docs/administration/outbound-requests.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/outbound-requests/index
+redirect: https://octopus.com/docs/security/outbound-requests
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/performance.md
+++ b/src/pages/docs/administration/performance.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/performance/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/performance
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/retention-policies/retention-policies-and-channels.md
+++ b/src/pages/docs/administration/retention-policies/retention-policies-and-channels.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/retention-policies/index
+redirect: https://octopus.com/docs/administration/retention-policies
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/security/cve/index.md
+++ b/src/pages/docs/administration/security/cve/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/cve/index
+redirect: https://octopus.com/docs/security/cve
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/security/exposing-octopus/index.md
+++ b/src/pages/docs/administration/security/exposing-octopus/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/exposing-octopus/index
+redirect: https://octopus.com/docs/security/exposing-octopus
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/security/index.md
+++ b/src/pages/docs/administration/security/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/index
+redirect: https://octopus.com/docs/security
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/security/octopus-tentacle-communication/index.md
+++ b/src/pages/docs/administration/security/octopus-tentacle-communication/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/octopus-tentacle-communication/index
+redirect: https://octopus.com/docs/security/octopus-tentacle-communication
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/security/outbound-requests.md
+++ b/src/pages/docs/administration/security/outbound-requests.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/outbound-requests/index
+redirect: https://octopus.com/docs/security/outbound-requests
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/server-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/server-configuration-and-file-storage/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration-and-file-storage/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration-and-file-storage
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/server-configuration/index.md
+++ b/src/pages/docs/administration/server-configuration/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/server-configuration
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/spaces/private-space.md
+++ b/src/pages/docs/administration/spaces/private-space.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/spaces/index
+redirect: https://octopus.com/docs/administration/spaces
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/subscription-events.md
+++ b/src/pages/docs/administration/subscription-events.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/subscription_events.md
+++ b/src/pages/docs/administration/subscription_events.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/subscriptions/index.md
+++ b/src/pages/docs/administration/subscriptions/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/subscriptions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/tentacle-configuration-and-file-storage/index.md
+++ b/src/pages/docs/administration/tentacle-configuration-and-file-storage/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage/index
+redirect: https://octopus.com/docs/administration/managing-infrastructure/tentacle-configuration-and-file-storage
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/upgrading/long-term-support.md
+++ b/src/pages/docs/administration/upgrading/long-term-support.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/upgrading/migrating-from-redgate-deployment-manager-to-octopus-deploy.md
+++ b/src/pages/docs/administration/upgrading/migrating-from-redgate-deployment-manager-to-octopus-deploy.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/index
+redirect: https://octopus.com/docs/administration/upgrading
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/upgrading/upgrading-from-octopus-2.6/index.md
+++ b/src/pages/docs/administration/upgrading/upgrading-from-octopus-2.6/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/legacy/upgrading-from-octopus-2.6.5-2018.10lts/index
+redirect: https://octopus.com/docs/administration/upgrading/legacy/upgrading-from-octopus-2.6.5-2018.10lts
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/upgrading/upgrading-from-octopus-3.x.md
+++ b/src/pages/docs/administration/upgrading/upgrading-from-octopus-3.x.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/guide/index
+redirect: https://octopus.com/docs/administration/upgrading/guide
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/workers/external-workers.md
+++ b/src/pages/docs/administration/workers/external-workers.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/administration/workers/index.md
+++ b/src/pages/docs/administration/workers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/api/index.md
+++ b/src/pages/docs/api-and-integration/api/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/api/sensitive-properties-api-changes-in-release-3.3.md
+++ b/src/pages/docs/api-and-integration/api/sensitive-properties-api-changes-in-release-3.3.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/app-veyor/index.md
+++ b/src/pages/docs/api-and-integration/app-veyor/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/appveyor/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/appveyor
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/appveyor/index.md
+++ b/src/pages/docs/api-and-integration/appveyor/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/appveyor/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/appveyor
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/bitbucket-pipelines/index.md
+++ b/src/pages/docs/api-and-integration/bitbucket-pipelines/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/bitbucket-pipelines/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/bitbucket-pipelines
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/examples/index.md
+++ b/src/pages/docs/api-and-integration/examples/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/examples/index
+redirect: https://octopus.com/docs/octopus-rest-api/examples
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/index.md
+++ b/src/pages/docs/api-and-integration/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/jenkins.md
+++ b/src/pages/docs/api-and-integration/jenkins.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/jenkins/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/jenkins
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/metadata/index.md
+++ b/src/pages/docs/api-and-integration/metadata/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/migration-api/index.md
+++ b/src/pages/docs/api-and-integration/migration-api/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/migration-api/index
+redirect: https://octopus.com/docs/octopus-rest-api/migration-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/octo.exe-command-line/index.md
+++ b/src/pages/docs/api-and-integration/octo.exe-command-line/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/octopus-rest-api.md
+++ b/src/pages/docs/api-and-integration/octopus-rest-api.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/octopus.client.md
+++ b/src/pages/docs/api-and-integration/octopus.client.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus.client/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus.client
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/octopus.migrator.exe-command-line/index.md
+++ b/src/pages/docs/api-and-integration/octopus.migrator.exe-command-line/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus.migrator.exe-command-line/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus.migrator.exe-command-line
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/octopus.server.exe-command-line/index.md
+++ b/src/pages/docs/api-and-integration/octopus.server.exe-command-line/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus.server.exe-command-line/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus.server.exe-command-line
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/server-extensibility/building-an-authentication-provider/index.md
+++ b/src/pages/docs/api-and-integration/server-extensibility/building-an-authentication-provider/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/server-extensibility/building-an-authentication-provider/index
+redirect: https://octopus.com/docs/administration/server-extensibility/building-an-authentication-provider
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/server-extensibility/index.md
+++ b/src/pages/docs/api-and-integration/server-extensibility/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/server-extensibility/index
+redirect: https://octopus.com/docs/administration/server-extensibility
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/team-foundation-server-tfs.md
+++ b/src/pages/docs/api-and-integration/team-foundation-server-tfs.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tentacle.exe-command-line/index.md
+++ b/src/pages/docs/api-and-integration/tentacle.exe-command-line/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/tentacle.exe-command-line/index
+redirect: https://octopus.com/docs/octopus-rest-api/tentacle.exe-command-line
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-azure-devops/index.md
+++ b/src/pages/docs/api-and-integration/tfs-azure-devops/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-azure-devops/using-octopack.md
+++ b/src/pages/docs/api-and-integration/tfs-azure-devops/using-octopack.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-azure-devops/using-octopus-extension/index.md
+++ b/src/pages/docs/api-and-integration/tfs-azure-devops/using-octopus-extension/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-azure-devops/using-octopus-extension/manually-install-the-build-task.md
+++ b/src/pages/docs/api-and-integration/tfs-azure-devops/using-octopus-extension/manually-install-the-build-task.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-vsts/index.md
+++ b/src/pages/docs/api-and-integration/tfs-vsts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-vsts/using-octopack.md
+++ b/src/pages/docs/api-and-integration/tfs-vsts/using-octopack.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-vsts/using-octopus-extension/index.md
+++ b/src/pages/docs/api-and-integration/tfs-vsts/using-octopus-extension/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/tfs-vsts/using-octopus-extension/manually-install-the-build-task.md
+++ b/src/pages/docs/api-and-integration/tfs-vsts/using-octopus-extension/manually-install-the-build-task.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/api-and-integration/visual-studio-team-services-vsts.md
+++ b/src/pages/docs/api-and-integration/visual-studio-team-services-vsts.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/approvals/service-now/index.md
+++ b/src/pages/docs/approvals/service-now/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/approvals/servicenow/index
+redirect: https://octopus.com/docs/approvals/servicenow
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/adding-steps/index.md
+++ b/src/pages/docs/deploying-applications/adding-steps/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/index
+redirect: https://octopus.com/docs/projects/steps
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/automatic-deployment-triggers/index.md
+++ b/src/pages/docs/deploying-applications/automatic-deployment-triggers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/project-triggers/index
+redirect: https://octopus.com/docs/projects/project-triggers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/aws-deployments/cloudformation/index.md
+++ b/src/pages/docs/deploying-applications/aws-deployments/cloudformation/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/aws/index
+redirect: https://octopus.com/docs/deployments/aws
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/azure-deployments/deploying-to-service-fabric/connecting-securely-with-azure-active-directory/index.md
+++ b/src/pages/docs/deploying-applications/azure-deployments/deploying-to-service-fabric/connecting-securely-with-azure-active-directory/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/azure-deployments/deploying-to-service-fabric/connecting-securely-with-client-certificates/index.md
+++ b/src/pages/docs/deploying-applications/azure-deployments/deploying-to-service-fabric/connecting-securely-with-client-certificates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/certificates/index.md
+++ b/src/pages/docs/deploying-applications/certificates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/certificates/index
+redirect: https://octopus.com/docs/deployments/certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/configuration-files/index.md
+++ b/src/pages/docs/deploying-applications/configuration-files/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/custom-scripts/index.md
+++ b/src/pages/docs/deploying-applications/custom-scripts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/custom-scripts/index
+redirect: https://octopus.com/docs/deployments/custom-scripts
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/deploy-java-applications/index.md
+++ b/src/pages/docs/deploying-applications/deploy-java-applications/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/java/index
+redirect: https://octopus.com/docs/deployments/java
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/deploying-to-azure/deploying-a-package-to-an-azure-cloud-service/index.md
+++ b/src/pages/docs/deploying-applications/deploying-to-azure/deploying-a-package-to-an-azure-cloud-service/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/deploying-to-azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps/index.md
+++ b/src/pages/docs/deploying-applications/deploying-to-azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index
+redirect: https://octopus.com/docs/deployments/azure/deploying-a-package-to-an-azure-web-app
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/deploying-to-azure/index.md
+++ b/src/pages/docs/deploying-applications/deploying-to-azure/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/index
+redirect: https://octopus.com/docs/deployments/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/deployment-process/configuration-features/index.md
+++ b/src/pages/docs/deploying-applications/deployment-process/configuration-features/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/deployment-process/index.md
+++ b/src/pages/docs/deploying-applications/deployment-process/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/deployment-process/index
+redirect: https://octopus.com/docs/projects/deployment-process
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/docker-containers/index.md
+++ b/src/pages/docs/deploying-applications/docker-containers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/docker/index
+redirect: https://octopus.com/docs/deployments/docker
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/index.md
+++ b/src/pages/docs/deploying-applications/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/index
+redirect: https://octopus.com/docs/deployments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/run-steps-in-parallel/index.md
+++ b/src/pages/docs/deploying-applications/run-steps-in-parallel/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/conditions/index
+redirect: https://octopus.com/docs/projects/steps/conditions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/sql-server-databases/index.md
+++ b/src/pages/docs/deploying-applications/sql-server-databases/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/sql-server/index
+redirect: https://octopus.com/docs/deployments/databases/sql-server
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/step-templates/custom-step-templates/index.md
+++ b/src/pages/docs/deploying-applications/step-templates/custom-step-templates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/index
+redirect: https://octopus.com/docs/projects/steps
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/step-templates/index.md
+++ b/src/pages/docs/deploying-applications/step-templates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/index
+redirect: https://octopus.com/docs/projects/steps
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/step-templates/updating-step-templates/index.md
+++ b/src/pages/docs/deploying-applications/step-templates/updating-step-templates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/index
+redirect: https://octopus.com/docs/projects/steps
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deploying-applications/variables/index.md
+++ b/src/pages/docs/deploying-applications/variables/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-applications/configuration-files/index.md
+++ b/src/pages/docs/deployment-applications/configuration-files/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/aws-deployments/cloudformation/index.md
+++ b/src/pages/docs/deployment-examples/aws-deployments/cloudformation/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/aws/cloudformation/index
+redirect: https://octopus.com/docs/deployments/aws/cloudformation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/aws-deployments/index.md
+++ b/src/pages/docs/deployment-examples/aws-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/aws/index
+redirect: https://octopus.com/docs/deployments/aws
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/aws-deployments/permissions/index.md
+++ b/src/pages/docs/deployment-examples/aws-deployments/permissions/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/aws/permissions/index
+redirect: https://octopus.com/docs/deployments/aws/permissions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/aws-deployments/removecloudformation/index.md
+++ b/src/pages/docs/deployment-examples/aws-deployments/removecloudformation/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/aws/removecloudformation/index
+redirect: https://octopus.com/docs/deployments/aws/removecloudformation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/aws-deployments/s3/index.md
+++ b/src/pages/docs/deployment-examples/aws-deployments/s3/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/aws/s3/index
+redirect: https://octopus.com/docs/deployments/aws/s3
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/ase/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/ase/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/ase/index
+redirect: https://octopus.com/docs/deployments/azure/ase
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/cloud-services/cloud-service-concepts.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/cloud-services/cloud-service-concepts.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/cloud-services/getting-started-with-azure-cloud-services.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/cloud-services/getting-started-with-azure-cloud-services.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/cloud-services/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/cloud-services/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-cloud-service/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-cloud-service/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-web-app/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/deploying-a-package-to-an-azure-web-app/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index
+redirect: https://octopus.com/docs/deployments/azure/deploying-a-package-to-an-azure-web-app
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/deploying-to-azure-via-a-firewall/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/deploying-to-azure-via-a-firewall/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/deploying-to-azure-via-a-firewall/index
+redirect: https://octopus.com/docs/deployments/azure/deploying-to-azure-via-a-firewall
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/deploying-to-service-fabric/connecting-securely-with-azure-active-directory/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/deploying-to-service-fabric/connecting-securely-with-azure-active-directory/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-azure-active-directory/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-azure-active-directory
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/deploying-to-service-fabric/connecting-securely-with-client-certificates/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/deploying-to-service-fabric/connecting-securely-with-client-certificates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/deploying-to-service-fabric/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/deploying-to-service-fabric/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/index
+redirect: https://octopus.com/docs/deployments/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/resource-groups/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/resource-groups/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/resource-groups/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/resource-groups
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/running-azure-powershell/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/running-azure-powershell/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/running-azure-powershell/index
+redirect: https://octopus.com/docs/deployments/azure/running-azure-powershell
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/service-fabric/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/service-fabric/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/azure-deployments/service-fabric/version-automation-with-service-fabric-application-packages/index.md
+++ b/src/pages/docs/deployment-examples/azure-deployments/service-fabric/version-automation-with-service-fabric-application-packages/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/version-automation-with-service-fabric-application-packages/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/version-automation-with-service-fabric-application-packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/certificates/file-formats.md
+++ b/src/pages/docs/deployment-examples/certificates/file-formats.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/certificates/index
+redirect: https://octopus.com/docs/deployments/certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/certificates/index.md
+++ b/src/pages/docs/deployment-examples/certificates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/certificates/index
+redirect: https://octopus.com/docs/deployments/certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/custom-scripts/debugging-powershell-scripts/index.md
+++ b/src/pages/docs/deployment-examples/custom-scripts/debugging-powershell-scripts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/custom-scripts/debugging-powershell-scripts/index
+redirect: https://octopus.com/docs/deployments/custom-scripts/debugging-powershell-scripts
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/custom-scripts/index.md
+++ b/src/pages/docs/deployment-examples/custom-scripts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/custom-scripts/index
+redirect: https://octopus.com/docs/deployments/custom-scripts
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/custom-scripts/scripts-in-packages/index.md
+++ b/src/pages/docs/deployment-examples/custom-scripts/scripts-in-packages/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/custom-scripts/scripts-in-packages/index
+redirect: https://octopus.com/docs/deployments/custom-scripts/scripts-in-packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/database-deployments/common-patterns/index.md
+++ b/src/pages/docs/deployment-examples/database-deployments/common-patterns/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/common-patterns/index
+redirect: https://octopus.com/docs/deployments/databases/common-patterns
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/database-deployments/configuration/index.md
+++ b/src/pages/docs/deployment-examples/database-deployments/configuration/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/configuration/index
+redirect: https://octopus.com/docs/deployments/databases/configuration
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/database-deployments/index.md
+++ b/src/pages/docs/deployment-examples/database-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/index
+redirect: https://octopus.com/docs/deployments/databases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/database-deployments/mysql-flyway/index.md
+++ b/src/pages/docs/deployment-examples/database-deployments/mysql-flyway/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/mysql-flyway/index
+redirect: https://octopus.com/docs/deployments/databases/mysql-flyway
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/database-deployments/sql-server/index.md
+++ b/src/pages/docs/deployment-examples/database-deployments/sql-server/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/sql-server/index
+redirect: https://octopus.com/docs/deployments/databases/sql-server
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/deploying-mobile-applications.md
+++ b/src/pages/docs/deployment-examples/deploying-mobile-applications.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/index
+redirect: https://octopus.com/docs/deployments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/deploying-packages/index.md
+++ b/src/pages/docs/deployment-examples/deploying-packages/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/packages/index
+redirect: https://octopus.com/docs/deployments/packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/docker-containers/index.md
+++ b/src/pages/docs/deployment-examples/docker-containers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/docker/index
+redirect: https://octopus.com/docs/deployments/docker
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/index.md
+++ b/src/pages/docs/deployment-examples/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/index
+redirect: https://octopus.com/docs/deployments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/java-applications/index.md
+++ b/src/pages/docs/deployment-examples/java-applications/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/java/index
+redirect: https://octopus.com/docs/deployments/java
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/deploy-container/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/deploy-container/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/kubernetes/deploy-container/index
+redirect: https://octopus.com/docs/deployments/kubernetes/deploy-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/deploy-ingress/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/deploy-ingress/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/kubernetes/deploy-ingress/index
+redirect: https://octopus.com/docs/deployments/kubernetes/deploy-ingress
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/deploy-service/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/deploy-service/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/kubernetes/deploy-service/index
+redirect: https://octopus.com/docs/deployments/kubernetes/deploy-service
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/helm-update/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/helm-update/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/kubernetes/helm-update/index
+redirect: https://octopus.com/docs/deployments/kubernetes/helm-update
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/kubernetes/index
+redirect: https://octopus.com/docs/deployments/kubernetes
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/kubectl/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/kubectl/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/kubernetes/kubectl/index
+redirect: https://octopus.com/docs/deployments/kubernetes/kubectl
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/kubernetes-deployments/kubernetes-target/index.md
+++ b/src/pages/docs/deployment-examples/kubernetes-deployments/kubernetes-target/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/kubernetes-target/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/kubernetes-target
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/mobile-application-deployments.md
+++ b/src/pages/docs/deployment-examples/mobile-application-deployments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/index
+redirect: https://octopus.com/docs/deployments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/nginx-on-linux-deployments/index.md
+++ b/src/pages/docs/deployment-examples/nginx-on-linux-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/nginx/index
+redirect: https://octopus.com/docs/deployments/nginx
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/nginx-on-nix-deployments/index.md
+++ b/src/pages/docs/deployment-examples/nginx-on-nix-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/nginx/index
+redirect: https://octopus.com/docs/deployments/nginx
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/node-deployments/index.md
+++ b/src/pages/docs/deployment-examples/node-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/node-js/index
+redirect: https://octopus.com/docs/deployments/node-js
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/node-on-linux-deployments/index.md
+++ b/src/pages/docs/deployment-examples/node-on-linux-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/node-js/index
+redirect: https://octopus.com/docs/deployments/node-js
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/package-deployments/index.md
+++ b/src/pages/docs/deployment-examples/package-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/packages/index
+redirect: https://octopus.com/docs/deployments/packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/sql-server-databases.md
+++ b/src/pages/docs/deployment-examples/sql-server-databases.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/databases/index
+redirect: https://octopus.com/docs/deployments/databases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/terraform-deployments/apply-terraform/index.md
+++ b/src/pages/docs/deployment-examples/terraform-deployments/apply-terraform/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes/index
+redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/terraform-deployments/destroy-terraform/index.md
+++ b/src/pages/docs/deployment-examples/terraform-deployments/destroy-terraform/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes/index
+redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/terraform-deployments/index.md
+++ b/src/pages/docs/deployment-examples/terraform-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/index
+redirect: https://octopus.com/docs/deployments/terraform
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-examples/terraform-deployments/plan-terraform/index.md
+++ b/src/pages/docs/deployment-examples/terraform-deployments/plan-terraform/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/plan-terraform/index
+redirect: https://octopus.com/docs/deployments/terraform/plan-terraform
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/blue-green-deployments/index.md
+++ b/src/pages/docs/deployment-patterns/blue-green-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/patterns/blue-green-deployments/index
+redirect: https://octopus.com/docs/deployments/patterns/blue-green-deployments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/clustered-listening-tentacles/index.md
+++ b/src/pages/docs/deployment-patterns/clustered-listening-tentacles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/clustered-listening-tentacles/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/clustered-listening-tentacles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/elastic-and-transient-environments/index.md
+++ b/src/pages/docs/deployment-patterns/elastic-and-transient-environments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/patterns/elastic-and-transient-environments/index
+redirect: https://octopus.com/docs/deployments/patterns/elastic-and-transient-environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/index.md
+++ b/src/pages/docs/deployment-patterns/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/patterns/index
+redirect: https://octopus.com/docs/deployments/patterns
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployment-pattern.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployment-pattern.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/index.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-multi-tenant-project.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-multi-tenant-project.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/tenant-creation/index
+redirect: https://octopus.com/docs/tenants/tenant-creation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-tenant.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-tenant.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/tenant-creation/index
+redirect: https://octopus.com/docs/tenants/tenant-creation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/deploying-a-simple-multi-tenant-project.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/deploying-a-simple-multi-tenant-project.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/designing-a-multi-tenant-upgrade-process.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/designing-a-multi-tenant-upgrade-process.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/index.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployment-guide/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployments-prior-to-octopus-3.4.md
+++ b/src/pages/docs/deployment-patterns/multi-tenant-deployments/multi-tenant-deployments-prior-to-octopus-3.4.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/channels/index.md
+++ b/src/pages/docs/deployment-process/channels/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/channels/index
+redirect: https://octopus.com/docs/releases/channels
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/conditions/index.md
+++ b/src/pages/docs/deployment-process/conditions/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/conditions/index
+redirect: https://octopus.com/docs/projects/steps/conditions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/configuration-features/advanced-configuration-transforms-examples.md
+++ b/src/pages/docs/deployment-process/configuration-features/advanced-configuration-transforms-examples.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/configuration-features/configuration-transforms/index.md
+++ b/src/pages/docs/deployment-process/configuration-features/configuration-transforms/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/configuration-features/index.md
+++ b/src/pages/docs/deployment-process/configuration-features/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/configuration-files/advanced-configuration-transforms-examples.md
+++ b/src/pages/docs/deployment-process/configuration-files/advanced-configuration-transforms-examples.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/configuration-files/configuration-transforms.md
+++ b/src/pages/docs/deployment-process/configuration-files/configuration-transforms.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/configuration-files/index.md
+++ b/src/pages/docs/deployment-process/configuration-files/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/coordinating-multiple-projects/deploy-release-step/index.md
+++ b/src/pages/docs/deployment-process/coordinating-multiple-projects/deploy-release-step/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/coordinating-multiple-projects/deploy-release-step/index
+redirect: https://octopus.com/docs/projects/coordinating-multiple-projects/deploy-release-step
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/coordinating-multiple-projects/index.md
+++ b/src/pages/docs/deployment-process/coordinating-multiple-projects/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/coordinating-multiple-projects/index
+redirect: https://octopus.com/docs/projects/coordinating-multiple-projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/deploy-to-a-specific-subset-of-targets.md
+++ b/src/pages/docs/deployment-process/deploy-to-a-specific-subset-of-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/execution-containers-for-workers/index.md
+++ b/src/pages/docs/deployment-process/execution-containers-for-workers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/execution-containers-for-workers/index
+redirect: https://octopus.com/docs/projects/steps/execution-containers-for-workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/index.md
+++ b/src/pages/docs/deployment-process/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/deployment-process/index
+redirect: https://octopus.com/docs/projects/deployment-process
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/issue-tracking/index.md
+++ b/src/pages/docs/deployment-process/issue-tracking/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/issue-tracking/index
+redirect: https://octopus.com/docs/releases/issue-tracking
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/lifecycles/index.md
+++ b/src/pages/docs/deployment-process/lifecycles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/operations-runbooks/index.md
+++ b/src/pages/docs/deployment-process/operations-runbooks/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/index
+redirect: https://octopus.com/docs/runbooks
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/project-triggers/index.md
+++ b/src/pages/docs/deployment-process/project-triggers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/project-triggers/index
+redirect: https://octopus.com/docs/projects/project-triggers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/project-triggers/scheduled-runbook-trigger.md
+++ b/src/pages/docs/deployment-process/project-triggers/scheduled-runbook-trigger.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/scheduled-runbook-trigger/index
+redirect: https://octopus.com/docs/runbooks/scheduled-runbook-trigger
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/projects/coordinating-multiple-projects/deploy-release-step/index.md
+++ b/src/pages/docs/deployment-process/projects/coordinating-multiple-projects/deploy-release-step/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/coordinating-multiple-projects/deploy-release-step/index
+redirect: https://octopus.com/docs/projects/coordinating-multiple-projects/deploy-release-step
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/projects/coordinating-multiple-projects/index.md
+++ b/src/pages/docs/deployment-process/projects/coordinating-multiple-projects/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/coordinating-multiple-projects/index
+redirect: https://octopus.com/docs/projects/coordinating-multiple-projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/projects/index.md
+++ b/src/pages/docs/deployment-process/projects/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/index
+redirect: https://octopus.com/docs/projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/projects/reporting.md
+++ b/src/pages/docs/deployment-process/projects/reporting.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/reporting/index
+redirect: https://octopus.com/docs/administration/reporting
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/releases/deploy-to-a-specific-subset-of-targets.md
+++ b/src/pages/docs/deployment-process/releases/deploy-to-a-specific-subset-of-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/releases/index.md
+++ b/src/pages/docs/deployment-process/releases/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/releases/scheduled-deployments.md
+++ b/src/pages/docs/deployment-process/releases/scheduled-deployments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/conditions/index.md
+++ b/src/pages/docs/deployment-process/steps/conditions/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/conditions/index
+redirect: https://octopus.com/docs/projects/steps/conditions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/conditions/run-steps-in-parallel.md
+++ b/src/pages/docs/deployment-process/steps/conditions/run-steps-in-parallel.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/conditions/index
+redirect: https://octopus.com/docs/projects/steps/conditions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/configuration-files/advanced-configuration-transforms-examples.md
+++ b/src/pages/docs/deployment-process/steps/configuration-files/advanced-configuration-transforms-examples.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features/configuration-transforms
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/configuration-files/index.md
+++ b/src/pages/docs/deployment-process/steps/configuration-files/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/deploying-packages/index.md
+++ b/src/pages/docs/deployment-process/steps/deploying-packages/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/packages/index
+redirect: https://octopus.com/docs/deployments/packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/index.md
+++ b/src/pages/docs/deployment-process/steps/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/index
+redirect: https://octopus.com/docs/projects/steps
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/run-steps-in-parallel.md
+++ b/src/pages/docs/deployment-process/steps/run-steps-in-parallel.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/conditions/index
+redirect: https://octopus.com/docs/projects/steps/conditions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/steps/using-target-roles-in-deployment-steps.md
+++ b/src/pages/docs/deployment-process/steps/using-target-roles-in-deployment-steps.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/index
+redirect: https://octopus.com/docs/projects/steps
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/variables/index.md
+++ b/src/pages/docs/deployment-process/variables/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-process/variables/scoping-variables/index.md
+++ b/src/pages/docs/deployment-process/variables/scoping-variables/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-targets/azure-web-apps/index.md
+++ b/src/pages/docs/deployment-targets/azure-web-apps/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/web-app-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/web-app-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployment-targets/index.md
+++ b/src/pages/docs/deployment-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/azure/cloud-services/getting-started-with-azure-cloud-services.md
+++ b/src/pages/docs/deployments/azure/cloud-services/getting-started-with-azure-cloud-services.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/azure/deploying-a-package-to-an-azure-cloud-service/index.md
+++ b/src/pages/docs/deployments/azure/deploying-a-package-to-an-azure-cloud-service/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/cloud-services/index
+redirect: https://octopus.com/docs/deployments/azure/cloud-services
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/azure/deploying-to-service-fabric/connecting-securely-with-azure-active-directory/index.md
+++ b/src/pages/docs/deployments/azure/deploying-to-service-fabric/connecting-securely-with-azure-active-directory/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-azure-active-directory/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-azure-active-directory
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/azure/deploying-to-service-fabric/connecting-securely-with-client-certificates/index.md
+++ b/src/pages/docs/deployments/azure/deploying-to-service-fabric/connecting-securely-with-client-certificates/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric/connecting-securely-with-client-certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/azure/deploying-to-service-fabric/index.md
+++ b/src/pages/docs/deployments/azure/deploying-to-service-fabric/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/azure/service-fabric/index
+redirect: https://octopus.com/docs/deployments/azure/service-fabric
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/certificates/file-formats.md
+++ b/src/pages/docs/deployments/certificates/file-formats.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/certificates/index
+redirect: https://octopus.com/docs/deployments/certificates
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/patterns/multi-tenant-deployments/index.md
+++ b/src/pages/docs/deployments/patterns/multi-tenant-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-multi-tenant-project.md
+++ b/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-multi-tenant-project.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/tenant-creation/index
+redirect: https://octopus.com/docs/tenants/tenant-creation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-tenant.md
+++ b/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/creating-your-first-tenant.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/tenant-creation/index
+redirect: https://octopus.com/docs/tenants/tenant-creation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/deploying-a-simple-multi-tenant-project.md
+++ b/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/deploying-a-simple-multi-tenant-project.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/designing-a-multi-tenant-upgrade-process.md
+++ b/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/designing-a-multi-tenant-upgrade-process.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/index.md
+++ b/src/pages/docs/deployments/patterns/multi-tenant-deployments/multi-tenant-deployment-guide/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/guides/index
+redirect: https://octopus.com/docs/tenants/guides
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/terraform/apply-terraform/index.md
+++ b/src/pages/docs/deployments/terraform/apply-terraform/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes/index
+redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/terraform/destroy-terraform/index.md
+++ b/src/pages/docs/deployments/terraform/destroy-terraform/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes/index
+redirect: https://octopus.com/docs/deployments/terraform/apply-terraform-changes
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/terraform/managed-accounts/index.md
+++ b/src/pages/docs/deployments/terraform/managed-accounts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/preparing-your-terraform-environment/index
+redirect: https://octopus.com/docs/deployments/terraform/preparing-your-terraform-environment
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/deployments/terraform/remote-state/index.md
+++ b/src/pages/docs/deployments/terraform/remote-state/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/terraform/preparing-your-terraform-environment/index
+redirect: https://octopus.com/docs/deployments/terraform/preparing-your-terraform-environment
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/create-a-release.md
+++ b/src/pages/docs/getting-started-guides/create-a-release.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/deployment-process.md
+++ b/src/pages/docs/getting-started-guides/deployment-process.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/deployment-process/index
+redirect: https://octopus.com/docs/projects/deployment-process
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/deployment-targets.md
+++ b/src/pages/docs/getting-started-guides/deployment-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/environments.md
+++ b/src/pages/docs/getting-started-guides/environments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/environments/index
+redirect: https://octopus.com/docs/infrastructure/environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/hello-world.md
+++ b/src/pages/docs/getting-started-guides/hello-world.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/index.md
+++ b/src/pages/docs/getting-started-guides/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/lifecycle.md
+++ b/src/pages/docs/getting-started-guides/lifecycle.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/configuration-features.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/configuration-features.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/index.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/octopus-cli.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/octopus-cli.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/projects.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/projects.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/index
+redirect: https://octopus.com/docs/projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/rest-api.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/rest-api.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/runbooks.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/runbooks.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/index
+redirect: https://octopus.com/docs/runbooks
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/tentacles.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/tentacles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/variables.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/variables.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/octopus-concepts/workers.md
+++ b/src/pages/docs/getting-started-guides/octopus-concepts/workers.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/package-your-software.md
+++ b/src/pages/docs/getting-started-guides/package-your-software.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/projects.md
+++ b/src/pages/docs/getting-started-guides/projects.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/index
+redirect: https://octopus.com/docs/projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/releases.md
+++ b/src/pages/docs/getting-started-guides/releases.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/runbooks.md
+++ b/src/pages/docs/getting-started-guides/runbooks.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/index
+redirect: https://octopus.com/docs/runbooks
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/setup-octopus-deploy.md
+++ b/src/pages/docs/getting-started-guides/setup-octopus-deploy.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/tentacles.md
+++ b/src/pages/docs/getting-started-guides/tentacles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/the-cicd-pipeline.md
+++ b/src/pages/docs/getting-started-guides/the-cicd-pipeline.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/the-octopus-web-portal.md
+++ b/src/pages/docs/getting-started-guides/the-octopus-web-portal.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/upgrading.md
+++ b/src/pages/docs/getting-started-guides/upgrading.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/index
+redirect: https://octopus.com/docs/administration/upgrading
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/variables.md
+++ b/src/pages/docs/getting-started-guides/variables.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started-guides/workers.md
+++ b/src/pages/docs/getting-started-guides/workers.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/configure-your-environments.md
+++ b/src/pages/docs/getting-started/configure-your-environments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/environments/index
+redirect: https://octopus.com/docs/infrastructure/environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/connect-your-deployment-targets-to-octopus.md
+++ b/src/pages/docs/getting-started/connect-your-deployment-targets-to-octopus.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/create-a-release.md
+++ b/src/pages/docs/getting-started/create-a-release.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/define-your-deployment-process.md
+++ b/src/pages/docs/getting-started/define-your-deployment-process.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/deployment-process/index
+redirect: https://octopus.com/docs/projects/deployment-process
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/deployment-targets.md
+++ b/src/pages/docs/getting-started/deployment-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/environments.md
+++ b/src/pages/docs/getting-started/environments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/environments/index
+redirect: https://octopus.com/docs/infrastructure/environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/getting-started-guides.md
+++ b/src/pages/docs/getting-started/getting-started-guides.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/hello-world.md
+++ b/src/pages/docs/getting-started/hello-world.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/lifecycle.md
+++ b/src/pages/docs/getting-started/lifecycle.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/configuration-features.md
+++ b/src/pages/docs/getting-started/octopus-concepts/configuration-features.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/deployment-process.md
+++ b/src/pages/docs/getting-started/octopus-concepts/deployment-process.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/deployment-process/index
+redirect: https://octopus.com/docs/projects/deployment-process
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/deployment-targets.md
+++ b/src/pages/docs/getting-started/octopus-concepts/deployment-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/environments.md
+++ b/src/pages/docs/getting-started/octopus-concepts/environments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/environments/index
+redirect: https://octopus.com/docs/infrastructure/environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/index.md
+++ b/src/pages/docs/getting-started/octopus-concepts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/lifecycle.md
+++ b/src/pages/docs/getting-started/octopus-concepts/lifecycle.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/octopus-cli.md
+++ b/src/pages/docs/getting-started/octopus-concepts/octopus-cli.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/octopus-cloud.md
+++ b/src/pages/docs/getting-started/octopus-concepts/octopus-cloud.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-cloud/index
+redirect: https://octopus.com/docs/octopus-cloud
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/octopus-server.md
+++ b/src/pages/docs/getting-started/octopus-concepts/octopus-server.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/octopus-web-portal.md
+++ b/src/pages/docs/getting-started/octopus-concepts/octopus-web-portal.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/projects.md
+++ b/src/pages/docs/getting-started/octopus-concepts/projects.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/index
+redirect: https://octopus.com/docs/projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/releases.md
+++ b/src/pages/docs/getting-started/octopus-concepts/releases.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/rest-api.md
+++ b/src/pages/docs/getting-started/octopus-concepts/rest-api.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/runbooks.md
+++ b/src/pages/docs/getting-started/octopus-concepts/runbooks.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/index
+redirect: https://octopus.com/docs/runbooks
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/target-roles.md
+++ b/src/pages/docs/getting-started/octopus-concepts/target-roles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/tentacles.md
+++ b/src/pages/docs/getting-started/octopus-concepts/tentacles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/upgrading.md
+++ b/src/pages/docs/getting-started/octopus-concepts/upgrading.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/index
+redirect: https://octopus.com/docs/administration/upgrading
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/variables.md
+++ b/src/pages/docs/getting-started/octopus-concepts/variables.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/octopus-concepts/workers.md
+++ b/src/pages/docs/getting-started/octopus-concepts/workers.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/package-your-software.md
+++ b/src/pages/docs/getting-started/package-your-software.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/setup-octopus-deploy.md
+++ b/src/pages/docs/getting-started/setup-octopus-deploy.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/terms.md
+++ b/src/pages/docs/getting-started/terms.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/the-cicd-pipeline.md
+++ b/src/pages/docs/getting-started/the-cicd-pipeline.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/the-octopus-web-portal.md
+++ b/src/pages/docs/getting-started/the-octopus-web-portal.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/getting-started/upgrading.md
+++ b/src/pages/docs/getting-started/upgrading.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/index
+redirect: https://octopus.com/docs/administration/upgrading
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/guides/azure-deployments/creating-an-azure-account/creating-an-azure-service-principal-account/index.md
+++ b/src/pages/docs/guides/azure-deployments/creating-an-azure-account/creating-an-azure-service-principal-account/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/azure/index
+redirect: https://octopus.com/docs/infrastructure/accounts/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/guides/azure-deployments/resource-groups/deploy-using-an-azure-resource-group-template/index.md
+++ b/src/pages/docs/guides/azure-deployments/resource-groups/deploy-using-an-azure-resource-group-template/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/resource-groups/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/resource-groups
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/guides/deploying-asp.net-core-web-applications/json-configuration-variables-feature/index.md
+++ b/src/pages/docs/guides/deploying-asp.net-core-web-applications/json-configuration-variables-feature/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/guides/elastic-and-transient-environments/index.md
+++ b/src/pages/docs/guides/elastic-and-transient-environments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/patterns/elastic-and-transient-environments/index
+redirect: https://octopus.com/docs/deployments/patterns/elastic-and-transient-environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/guides/multi-tenant-deployments/index.md
+++ b/src/pages/docs/guides/multi-tenant-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/how-to/sensitive-properties-api-changes-in-release-3.3/index.md
+++ b/src/pages/docs/how-to/sensitive-properties-api-changes-in-release-3.3/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/examples/index
+redirect: https://octopus.com/docs/octopus-rest-api/examples
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/aws/creating-an-aws-account/index.md
+++ b/src/pages/docs/infrastructure/aws/creating-an-aws-account/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/aws/index
+redirect: https://octopus.com/docs/infrastructure/accounts/aws
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/aws/index.md
+++ b/src/pages/docs/infrastructure/aws/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/aws/index
+redirect: https://octopus.com/docs/infrastructure/accounts/aws
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure-cloud-service-target.md
+++ b/src/pages/docs/infrastructure/azure-cloud-service-target.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/cloud-service-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/cloud-service-targets/index.md
+++ b/src/pages/docs/infrastructure/azure/cloud-service-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/cloud-service-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/creating-an-azure-account/creating-an-azure-management-certificate-account.md
+++ b/src/pages/docs/infrastructure/azure/creating-an-azure-account/creating-an-azure-management-certificate-account.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/azure/index
+redirect: https://octopus.com/docs/infrastructure/accounts/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/creating-an-azure-account/creating-an-azure-service-principal-account.md
+++ b/src/pages/docs/infrastructure/azure/creating-an-azure-account/creating-an-azure-service-principal-account.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/azure/index
+redirect: https://octopus.com/docs/infrastructure/accounts/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/creating-an-azure-account/index.md
+++ b/src/pages/docs/infrastructure/azure/creating-an-azure-account/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/azure/index
+redirect: https://octopus.com/docs/infrastructure/accounts/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/index.md
+++ b/src/pages/docs/infrastructure/azure/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/service-fabric-cluster-targets/index.md
+++ b/src/pages/docs/infrastructure/azure/service-fabric-cluster-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/service-fabric-cluster-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/service-fabric-cluster-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/azure/web-app-targets/index.md
+++ b/src/pages/docs/infrastructure/azure/web-app-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/web-app-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/web-app-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/aws/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/aws/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/aws/index
+redirect: https://octopus.com/docs/infrastructure/accounts/aws
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/azure/azure-targets.md
+++ b/src/pages/docs/infrastructure/deployment-targets/azure/azure-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes-cluster/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes-cluster/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/kubernetes-target/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/kubernetes-target
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/linux/requirements.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/requirements.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-targets/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/linux/tentacle/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/tentacle/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/ssh-targets/configuring-ssh-connection.md
+++ b/src/pages/docs/infrastructure/deployment-targets/ssh-targets/configuring-ssh-connection.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/ssh-targets/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/ssh-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/target-roles/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/target-roles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/windows-targets/azure-virtual-machines/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/windows-targets/azure-virtual-machines/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/azure-virtual-machines/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/azure-virtual-machines
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/windows-targets/clustered-listening-tentacles/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/windows-targets/clustered-listening-tentacles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/clustered-listening-tentacles/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/clustered-listening-tentacles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/windows-targets/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/windows-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/deployment-targets/windows-targets/requirements/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/windows-targets/requirements/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/requirements/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/requirements
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/dynamic-infrastructure/index.md
+++ b/src/pages/docs/infrastructure/dynamic-infrastructure/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/dynamic-infrastructure/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/dynamic-infrastructure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/environments/accounts/azure-account.md
+++ b/src/pages/docs/infrastructure/environments/accounts/azure-account.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/azure/index
+redirect: https://octopus.com/docs/infrastructure/accounts/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/environments/accounts/index.md
+++ b/src/pages/docs/infrastructure/environments/accounts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/accounts/index
+redirect: https://octopus.com/docs/infrastructure/accounts
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/environments/elastic-and-transient-environments/index.md
+++ b/src/pages/docs/infrastructure/environments/elastic-and-transient-environments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/deployments/patterns/elastic-and-transient-environments/index
+redirect: https://octopus.com/docs/deployments/patterns/elastic-and-transient-environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/environments/target-roles/index.md
+++ b/src/pages/docs/infrastructure/environments/target-roles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/lifecycles/index.md
+++ b/src/pages/docs/infrastructure/lifecycles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/ssh-targets/configuring-ssh-connection.md
+++ b/src/pages/docs/infrastructure/ssh-targets/configuring-ssh-connection.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/ssh-targets/index.md
+++ b/src/pages/docs/infrastructure/ssh-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/linux
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/target-roles/index.md
+++ b/src/pages/docs/infrastructure/target-roles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/windows-targets/azure-virtual-machines/index.md
+++ b/src/pages/docs/infrastructure/windows-targets/azure-virtual-machines/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/azure-virtual-machines/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/azure-virtual-machines
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/windows-targets/index.md
+++ b/src/pages/docs/infrastructure/windows-targets/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/infrastructure/windows-targets/requirements/index.md
+++ b/src/pages/docs/infrastructure/windows-targets/requirements/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/requirements/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/requirements
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/downloads.md
+++ b/src/pages/docs/installation/downloads.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/installing-octopus/index.md
+++ b/src/pages/docs/installation/installing-octopus/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/installing-tentacles/azure-virtual-machines/index.md
+++ b/src/pages/docs/installation/installing-tentacles/azure-virtual-machines/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/azure-virtual-machines/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/windows/azure-virtual-machines
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/installing-tentacles/index.md
+++ b/src/pages/docs/installation/installing-tentacles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets/tentacle
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/octopus-in-container/docker-compose-windows.md
+++ b/src/pages/docs/installation/octopus-in-container/docker-compose-windows.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/octopus-server-linux-container/index
+redirect: https://octopus.com/docs/installation/octopus-server-linux-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/octopus-in-container/index.md
+++ b/src/pages/docs/installation/octopus-in-container/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/octopus-server-linux-container/index
+redirect: https://octopus.com/docs/installation/octopus-server-linux-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/octopus-in-container/octopus-server-container-linux.md
+++ b/src/pages/docs/installation/octopus-in-container/octopus-server-container-linux.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/octopus-server-linux-container/index
+redirect: https://octopus.com/docs/installation/octopus-server-linux-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/octopus-in-container/octopus-server-container-windows.md
+++ b/src/pages/docs/installation/octopus-in-container/octopus-server-container-windows.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/octopus-server-linux-container/index
+redirect: https://octopus.com/docs/installation/octopus-server-linux-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/octopus-in-container/octopus-server-container.md
+++ b/src/pages/docs/installation/octopus-in-container/octopus-server-container.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/octopus-server-linux-container/index
+redirect: https://octopus.com/docs/installation/octopus-server-linux-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/octopus-server-windows-container.md
+++ b/src/pages/docs/installation/octopus-server-windows-container.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/octopus-server-linux-container/index
+redirect: https://octopus.com/docs/installation/octopus-server-linux-container
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/installation/upgrading.md
+++ b/src/pages/docs/installation/upgrading.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/index
+redirect: https://octopus.com/docs/administration/upgrading
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/key-concepts/environments/index.md
+++ b/src/pages/docs/key-concepts/environments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/environments/index
+redirect: https://octopus.com/docs/infrastructure/environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/key-concepts/lifecycles/index.md
+++ b/src/pages/docs/key-concepts/lifecycles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/key-concepts/machine-roles.md
+++ b/src/pages/docs/key-concepts/machine-roles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/key-concepts/projects/index.md
+++ b/src/pages/docs/key-concepts/projects/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/index
+redirect: https://octopus.com/docs/projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/key-concepts/projects/project-triggers/index.md
+++ b/src/pages/docs/key-concepts/projects/project-triggers/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/project-triggers/index
+redirect: https://octopus.com/docs/projects/project-triggers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/managing-releases/channels/index.md
+++ b/src/pages/docs/managing-releases/channels/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/channels/index
+redirect: https://octopus.com/docs/releases/channels
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/managing-releases/index.md
+++ b/src/pages/docs/managing-releases/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/managing-releases/issue-tracking/index.md
+++ b/src/pages/docs/managing-releases/issue-tracking/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/issue-tracking/index
+redirect: https://octopus.com/docs/releases/issue-tracking
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/managing-releases/lifecycles/index.md
+++ b/src/pages/docs/managing-releases/lifecycles/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/api.md
+++ b/src/pages/docs/octopus-concepts/api.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/configuration-features.md
+++ b/src/pages/docs/octopus-concepts/configuration-features.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/steps/configuration-features/index
+redirect: https://octopus.com/docs/projects/steps/configuration-features
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/deployment-process.md
+++ b/src/pages/docs/octopus-concepts/deployment-process.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/deployment-process/index
+redirect: https://octopus.com/docs/projects/deployment-process
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/deployment-targets.md
+++ b/src/pages/docs/octopus-concepts/deployment-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/environments.md
+++ b/src/pages/docs/octopus-concepts/environments.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/environments/index
+redirect: https://octopus.com/docs/infrastructure/environments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/index.md
+++ b/src/pages/docs/octopus-concepts/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/lifecycle.md
+++ b/src/pages/docs/octopus-concepts/lifecycle.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/lifecycles/index
+redirect: https://octopus.com/docs/releases/lifecycles
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/octo.exe.md
+++ b/src/pages/docs/octopus-concepts/octo.exe.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/octopus-cli.md
+++ b/src/pages/docs/octopus-concepts/octopus-cli.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/octopus-cloud.md
+++ b/src/pages/docs/octopus-concepts/octopus-cloud.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-cloud/index
+redirect: https://octopus.com/docs/octopus-cloud
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/octopus-deploy-server.md
+++ b/src/pages/docs/octopus-concepts/octopus-deploy-server.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/octopus-server.md
+++ b/src/pages/docs/octopus-concepts/octopus-server.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/installation/index
+redirect: https://octopus.com/docs/installation
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/octopus-web-portal.md
+++ b/src/pages/docs/octopus-concepts/octopus-web-portal.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/operations-runbooks.md
+++ b/src/pages/docs/octopus-concepts/operations-runbooks.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/index
+redirect: https://octopus.com/docs/runbooks
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/projects.md
+++ b/src/pages/docs/octopus-concepts/projects.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/index
+redirect: https://octopus.com/docs/projects
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/releases.md
+++ b/src/pages/docs/octopus-concepts/releases.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/rest-api.md
+++ b/src/pages/docs/octopus-concepts/rest-api.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/target-roles.md
+++ b/src/pages/docs/octopus-concepts/target-roles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/tentacles.md
+++ b/src/pages/docs/octopus-concepts/tentacles.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/deployment-targets/index
+redirect: https://octopus.com/docs/infrastructure/deployment-targets
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/upgrading.md
+++ b/src/pages/docs/octopus-concepts/upgrading.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/administration/upgrading/index
+redirect: https://octopus.com/docs/administration/upgrading
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/variables.md
+++ b/src/pages/docs/octopus-concepts/variables.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/variables/index
+redirect: https://octopus.com/docs/projects/variables
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-concepts/workers.md
+++ b/src/pages/docs/octopus-concepts/workers.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/infrastructure/workers/index
+redirect: https://octopus.com/docs/infrastructure/workers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-rest-api/examples/users/index.md
+++ b/src/pages/docs/octopus-rest-api/examples/users/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/examples/users-and-teams/index
+redirect: https://octopus.com/docs/octopus-rest-api/examples/users-and-teams
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/octopus-rest-api/octo.exe-command-line/index.md
+++ b/src/pages/docs/octopus-rest-api/octo.exe-command-line/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli/index
+redirect: https://octopus.com/docs/octopus-rest-api/octopus-cli
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/index.md
+++ b/src/pages/docs/operations-runbooks/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/index
+redirect: https://octopus.com/docs/runbooks
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-examples/azure/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-examples/azure/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/azure
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-examples/azure/resource-groups/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-examples/azure/resource-groups/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/resource-groups/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/azure/resource-groups
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-examples/databases/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-examples/databases/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/databases/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/databases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-examples/emergency/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-examples/emergency/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/emergency/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/emergency
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-examples/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-examples/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-examples/routine/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-examples/routine/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-examples/routine/index
+redirect: https://octopus.com/docs/runbooks/runbook-examples/routine
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-permissions/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-permissions/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-permissions/index
+redirect: https://octopus.com/docs/runbooks/runbook-permissions
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbook-publishing/index.md
+++ b/src/pages/docs/operations-runbooks/runbook-publishing/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbook-publishing/index
+redirect: https://octopus.com/docs/runbooks/runbook-publishing
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/runbooks-vs-deployments/index.md
+++ b/src/pages/docs/operations-runbooks/runbooks-vs-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/runbooks-vs-deployments/index
+redirect: https://octopus.com/docs/runbooks/runbooks-vs-deployments
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/operations-runbooks/scheduled-runbook-trigger/index.md
+++ b/src/pages/docs/operations-runbooks/scheduled-runbook-trigger/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/scheduled-runbook-trigger/index
+redirect: https://octopus.com/docs/runbooks/scheduled-runbook-trigger
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/overview.md
+++ b/src/pages/docs/overview.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/getting-started/index
+redirect: https://octopus.com/docs/getting-started
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/build-servers/metadata/index.md
+++ b/src/pages/docs/packaging-applications/build-servers/metadata/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopack.md
+++ b/src/pages/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopack.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/manually-install-the-build-task.md
+++ b/src/pages/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/manually-install-the-build-task.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/index
+redirect: https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/create-packages/nuget-packages.md
+++ b/src/pages/docs/packaging-applications/create-packages/nuget-packages.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages.md
+++ b/src/pages/docs/packaging-applications/creating-packages.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/applications/index.md
+++ b/src/pages/docs/packaging-applications/creating-packages/applications/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/applications/web-apps/index.md
+++ b/src/pages/docs/packaging-applications/creating-packages/applications/web-apps/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/nuget-packages/index.md
+++ b/src/pages/docs/packaging-applications/creating-packages/nuget-packages/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/nuget-packages/manually.md
+++ b/src/pages/docs/packaging-applications/creating-packages/nuget-packages/manually.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/nuget-packages/push-a-nuget-package-that-already-exists.md
+++ b/src/pages/docs/packaging-applications/creating-packages/nuget-packages/push-a-nuget-package-that-already-exists.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md
+++ b/src/pages/docs/packaging-applications/creating-packages/nuget-packages/using-octopack/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/package-id.md
+++ b/src/pages/docs/packaging-applications/creating-packages/package-id.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/creating-packages/supported-packages.md
+++ b/src/pages/docs/packaging-applications/creating-packages/supported-packages.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/nuget-packages.md
+++ b/src/pages/docs/packaging-applications/nuget-packages.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/nuget-packages/using-octopack/index.md
+++ b/src/pages/docs/packaging-applications/nuget-packages/using-octopack/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/octopack/index.md
+++ b/src/pages/docs/packaging-applications/octopack/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/octopack/push-a-nuget-package-that-already-exists.md
+++ b/src/pages/docs/packaging-applications/octopack/push-a-nuget-package-that-already-exists.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack/index
+redirect: https://octopus.com/docs/packaging-applications/create-packages/octopack
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/package-id.md
+++ b/src/pages/docs/packaging-applications/package-id.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/package-repositories/built-in-repository-reindexing.md
+++ b/src/pages/docs/packaging-applications/package-repositories/built-in-repository-reindexing.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository/index
+redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/package-repositories/built-in-repository/built-in-repository-reindexing.md
+++ b/src/pages/docs/packaging-applications/package-repositories/built-in-repository/built-in-repository-reindexing.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository/index
+redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/package-repositories/built-in-repository/pushing-packages-to-the-built-in-repository.md
+++ b/src/pages/docs/packaging-applications/package-repositories/built-in-repository/pushing-packages-to-the-built-in-repository.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository/index
+redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/package-repositories/pushing-packages-to-the-built-in-repository.md
+++ b/src/pages/docs/packaging-applications/package-repositories/pushing-packages-to-the-built-in-repository.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository/index
+redirect: https://octopus.com/docs/packaging-applications/package-repositories/built-in-repository
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/package-repositories/registries/index.md
+++ b/src/pages/docs/packaging-applications/package-repositories/registries/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/package-repositories/docker-registries/index
+redirect: https://octopus.com/docs/packaging-applications/package-repositories/docker-registries
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/supported-packages.md
+++ b/src/pages/docs/packaging-applications/supported-packages.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/packaging-applications/versioning-in-octopus-deploy/index.md
+++ b/src/pages/docs/packaging-applications/versioning-in-octopus-deploy/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/packaging-applications/index
+redirect: https://octopus.com/docs/packaging-applications
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/projects/project-triggers/scheduled-runbook-trigger.md
+++ b/src/pages/docs/projects/project-triggers/scheduled-runbook-trigger.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/runbooks/scheduled-runbook-trigger/index
+redirect: https://octopus.com/docs/runbooks/scheduled-runbook-trigger
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/projects/version-control/configuring-version-control-on-a-project.md
+++ b/src/pages/docs/projects/version-control/configuring-version-control-on-a-project.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/projects/version-control/converting/index
+redirect: https://octopus.com/docs/projects/version-control/converting
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/reference/security-and-encryption/index.md
+++ b/src/pages/docs/reference/security-and-encryption/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/security/index
+redirect: https://octopus.com/docs/security
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/release-management/index.md
+++ b/src/pages/docs/release-management/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/index
+redirect: https://octopus.com/docs/releases
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/release-management/issue-tracking/index.md
+++ b/src/pages/docs/release-management/issue-tracking/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/releases/issue-tracking/index
+redirect: https://octopus.com/docs/releases/issue-tracking
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/support/sensitive-properties-api-changes-in-release-3.3.md
+++ b/src/pages/docs/support/sensitive-properties-api-changes-in-release-3.3.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/octopus-rest-api/index
+redirect: https://octopus.com/docs/octopus-rest-api
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/tenants/connecting-targets.md
+++ b/src/pages/docs/tenants/connecting-targets.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false

--- a/src/pages/docs/tenants/create-a-tenant.md
+++ b/src/pages/docs/tenants/create-a-tenant.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: https://octopus.com/docs/tenants/index
+redirect: https://octopus.com/docs/tenants
 pubDate:  2023-01-01
 navSearch: false
 navSitemap: false


### PR DESCRIPTION
The "index" suffix refers to the markdown file, but on the server we serve from the folder.