### PR TITLE
Removes use of the docker image feature

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/octopus-tentacle-container.md
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/octopus-tentacle-container.md
@@ -33,7 +33,7 @@ docker run --interactive --detach `
  --env TargetEnvironment="Development" `
  --env TargetRole="container-server" `
  --env ServerUrl="http://10.0.0.1:8080" `
- !docker-image <octopusdeploy/tentacle>
+ octopusdeploy/tentacle
 ```
 
 </details>
@@ -49,7 +49,7 @@ docker run --interactive --detach `
  --env ServerApiKey="API-MZKUUUMK3EYX7TBJP6FAKIFHIEO" `
  --env TargetWorkerPool="LinuxWorkers" `
  --env ServerUrl="http://10.0.0.1:8080" `
- !docker-image <octopusdeploy/tentacle>
+ octopusdeploy/tentacle
 ```
 
 </details>
@@ -116,7 +116,7 @@ If you plan to host Octopus Tentacle in Kubernetes, you should set the `privileg
 ```yaml
 containers:
 - name: octopus_tentacle
-  image: !docker-image <octopusdeploy/tentacle>
+  image: octopusdeploy/tentacle
   securityContext:
     privileged: true
 ```

--- a/src/pages/docs/infrastructure/workers/worker-tools-versioning-and-caching.md
+++ b/src/pages/docs/infrastructure/workers/worker-tools-versioning-and-caching.md
@@ -49,26 +49,12 @@ To update to the latest set of Worker Tools select the "Use latest Distro-based 
 ![](/docs/infrastructure/workers/images/container-selector.png "width=500")
 :::
 
-
 ## Currently Cached Worker Tools
 
 **Octopus worker-tools cached on Dynamic Workers**
 The `octopusdeploy/worker-tools` images provided for the execution containers feature cache the five latest Ubuntu and two latest Windows images on a Dynamic Worker when it's created. This makes them an excellent choice over installing additional software on a Dynamic Worker.
 
-The following Worker Tools images are cached:
-
-**On Linux Workers**:
-
-- `!docker-image <octopusdeploy/worker-tools:ubuntu.22.04>` ([Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.22.04))
-- `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>` ([Latest Linux-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/ubuntu.18.04))
-- `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>-1`
-- `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>-2`
-- `!docker-image <octopusdeploy/worker-tools:ubuntu.18.04>-3`
-
-**On Windows Workers**:
-
-- `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>` ([Latest Windows-based image](https://github.com/OctopusDeploy/WorkerTools/blob/master/windows.ltsc2019))
-- `!docker-image <octopusdeploy/worker-tools:windows.ltsc2019>-1`
+[View the latest versions of worker tools on DockerHub](https://hub.docker.com/r/octopusdeploy/worker-tools).
 
 Using non-cached versions of these worker-tools can result in long downloads.
 

--- a/src/pages/docs/installation/octopus-server-linux-container/index.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/index.mdx
@@ -33,7 +33,7 @@ $ docker run --interactive --detach --name OctopusDeploy --publish 1322:8080 --e
 - Using `--publish 1322:8080` maps the _container port_ `8080` to `1322` on the host so that the Octopus instance is accessible outside this sever.
 - To set the connection string we provide an _environment variable_ `DB_CONNECTION_STRING` (this can be to a local database or an external database).
 
-In this example, we are running the image `octopusdeploy/octopusdeploy`. The tag maps directly to the Octopus Server version that is bundled inside the image.
+In this example, we run the image `octopusdeploy/octopusdeploy` without an explicit tag, running the `latest` version of Octopus Server that's been published to DockerHub.
 
 ## Running Octopus Server in a Container
 

--- a/src/pages/docs/installation/octopus-server-linux-container/index.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/index.mdx
@@ -24,7 +24,7 @@ This page describes how to run Octopus Server in the Linux Container.
 Although there are a few different configuration options, the following is a simple example of starting the  Octopus Server Linux container:
 
 ```bash
-$ docker run --interactive --detach --name OctopusDeploy --publish 1322:8080 --env ACCEPT_EULA="Y" --env DB_CONNECTION_STRING="..." !docker-image <octopusdeploy/octopusdeploy>
+$ docker run --interactive --detach --name OctopusDeploy --publish 1322:8080 --env ACCEPT_EULA="Y" --env DB_CONNECTION_STRING="..." octopusdeploy/octopusdeploy
 ```
 
 - We run in detached mode with `--detach` to allow the container to run in the background.
@@ -33,7 +33,7 @@ $ docker run --interactive --detach --name OctopusDeploy --publish 1322:8080 --e
 - Using `--publish 1322:8080` maps the _container port_ `8080` to `1322` on the host so that the Octopus instance is accessible outside this sever.
 - To set the connection string we provide an _environment variable_ `DB_CONNECTION_STRING` (this can be to a local database or an external database).
 
-In this example, we are running the image `!docker-image <octopusdeploy/octopusdeploy>`. The tag maps directly to the Octopus Server version that is bundled inside the image.
+In this example, we are running the image `octopusdeploy/octopusdeploy`. The tag maps directly to the Octopus Server version that is bundled inside the image.
 
 ## Running Octopus Server in a Container
 
@@ -124,7 +124,7 @@ Similar to moving an instance, to perform the container upgrade you will need th
 When you have the Master Key, you can stop the running Octopus Server container instance (delete it if you plan on using the same name), and run _almost_ the same command as before, but this time, pass in the Master Key as an environment variable and reference the new Octopus Server version. When this new container starts up, it will use the same credentials and detect that the database has already been set up and use the Master Key to access its sensitive values:
 
 ```bash
-$ docker run --interactive --detach --name OctopusServer --publish 1322:8080 --env DB_CONNECTION_STRING="..." --env MASTER_KEY "5qJcW9E6B99teMmrOzaYNA==" !docker-image <octopusdeploy/octopusdeploy>
+$ docker run --interactive --detach --name OctopusServer --publish 1322:8080 --env DB_CONNECTION_STRING="..." --env MASTER_KEY "5qJcW9E6B99teMmrOzaYNA==" octopusdeploy/octopusdeploy
 ```
 
 The standard backup and restore procedures for the [data stored on the filesystem](/docs/administration/data/backup-and-restore/#octopus-file-storage) and the connected [SQL Server](/docs/administration/data/octopus-database) still apply as per normal Octopus installations.

--- a/src/pages/docs/projects/steps/execution-containers-for-workers/index.mdx
+++ b/src/pages/docs/projects/steps/execution-containers-for-workers/index.mdx
@@ -34,7 +34,7 @@ You need Docker installed and running on the [worker](/docs/infrastructure/worke
 - Set the **Execution Location** for your step to **Run on a worker**.
 - In **Container Image** select **Runs on a worker inside a container**.
 - Choose the previously added container registry.
-- Enter the name of the image (execution container) you want your step to run in. (e.g. `!docker-image <octopusdeploy/worker-tools:ubuntu.22.04>`).
+- Enter the name of the image (execution container) you want your step to run in. (e.g. `octopusdeploy/worker-tools:ubuntu.22.04`).
 - Click **Save**.
 - Click **Create release & deploy**.
 


### PR DESCRIPTION
The old docs platform had a feature to lookup and replace Docker images with specific versions.

This PR proposes to remove dependence on this feature.