### PR TITLE
Adding links to tenanted deployments use case page

### DIFF
--- a/src/pages/docs/tenants/index.md
+++ b/src/pages/docs/tenants/index.md
@@ -34,7 +34,7 @@ To solve this, Octopus provides first-class support for modeling tenants.
 ![](/docs/tenants/images/multiple-tenants.png "width=500")
 :::
 
-Tenants in Octopus allow you to easily create customer specific deployment pipelines without duplicating project configuration. You can
+[Tenants](https://octopus.com/use-case/tenanted-deployments) in Octopus allow you to easily create customer specific deployment pipelines without duplicating project configuration. You can
 manage separate instances of your application in multiple environments in a single Octopus project.
 
 Tenants enable:

--- a/src/pages/docs/tenants/tenant-creation/tenanted-deployments.md
+++ b/src/pages/docs/tenants/tenant-creation/tenanted-deployments.md
@@ -23,7 +23,7 @@ It's also possible to enable tenanted deployments when [connecting a tenant to a
 
 ## Tenanted and Untenanted deployments {#tenanted-and-untenanted-deployments}
 
-On the deployment screen, if you you choose **Tenanted** from the **Tenants** option, you are performing a **tenanted deployment** - deploying a release of a project to an environment for one or more tenants. 
+On the deployment screen, if you you choose **Tenanted** from the **Tenants** option, you are performing a [**tenanted deployment**](https://octopus.com/use-case/tenanted-deployments) - deploying a release of a project to an environment for one or more tenants. 
 
 :::figure
 ![](/docs/tenants/tenant-creation/images/multi-tenant-deploy-to-tenants.png "width=500")

--- a/src/pages/docs/tenants/tenant-infrastructure.md
+++ b/src/pages/docs/tenants/tenant-infrastructure.md
@@ -16,7 +16,7 @@ You can design and implement both **dedicated** and **shared** multi-tenant host
 
 ## Tenanted and untenanted deployments {#tenanted-and-untenanted-deploys}
 
-Although we focus on tenanted deployments in this section, untenanted deployments deserve some explanation with regards to hosting. Untenanted deployments provide a way for you to start introducing tenants into your existing Octopus configuration. An untenanted deployment is the default in Octopus; a deployment to an environment *without* a tenant. Octopus decides which deployment targets to include in a deployment like this:
+Although we focus on (tenanted deployments)[https://octopus.com/use-case/tenanted-deployments] in this section, untenanted deployments deserve some explanation with regards to hosting. Untenanted deployments provide a way for you to start introducing tenants into your existing Octopus configuration. An untenanted deployment is the default in Octopus; a deployment to an environment *without* a tenant. Octopus decides which deployment targets to include in a deployment like this:
 
 - **Tenanted deployments** will use **matching tenanted deployment targets**.
 - **Untenanted deployments** will only use **untenanted deployment targets**.

--- a/src/pages/docs/tenants/tenant-infrastructure.md
+++ b/src/pages/docs/tenants/tenant-infrastructure.md
@@ -16,7 +16,7 @@ You can design and implement both **dedicated** and **shared** multi-tenant host
 
 ## Tenanted and untenanted deployments {#tenanted-and-untenanted-deploys}
 
-Although we focus on (tenanted deployments)[https://octopus.com/use-case/tenanted-deployments] in this section, untenanted deployments deserve some explanation with regards to hosting. Untenanted deployments provide a way for you to start introducing tenants into your existing Octopus configuration. An untenanted deployment is the default in Octopus; a deployment to an environment *without* a tenant. Octopus decides which deployment targets to include in a deployment like this:
+Although we focus on [tenanted deployments](https://octopus.com/use-case/tenanted-deployments) in this section, untenanted deployments deserve some explanation with regards to hosting. Untenanted deployments provide a way for you to start introducing tenants into your existing Octopus configuration. An untenanted deployment is the default in Octopus; a deployment to an environment *without* a tenant. Octopus decides which deployment targets to include in a deployment like this:
 
 - **Tenanted deployments** will use **matching tenanted deployment targets**.
 - **Untenanted deployments** will only use **untenanted deployment targets**.


### PR DESCRIPTION
Added several links to tenanted deployments use case page from relevant docs pages. This will help with content discovery and improve our chances of ranking the new page higher in search results.