### PR TITLE
Fixes display issue with mis-interpreted colons

### DIFF
--- a/src/pages/docs/deployments/aws/cloudformation/index.md
+++ b/src/pages/docs/deployments/aws/cloudformation/index.md
@@ -192,6 +192,7 @@ For example, in the screenshot below you can see that the specified instance typ
 The AWS account used to perform the operation does not have the required permissions to query the current state of the CloudFormation stack. This step will complete without waiting for the stack to complete, and will not fail if the stack finishes in an error state.
 
 The error message will include the error from AWS, which looks like this:
+
 ```
 User: arn:aws:iam::123456789012:user/TestUser is not authorized to perform: cloudformation:DescribeStackEvents on resource: arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/*
 ```
@@ -212,6 +213,7 @@ This is logged as a warning as Octopus will make some assumptions about the stat
 * If the step was configured to delete the stack, it is assumed that the stack does exist and it will attempt to be deleted.
 
 The error message will include the error from AWS, which looks like this:
+
 ```
 User: arn:aws:iam::123456789012:user/TestUser is not authorized to perform: cloudformation:DescribeStacks on resource: arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/*
 ```
@@ -238,6 +240,7 @@ An unrecognized exception was thrown while checking to see if the CloudFormation
 The AWS account used to perform the operation does not have the required permissions to create the CloudFormation stack.
 
 The error message will include the error from AWS, which looks like this:
+
 ```
 User: arn:aws:iam::123456789012:user/TestUser is not authorized to perform: cloudformation:CreateStack on resource: arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/*
 ```
@@ -257,6 +260,7 @@ If the text `Requires capabilities : [CAPABILITY_NAMED_IAM]` or `Requires capabi
 The AWS account used to perform the operation does not have the required permissions to delete the CloudFormation stack.
 
 The error message will include the error from AWS, which looks like this:
+
 ```
 User: arn:aws:iam::123456789012:user/TestUser is not authorized to perform: cloudformation:DeleteStack on resource: arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/*
 ```
@@ -270,6 +274,7 @@ An unrecognized exception was thrown while deleting a CloudFormation stack.
 The AWS account used to perform the operation does not have the required permissions to update the CloudFormation stack.
 
 The error message will include the error from AWS, which looks like this:
+
 ```
 User: arn:aws:iam::123456789012:user/TestUser is not authorized to perform: cloudformation:UpdateStack on resource: arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/*
 ```

--- a/src/pages/docs/deployments/java/error-messages.md
+++ b/src/pages/docs/deployments/java/error-messages.md
@@ -117,6 +117,7 @@ This is a catch all error message for unexpected errors during a Tomcat deployme
 * Tomcat is started and running.
 
 If you see errors such as:
+
 ```
 23:22:33   Error    |       TOMCAT-DEPLOY-ERROR-0005: An exception was thrown during the deployment. https://oc.to/JavaAppDeploy#tomcat-deploy-error-0005
 23:22:33   Error    |       org.apache.http.conn.HttpHostConnectException: Connect to tomcat-server:8080 [tomcat-server/127.0.1.1] failed: Connection refused

--- a/src/pages/docs/deployments/nginx/configure-octopus-deploy-project.md
+++ b/src/pages/docs/deployments/nginx/configure-octopus-deploy-project.md
@@ -59,7 +59,7 @@ To configure NGINX to send traffic to your application you need to fill in a few
 | **Bindings**              | Specify any number of HTTP/HTTPS bindings that should be added to the NGINX virtual server. |                                          |                                          |
 | **Locations**             | Specify any number of locations that NGINX should test request URIs against to send traffic to your application. |                                          |                                          |
 
-When defining **locations** you can configure NGINX to deliver files from the file system , or proxy requests to another server. For our sample application we want requests to `http://<IPorDNSofServer>/` to deliver the `index.html` file from the `wwwroot` folder of our ASP.NET Core project and requests to `http://<IPorDNSofServer>/api/` to be proxied to our ASP.NET Core project running on http://localhost:5000.
+When defining **locations** you can configure NGINX to deliver files from the file system , or proxy requests to another server. For our sample application we want requests to `http://<IPorDNSofServer>/` to deliver the `index.html` file from the `wwwroot` folder of our ASP.NET Core project and requests to `http://<IPorDNSofServer>/api/` to be proxied to our ASP.NET Core project running on [http://localhost:5000](http://localhost:5000).
 
 :::figure
 ![](/docs/deployments/nginx/images/deployment_process_nginx_feature.png "width=500")

--- a/src/pages/docs/deployments/node-js/node-on-linux.md
+++ b/src/pages/docs/deployments/node-js/node-on-linux.md
@@ -107,7 +107,7 @@ npm run build
 npm start
 ```
 
-If the site runs correctly, when you navigate to http://localhost:8081 you should see a page with words that appear to be missing. These will be populated in the config files during the deployment.
+If the site runs correctly, when you navigate to [http://localhost:8081](http://localhost:8081) you should see a page with words that appear to be missing. These will be populated in the config files during the deployment.
 
 :::figure
 ![App with missing variables](/docs/deployments/node-js/images/missing-variables.png "width=500")

--- a/src/pages/docs/packaging-applications/create-packages/octopack/octopack-to-include-buildevent-files.md
+++ b/src/pages/docs/packaging-applications/create-packages/octopack/octopack-to-include-buildevent-files.md
@@ -31,7 +31,7 @@ This is resolved by creating a NuSpec file, and creating a files tag to tell Oct
 
 It is important to note here that for OctoPack to find and use a NuSpec file, it must be named the same as your project as seen above. For instance, in our example, the project is called `OctoFX.TradingWebsite` so our NuSpec file must be called `OctoFx.TragingWebsite.nuspec`.
 
-To ensure I don't just get the files defined within the NeSpec file, I add **/p:OctoPackEnforceAddingFiles=true**, to tell OctoPack to also add the files it would normally add while building as well as those targeted by my files tag in the NuSpec file.
+To ensure I don't just get the files defined within the NeSpec file, I add `/p:OctoPackEnforceAddingFiles=true`, to tell OctoPack to also add the files it would normally add while building as well as those targeted by my files tag in the NuSpec file.
 
 ```powershell
 F:\Workspace\OctoFX\source>msbuild OctoFX.sln /t:Build /p:RunOctoPack=true /p:OctoPackPackageVersion=1.0.0.7 /p:OctoPackEnforceAddingFiles=true

--- a/src/pages/docs/packaging-applications/create-packages/octopus-cli.md
+++ b/src/pages/docs/packaging-applications/create-packages/octopus-cli.md
@@ -90,6 +90,7 @@ dotnet octo pack ./dist --id="SomeLibrary" --version="1.0.0"
 ## Packaging a .NET Framework web application
 
 There are usually some extra steps required to get the resulting application built and deployable. Full framework web applications are a good example of this, where simply building the application will not give you the desired output. We still recommend [Octopack](/docs/packaging-applications/create-packages/octopack) for these cases. However, you may be able to achieve this using msbuild parameters such as:
+
 ```
 msbuild ./OctoWeb.csproj /p:DeployDefaultTarget=WebPublish /p:DeployOnBuild=true /p:WebPublishMethod=FileSystem /p:SkipInvalidConfigurations=true /p:publishUrl=dist
 dotnet octo pack ./dist --id="OctoWeb" --version="1.0.0-alpha0001"

--- a/src/shared-content/structured-configuration-variables.include.md
+++ b/src/shared-content/structured-configuration-variables.include.md
@@ -75,10 +75,10 @@ An example for each supported file type can be found in the following table:
 
 | Format | Input file | Octopus variable name | Octopus variable value | Output file |
 | ------ | ---------- | ---- | ----- | ----------- |
-| JSON   | {"app": {"port": 80 }} | app:port | 4444 | {"app": {"port": 4444}} |
-| YAML   | app:<br/>&nbsp;&nbsp;port: 80 | app:port | 4444 | app:<br/>&nbsp;&nbsp;port: 4444 |
-| XML    | &lt;app&gt;&lt;port&gt;80&lt;/port&gt;&lt;/app&gt; | /app/port | 4444 | &lt;app&gt;&lt;port&gt;4444&lt;/port&gt;&lt;/app&gt; |
-| Java Properties | app_port: 80 | app_port | 4444 | app_port: 4444 |
+| JSON   | {"app": {"port": 80 }} | `app:port` | 4444 | {"app": {"port": 4444}} |
+| YAML   | app:<br/>&nbsp;&nbsp;port: 80 | `app:port` | 4444 | app:<br/>&nbsp;&nbsp;port: 4444 |
+| XML    | &lt;app&gt;&lt;port&gt;80&lt;/port&gt;&lt;/app&gt; | `/app/port` | 4444 | &lt;app&gt;&lt;port&gt;4444&lt;/port&gt;&lt;/app&gt; |
+| Java Properties | app_port: 80 | `app_port` | 4444 | app_port: 4444 |
 
 #### Variable names starting with the word Octopus
 


### PR DESCRIPTION
This syntax is reserved by the remark / rehype extensions.

The second column should contain "app:port" but this is being converted into "app<port />" due to markdown extensions.

![image](https://github.com/OctopusDeploy/docs/assets/99181436/76a6ef75-2b32-4984-b376-e5c3f519c45f)

![image](https://github.com/OctopusDeploy/docs/assets/99181436/877bb3b0-b736-4586-844c-82596cd7d259)

