### PR TITLE
Fix the size of the bookmark icon

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -241,15 +241,12 @@ strong {
 .bookmark-link {
     border-radius: var(--block-radius);
     color: var(--fore-link);
-    display: block;
-    float: right;
-    font-size: 0.6em;
-    height: 1.6em;
-    margin-inline-start: .2em;
+    display: inline-block;
+    font-size: 1.2rem;
+    height: 1.2em;
+    margin-inline-start: 0.3rem;
     opacity: .5;
     overflow: hidden;
-    padding-top: 1px;
-    position: relative;
     text-decoration: none;
     top: 0.5em;
     opacity: 0;


### PR DESCRIPTION
From: https://octopusdeploy.slack.com/archives/C04PQ8XJ4CB/p1686716227088579

Make the icons all the same size, rather than relative to the heading size.