### PR TITLE
Fix invalid fragments (remove :)

### DIFF
--- a/src/pages/docs/administration/upgrading/legacy/upgrading-from-octopus-2.6.5-2018.10lts/index.md
+++ b/src/pages/docs/administration/upgrading/legacy/upgrading-from-octopus-2.6.5-2018.10lts/index.md
@@ -25,13 +25,13 @@ We recommend choosing from two different approaches for upgrading from **Octopus
 - Create a new Octopus Server and migrate to it. We recommend this approach.
 - Install over the top of your existing Octopus Server.
 
-### Approach 1: Install the new version of Octopus on a new server, and migrate to it (recommended) {#UpgradingfromOctopus2.6-Approach1:Install3.xonanewserver,andmigratetoit(recommended)}
+### Approach 1: Install the new version of Octopus on a new server, and migrate to it (recommended) {#UpgradingfromOctopus2.6-Approach1-Install3.xonanewserver,andmigratetoit(recommended)}
 
 If you are able to provision a new Octopus Server, this is the safest option. That way, if something goes wrong in the upgrade, it will be easy to discard the new server and start the process again. And when it works, you can decommission the old Octopus Server.
 
 Read the full guide: [Upgrade with a new Server instance](/docs/administration/upgrading/legacy/upgrading-from-octopus-2.6.5-2018.10lts/upgrade-with-a-new-server-instance)
 
-### Approach 2: In-place (Over the Top) upgrade of an existing server {#UpgradingfromOctopus2.6-Approach2:In-place(overthetop)upgradeofanexistingserver}
+### Approach 2: In-place (Over the Top) upgrade of an existing server {#UpgradingfromOctopus2.6-Approach2-In-place(overthetop)upgradeofanexistingserver}
 
 It is possible to install newer versions of Octopus over the top of a **Octopus 2.6** instance. You'll upgrade the Tentacles, then upgrade the Octopus Server.
 

--- a/src/pages/docs/deployments/azure/cloud-services/index.mdx
+++ b/src/pages/docs/deployments/azure/cloud-services/index.mdx
@@ -12,7 +12,7 @@ import AzureCloudServicesDeprecated from 'src/shared-content/deprecated-items/az
 
 Octopus Deploy supports deployment of [Azure Cloud Services](http://azure.microsoft.com/en-us/services/cloud-services/). This page will walk you through, step by step, setting up a deployment using the Octopus built-in **Deploy an Azure Cloud Service** step.
 
-## Step 1: Packaging \{#DeployingapackagetoanAzureCloudService-Step1:Packaging}
+## Step 1: Packaging \{#DeployingapackagetoanAzureCloudService-Step1-Packaging}
 
 An Azure cloud service package is normally compiled into a `.cspkg` file. This file will need to be [re-packed into a supported package](/docs/packaging-applications) for Octopus to consume. The easiest way to do this currently is to either create a simple zip file or use the [NuGet.exe command line tool](https://docs.microsoft.com/en-us/nuget/tools/nuget-exe-cli-reference). For example, the resulting NuGet package will look like this:
 
@@ -28,11 +28,11 @@ In order to make the NuGet package accessible to Octopus it needs to be uploaded
 ![Package feed](package-feed.png "width=500")
 :::
 
-## Step 2: Create an Azure account \{#DeployingapackagetoanAzureCloudService-Step2:CreateanAzureAccount}
+## Step 2: Create an Azure account \{#DeployingapackagetoanAzureCloudService-Step2-CreateanAzureAccount}
 
 If you haven't already, create an [Azure Management Certificate Account](/docs/infrastructure/accounts/azure) to grant Octopus Deploy access to your Azure Subscription.
 
-## Step 3: Create the Azure Cloud Service deployment step \{#DeployingapackagetoanAzureCloudService-Step3:CreatetheAzureCloudServicedeploymentstep}
+## Step 3: Create the Azure Cloud Service deployment step \{#DeployingapackagetoanAzureCloudService-Step3-CreatetheAzureCloudServicedeploymentstep}
 
 Add a new Azure Cloud Service Deployment Step to your project. For information about adding a step to the deployment process, see the [add step](/docs/projects/steps) section.
 
@@ -40,7 +40,7 @@ Add a new Azure Cloud Service Deployment Step to your project. For information a
 ![](/docs/deployments/azure/cloud-services/5865904.png "width=170")
 :::
 
-## Step 4: Configure your Azure Cloud Service step \{#DeployingapackagetoanAzureCloudService-Step4:ConfigureyourAzureCloudServicestep}
+## Step 4: Configure your Azure Cloud Service step \{#DeployingapackagetoanAzureCloudService-Step4-ConfigureyourAzureCloudServicestep}
 
 Once an Account is selected, the list of Cloud Services and Storage Accounts available to the Azure subscription associated with the chosen Account will be populated for you to choose from.
 

--- a/src/pages/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
+++ b/src/pages/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/index.md
@@ -22,17 +22,17 @@ Deploying an Azure Web App with Octopus Deploy behaves very similarly to the Vis
 The default values for these variables were chosen to match Visual Studio following the principle of least surprise. You will typically need to adjust these values depending on your specific circumstances.
 :::
 
-## Step 1: Packaging {#DeployingapackagetoanAzureWebApp-Step1:Packaging}
+## Step 1: Packaging {#DeployingapackagetoanAzureWebApp-Step1-Packaging}
 
 See the [packaging application docs](/docs/packaging-applications)
 
-## Step 2: Create an Azure account {#DeployingapackagetoanAzureWebApp-Step2:CreateanAzureAccount}
+## Step 2: Create an Azure account {#DeployingapackagetoanAzureWebApp-Step2-CreateanAzureAccount}
 
 If you haven't already, create an [Azure Account](/docs/infrastructure/accounts/azure) to grant Octopus Deploy access to your Azure Subscription.
 
 If instead you want to **dynamically** create you account during your deployment, check our [documentation on how to do so](/docs/infrastructure/deployment-targets/dynamic-infrastructure)
 
-## Step 3: Configure your Azure web app step {#DeployingapackagetoanAzureWebApp-Step4:ConfigureyourAzureWebAppstep}
+## Step 3: Configure your Azure web app step {#DeployingapackagetoanAzureWebApp-Step4-ConfigureyourAzureWebAppstep}
 
 1. Add a new **Deploy an Azure Web App** step to your [project's deployment process](/docs/projects/steps).
 

--- a/src/pages/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md
+++ b/src/pages/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/using-deployment-slots-with-azure-web-apps.md
@@ -27,7 +27,7 @@ The scripts below assume you have a variable named 'WebSite' that contains the n
 
 Follow the steps for [Azure Web App targets](/docs/infrastructure/deployment-targets/azure/web-app-targets).
 
-### Step 2: Create Staging Slot {#UsingDeploymentSlotswithAzureWebApps-Step1:CreateStagingSlot}
+### Step 2: Create Staging Slot {#UsingDeploymentSlotswithAzureWebApps-Step1-CreateStagingSlot}
 
 Create a [Run an Azure PowerShell Script](/docs/deployments/azure/running-azure-powershell) step.
 
@@ -67,7 +67,7 @@ So your step should look like:
 ![](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app/azure-remove-staging-slot-script.png "width=500")
 :::
 
-### Step 3: Deploy Your Package {#UsingDeploymentSlotswithAzureWebApps-Step2:DeployyourPackage}
+### Step 3: Deploy Your Package {#UsingDeploymentSlotswithAzureWebApps-Step2-DeployyourPackage}
 
 The next step is to deploy your package to the Staging slot.  We do this by creating a [Deploy an Azure Web App](/docs/deployments/azure/deploying-a-package-to-an-azure-web-app) step.
 
@@ -94,7 +94,7 @@ As shown below:
 You can choose to specify the slot directly on the deployment target, or directly on the step (if you wish to deploy to multiple different slots on the same Web App Service, for example), however, the slot on the target will take priority.
 :::
 
-### Step 4: Swap the Staging and Production Slots {#UsingDeploymentSlotswithAzureWebApps-Step3:SwaptheStagingandProductionSlots}
+### Step 4: Swap the Staging and Production Slots {#UsingDeploymentSlotswithAzureWebApps-Step3-SwaptheStagingandProductionSlots}
 
 The final step is to create another Azure PowerShell step to swap the Staging and Production slots.
 

--- a/src/pages/docs/deployments/html-and-javascript-application-deployments.md
+++ b/src/pages/docs/deployments/html-and-javascript-application-deployments.md
@@ -53,7 +53,7 @@ angular
 </html>
 ```
 
-### Step 1: Upload the package to the built-in repository {#DeployingHTMLandJavaScriptApplications-Step1:Uploadthepackagetothebuilt-inrepository}
+### Step 1: Upload the package to the built-in repository {#DeployingHTMLandJavaScriptApplications-Step1-Uploadthepackagetothebuilt-inrepository}
 
 Firstly we need to make the package available for Octopus to deploy.
 
@@ -68,7 +68,7 @@ We've crafted and packaged v1.0.0 of this sample application for you to try out 
 ![](/docs/deployments/images/5866205.png "width=500")
 :::
 
-### Step 2: Create the project, variables and deployment process {#DeployingHTMLandJavaScriptApplications-Step2:Createtheproject,variablesanddeploymentprocess}
+### Step 2: Create the project, variables and deployment process {#DeployingHTMLandJavaScriptApplications-Step2-Createtheproject,variablesanddeploymentprocess}
 
 Now we need to create the project and configure it ready to deploy our JavaScript application.
 
@@ -96,7 +96,7 @@ Now we need to create the project and configure it ready to deploy our JavaScrip
 ![](/docs/deployments/images/5866210.png "width=500")
 :::
 
-### Step 3: Deploy {#DeployingHTMLandJavaScriptApplications-Step3:Deploy}
+### Step 3: Deploy {#DeployingHTMLandJavaScriptApplications-Step3-Deploy}
 
 Now when we create a release for this project and deploy it we can see that Octopus has found the `MyApp.html` file and substituted the variable values into our expressions.
 
@@ -112,7 +112,7 @@ And finally when we load the application in our browser we can see the results h
 
 ![](/docs/deployments/images/5866211.png "width=500")
 
-### Step 4: Minify the JavaScript and deploy again {#DeployingHTMLandJavaScriptApplications-Step4:MinifytheJavaScriptanddeployagain!}
+### Step 4: Minify the JavaScript and deploy again {#DeployingHTMLandJavaScriptApplications-Step4-MinifytheJavaScriptanddeployagain!}
 
 This approach also works perfectly with minified sources. This is because the minifier won't change string literals like `"#{MyApp.ConfigValue1}"` and the substitution will work just like it did before. In this example we will just minify the JavaScript inline in the HTML file. You can get the same result by moving the JavaScript into an external file and minifying that.
 

--- a/src/pages/docs/deployments/java/deploying-java-applications.md
+++ b/src/pages/docs/deployments/java/deploying-java-applications.md
@@ -38,7 +38,7 @@ public class PressAnyKey {
 
 ## Deploying the application {#DeployingJavaapplications-Deployingtheapplication}
 
-### Step 1: Upload the application to the built-in repository {#DeployingJavaapplications-Step1:Uploadtheapplicationtothebuilt-inrepository}
+### Step 1: Upload the application to the built-in repository {#DeployingJavaapplications-Step1-Uploadtheapplicationtothebuilt-inrepository}
 
 In order to deploy the application with Octopus Deploy it must be compiled and packaged. This would usually be done by your build server but for the sake of this demonstration let's do it manually.
 
@@ -50,7 +50,7 @@ javac PressAnyKey.java
 2. Zip PressAnyKey.class into the archive `PressAnyKey.1.0.0.zip` (you can download a sample: [PressAnyKey.1.0.0.zip](https://download.octopusdeploy.com/demo/PressAnyKey.1.0.0.zip))
 3. Upload `PressAnyKey.1.0.0.zip` to the Octopus Deploy built-in feed (**Library ➜ Packages** or [follow the instructions here](/docs/packaging-applications/package-repositories/built-in-repository/#pushing-packages-to-the-built-in-repository)).
 
-### Step 2: Create the project and deployment process {#DeployingJavaapplications-Step2:Createtheprojectanddeploymentprocess}
+### Step 2: Create the project and deployment process {#DeployingJavaapplications-Step2-Createtheprojectanddeploymentprocess}
 
 1. Create a new project called **Press Any Key**.
 2. Add a **Deploy a package** step to the deployment process.
@@ -77,7 +77,7 @@ screen -d -m -S "PressAnyKey" java PressAnyKey
 The application must be launched in a new process or session so that control returns to the shell. Otherwise the deployment will wait until the application is terminated.
 :::
 
-### Step 3: Deploy {#DeployingJavaapplications-Step3:Deploy}
+### Step 3: Deploy {#DeployingJavaapplications-Step3-Deploy}
 
 Create a release and deploy.
 

--- a/src/pages/docs/deployments/windows/virtual-hard-drive-deployments.md
+++ b/src/pages/docs/deployments/windows/virtual-hard-drive-deployments.md
@@ -27,11 +27,11 @@ To deploy a Virtual Hard Drive, add a *Deploy a VHD* step. For information about
 ![](/docs/deployments/windows/images/deploying-virtual-hard-drives-configure-step.png "width=500")
 :::
 
-### Step 1: Select a package {#DeployingVirtualHardDrives-Step1:SelectaPackage}
+### Step 1: Select a package {#DeployingVirtualHardDrives-Step1-SelectaPackage}
 
 Use the Package Feed and Package ID fields to select the [package](/docs/packaging-applications) containing the Virtual Hard Drive (\*.vhd or \*.vhdx) to be installed. There must be a single VHD in the root of the package. The package may contain deployment scripts and other artifacts required by those scripts, but only a single VHD.
 
-### Step 2: Configure VHD options {#DeployingVirtualHardDrives-Step2:ConfigureVHDoptions}
+### Step 2: Configure VHD options {#DeployingVirtualHardDrives-Step2-ConfigureVHDoptions}
 
 +--------------------------+-----------------------------------------------------------------------------+
 | Field                    | Meaning                                                                     |

--- a/src/pages/docs/deployments/windows/windows-services.md
+++ b/src/pages/docs/deployments/windows/windows-services.md
@@ -20,11 +20,11 @@ To deploy a Windows Service, add a *Deploy a Windows Service* step. For informat
 ![Windows service configuration](/docs/deployments/windows/images/windows-service-configuration.png "width=500")
 :::
 
-### Step 1: Select a package {#WindowsServices-Step1:SelectaPackage}
+### Step 1: Select a package {#WindowsServices-Step1-SelectaPackage}
 
 Use the Package Feed and Package ID fields to select the [package](/docs/packaging-applications) containing the executable (.exe) to be installed as a Windows Service.
 
-### Step 2: Configure Windows Service options {#WindowsServices-Step2:ConfigureWindowsServiceoptions}
+### Step 2: Configure Windows Service options {#WindowsServices-Step2-ConfigureWindowsServiceoptions}
 
 | Field               | Meaning                                  |
 | ------------------- | ---------------------------------------- |

--- a/src/pages/docs/infrastructure/accounts/azure/index.md
+++ b/src/pages/docs/infrastructure/accounts/azure/index.md
@@ -224,7 +224,7 @@ The Azure Service Management APIs are being deprecated by Microsoft.  See [this 
 
 To create an Azure Management Certificate account as part of adding an [Azure subscription](#adding-azure-subscription), select Management Certificate as the Authentication Method.
 
-### Step 1: Management Certificate {#CreatinganAzureManagementCertificateAccount-Step2:ManagementCertificate}
+### Step 1: Management Certificate {#CreatinganAzureManagementCertificateAccount-Step2-ManagementCertificate}
 
 When using **Management Certificate**, Octopus authenticates with Azure using an X.509 certificate.  You can either upload an existing certificate (`.pfx`), or leave the field blank and Octopus will generate a certificate. Keep in mind that since Octopus securely stores the certificate internally, there is no need to upload a password protected `.pfx` file. If you would like to use one that is password protected, you will need to first remove the password. This can be done with the following commands.
 
@@ -242,7 +242,7 @@ Uploaded certificates can be viewed on the 'Management Certificates' tab of the 
 
 The certificate will be named **Octopus Deploy -``{Your Account Name}**.
 
-### Step 2: Save and Test {#CreatinganAzureManagementCertificateAccount-Step3:SaveandTest}
+### Step 2: Save and Test {#CreatinganAzureManagementCertificateAccount-Step3-SaveandTest}
 
 Click **Save and Test**, and Octopus will attempt to use the account credentials to access the Azure Service Management (ASM) API and list the Hosted Services in that subscription. You may need to include the appropriate IP Addresses for the Azure Data Center you are targeting in any firewall allow list. See [deploying to Azure via a Firewall](/docs/deployments/azure) for more details.
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/windows/automating-tentacle-installation.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/windows/automating-tentacle-installation.mdx
@@ -57,7 +57,7 @@ To configure the Tentacle in listening or polling mode, it's easiest to run the 
 
 When configuring your Tentacle, you can configure advanced options, such as [proxies](/docs/infrastructure/deployment-targets/proxy-support/), [machine policies](/docs/infrastructure/deployment-targets/machine-policies/), and [tenants](/docs/tenants/tenant-infrastructure), which can also be automated. Use the setup wizard to configure the Tentacle, and click the **Show Script** link which will show you the command-line equivalent to configure the Tentacle.
 
-## Example: Listening Tentacle \{#AutomatingTentacleinstallation-Example:ListeningTentacle}
+## Example: Listening Tentacle \{#AutomatingTentacleinstallation-Example-ListeningTentacle}
 
 The following example configures a [listening Tentacle](/docs/infrastructure/deployment-targets/tentacle/tentacle-communication/#listening-tentacles-recommended), and registers it with an Octopus Server:
 
@@ -108,7 +108,7 @@ $repository.machines.create($tentacle)
 Want to register your Tentacles another way? Take a look at our [examples](/docs/octopus-rest-api/examples/deployment-targets/) for ways to register Tentacles using the [Octopus REST API](/docs/octopus-rest-api).
 :::
 
-## Example: Polling Tentacle \{#AutomatingTentacleinstallation-Example:PollingTentacle}
+## Example: Polling Tentacle \{#AutomatingTentacleinstallation-Example-PollingTentacle}
 
 The following example configures a [Polling Tentacle](/docs/infrastructure/deployment-targets/tentacle/tentacle-communication/#polling-tentacles), and registers it with an Octopus Server:
 

--- a/src/pages/docs/security/octopus-tentacle-communication/index.md
+++ b/src/pages/docs/security/octopus-tentacle-communication/index.md
@@ -40,7 +40,7 @@ The X.509 certificates used by Octopus and Tentacle are generated on installatio
 Instead of having Tentacle generate its own certificate, you can [import a Tentacle certificate](/docs/infrastructure/deployment-targets/tentacle/windows/automating-tentacle-installation/#export-and-import-tentacle-certificates-without-a-profile) which is helpful when [automating Tentacle installation](/docs/infrastructure/deployment-targets/tentacle/windows/automating-tentacle-installation).
 :::
 
-### Scenario: Listening Tentacles {#Octopus-Tentaclecommunication-Scenario:ListeningTentacles}
+### Scenario: Listening Tentacles {#Octopus-Tentaclecommunication-Scenario-ListeningTentacles}
 
 Tentacle plays the role of server and Octopus as the client:
 
@@ -49,7 +49,7 @@ Tentacle plays the role of server and Octopus as the client:
 3. Octopus presents its certificate as a client certificate so the Tentacle can verify the identity of Octopus.
 4. Once the identity of the Octopus and Tentacle have been established the connection is held open and Octopus will start issuing commands to the Tentacle.
 
-### Scenario: Polling Tentacles {#Octopus-Tentaclecommunication-Scenario:PollingTentacles}
+### Scenario: Polling Tentacles {#Octopus-Tentaclecommunication-Scenario-PollingTentacles}
 
 Octopus plays the role of server and Tentacle as the client:
 

--- a/src/pages/docs/security/octopus-tentacle-communication/troubleshooting-schannel-and-tls.md
+++ b/src/pages/docs/security/octopus-tentacle-communication/troubleshooting-schannel-and-tls.md
@@ -25,18 +25,18 @@ Server-side:`System.IO.IOException: Unable to read data from the transport conne
 
 Depending on your circumstances you may need to implement one or more of these suggested solutions.
 
-### Solution: Ensure TLS 1.1 and/or TLS 1.2 are enabled on both machines {#TroubleshootingSchannelandTLS-Solution:EnsureTLS1.1and/orTLS1.2areenabledonbothmachines}
+### Solution: Ensure TLS 1.1 and/or TLS 1.2 are enabled on both machines {#TroubleshootingSchannelandTLS-Solution-EnsureTLS1.1and/orTLS1.2areenabledonbothmachines}
 
 TLS 1.1 and 1.2 are disabled by default on Windows Server 2003 and 2008 and need to be enabled by an administrator. See [this blog post](https://blogs.msdn.microsoft.com/kaushal/2011/10/02/support-for-ssltls-protocols-on-windows/) for more information. You can enable TLS 1.2 by changing the Windows registry (as described in that blog post), or use a tool like [IISCrypto](https://www.nartac.com/Products/IISCrypto). In some cases we have seen the Tentacle machine forced to use TLS 1.2 (via [KB3140245](https://support.microsoft.com/en-au/kb/3140245)) when the Octopus Server only supported TLS 1.0. Enabling TLS 1.2 on the Octopus Server fixed that problem.
 
-### Solution: Upgrade Octopus Server and Tentacle to 3.1 or newer {#TroubleshootingSchannelandTLS-Solution:UpgradeOctopusServerandTentacleto3.1ornewer}
+### Solution: Upgrade Octopus Server and Tentacle to 3.1 or newer {#TroubleshootingSchannelandTLS-Solution-UpgradeOctopusServerandTentacleto3.1ornewer}
 
 Upgrading Octopus Server and Tentacle to 3.1 or newer will enable TLS 1.2 which is enabled in most networks, noting TLS 1.2 needs to be enabled on Windows Server 2003 and Windows Server 2008.
 
 - Octopus Server and Tentacle prior to 3.1 used TLS 1.0 (due to a dependency on .NET Framework 4.0).
 - Octopus Server and Tentacle 3.1 or newer enable the newer TLS protocols and will use TLS 1.2 by default (with the updated dependency on .NET Framework 4.5).
 
-### Solution: Ensure Schannel is configured consistently on both servers {#TroubleshootingSchannelandTLS-Solution:EnsureSchannelisconfiguredconsistentlyonbothservers}
+### Solution: Ensure Schannel is configured consistently on both servers {#TroubleshootingSchannelandTLS-Solution-EnsureSchannelisconfiguredconsistentlyonbothservers}
 
 You can use a tool like [IISCrypto](https://www.nartac.com/Products/IISCrypto) to confirm and repair the configuration of Schannel on both servers. A mismatch in the enabled protocols, ciphers, hashes or key exchanges on either end can break Tentacle communications.
 
@@ -44,11 +44,11 @@ You can use a tool like [IISCrypto](https://www.nartac.com/Products/IISCrypto) t
 ![](/docs/security/octopus-tentacle-communication/5865774.png "width=500")
 :::
 
-### Solution: Consider rolling back recent Windows patches {#TroubleshootingSchannelandTLS-Solution:ConsiderrollingbackrecentWindowspatches}
+### Solution: Consider rolling back recent Windows patches {#TroubleshootingSchannelandTLS-Solution-ConsiderrollingbackrecentWindowspatches}
 
 Some customers have decided to roll back the Windows patches mentioned above and have reported success getting Tentacle communication working again. We would recommend upgrading Octopus and Tentacle to make use of TLS 1.2 by default in preference to rolling back any patches.
 
-### Solution: Increase the RSA key length of your Octopus Server or Tentacle certificate {#TroubleshootingSchannelandTLS-Solution:IncreaseRdaKeyLength}
+### Solution: Increase the RSA key length of your Octopus Server or Tentacle certificate {#TroubleshootingSchannelandTLS-Solution-IncreaseRdaKeyLength}
 
 Some customers have reported that after tightening the use of TLS to exclusively enable TLS 1.2, Tentacles become unable to communicate with Octopus Server and they see the error `A call to SSPI failed, see inner exception`.
 


### PR DESCRIPTION
Fragments can't include a `:` character.

They should also be short and ideally all lower, but these are not in scope for this fix.