### PR TITLE
added location to create variable to copy-workdir page

### DIFF
--- a/src/pages/docs/support/copy-working-directory.md
+++ b/src/pages/docs/support/copy-working-directory.md
@@ -9,7 +9,7 @@ navOrder: 2
 
 It can be frustrating when a deployment step isn't working as expected.  Often the working directory is deleted before it is able to be inspected.
 
-A handy way to debug is by using the variable `Octopus.Calamari.CopyWorkingDirectoryIncludingKeyTo`, which if set to a file-path will cause the [Calamari](/docs/octopus-rest-api/calamari) working directory to be copied to the configured location. The file-path location is local to the deployment target, so setting the value to c:\temp or #{Octopus.Agent.ProgramDirectoryPath}/#{Octopus.Release.Number} will copy the working directory to these folders on each of the targets. 
+A handy way to debug is by using the project variable `Octopus.Calamari.CopyWorkingDirectoryIncludingKeyTo`, which if set to a file-path will cause the [Calamari](/docs/octopus-rest-api/calamari) working directory to be copied to the configured location. The file-path location is local to the deployment target, so setting the value to c:\temp or #{Octopus.Agent.ProgramDirectoryPath}/#{Octopus.Release.Number} will copy the working directory to these folders on each of the targets. 
 
 :::div{.warning}
 The copied directory will include a file which contains the secret one-time key passed to Calamari to decrypt the sensitive variables used in the deployment.  


### PR DESCRIPTION
@steve-fenton-octopus - super minor clarification that it's a project variable not sys env var etc.

[Octopus Community Slack Thread](https://octopususergroup.slack.com/archives/C6UGLUWMQ/p1687312331662429?thread_ts=1687310296.328099&cid=C6UGLUWMQ)