### PR TITLE
added warning about azure workitems and other build envs

### DIFF
--- a/src/pages/docs/releases/issue-tracking/azure-devops.md
+++ b/src/pages/docs/releases/issue-tracking/azure-devops.md
@@ -19,7 +19,7 @@ Octopus integrates with Azure DevOps work items. The integration includes the ab
 :::
 
 :::div{.warning}
-Azure Workitems aren't currently supported by BuildEnvironments other than AzureDevops 
+Azure work items aren't currently supported unless the `BuildEnvironment` is Azure DevOps.
 :::
 
 1. Associate code changes with their relevant work items in any of the following ways:

--- a/src/pages/docs/releases/issue-tracking/azure-devops.md
+++ b/src/pages/docs/releases/issue-tracking/azure-devops.md
@@ -18,6 +18,10 @@ Octopus integrates with Azure DevOps work items. The integration includes the ab
 ![Octopus Azure DevOps integration - how it works diagram](/docs/releases/issue-tracking/images/octo-azure-devops-how-it-works.png "width=500")
 :::
 
+:::div{.warning}
+Azure Workitems aren't currently supported by BuildEnvironments other than AzureDevops 
+:::
+
 1. Associate code changes with their relevant work items in any of the following ways:
     - Edit a pull request in Azure DevOps, and use the **Work Items** panel to select a work item.
     - Edit a work item in Azure DevOps, and use the **Development** panel to add a pull request link (before build), or a commit link, or a build link.


### PR DESCRIPTION
Based on [this rnd slack thread](https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1677792597189299?thread_ts=1677725859.943959&cid=CNHBHV2BX)

> for Azure DevOps we ignore everything if the BuildEnvironment isn't Azure Devops.

Feel free to change wording! 