### PR TITLE
Document Deprecating GET /api/reporting/deployments-counted-by-week

### DIFF
--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -23,6 +23,12 @@ Deprecations are subject to change in detail or timeframe. If you need help asse
 
 ## Deprecations for 2023.2
 
+### Reporting `/reporting/deployments-counted-by-week` API endpoint
+
+The /reporting/deployments-counted-by-week API endpoint is being removed in future versions of Octopus.
+It is an old endpoint that is no longer used by any of our supported clients.
+While there is no direct replacement for this endpoint, much more detailed reporting is available via the [Insights feature](https://octopus.com/docs/insights).
+
 ### Project level `/git/branches` API endpoint
 
 The `POST` method on the `/projects/{projectId}/git/branches` endpoint for version controlled projects is being removed in future versions of Octopus. The same functionality is available using the `/projects/{projectId}/git/branches/v2` endpoint, however, a minor change will need to be made to the request payload.


### PR DESCRIPTION
# Background

The deployments-counted-by-week reporting endpoint is being deprecated

- [RFC](https://docs.google.com/document/d/1NM2-lb2TyokphO4H-BNjm9Zfeq4OFkzJrtJqN40VXdw/edit#heading=h.eeq4erbzkzf8)

# Results

Added a new section to the public deprecations documentation to explain the deprecation and possible migration.

# How to review this PR

<!--
Describe how you want people to review the pull request.
Perhaps you just want an "in principal" review to prove an idea.
Perhaps you want specific people to test the resulting changes.
-->

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->