### PR TITLE
Logging anything below Info to a file requires a bit more setup.

### DIFF
--- a/src/pages/docs/support/log-files.md
+++ b/src/pages/docs/support/log-files.md
@@ -45,7 +45,7 @@ The verbosity of file logging is controlled in the `octopus-log-file` section:
     <logger name="*" minlevel="Info" writeTo="octopus-log-file" />
 ```
 
-The `minlevel` attribute is most useful for configuring the logging level. Change this value to `Trace` to gather more information.
+The `minlevel` attribute is most useful for configuring the logging level. Change this value to `Trace` and set `OCTOPUS__Logging__File__LogEventLevel` environment variable to `Verbose` to gather more information.
 
 The Octopus process will automatically switch to the new logging level as soon as the file is saved.
 
@@ -66,7 +66,7 @@ The verbosity of file logging is controlled in the `octopus-log-file` section:
     <logger name="Halibut" minlevel="Info" writeTo="octopus-log-file" />
 ```
 
-The `minlevel` attribute is most useful for configuring the logging level. Change this value to `Trace` to gather more information.
+The `minlevel` attribute is most useful for configuring the logging level. Change this value to `Trace` and set `OCTOPUS__Logging__File__LogEventLevel` environment variable to `Verbose` to gather more information.
 
 The Octopus process will automatically switch to the new logging level as soon as the file is saved.
 

--- a/src/pages/docs/support/log-files.md
+++ b/src/pages/docs/support/log-files.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-07-04
 title: Log files
 description: Octopus Server and Tentacle log file locations and details.
 navOrder: 1


### PR DESCRIPTION
The Octopus Server logs only `Info` and up to the server log file by default. 
Context: https://octopusdeploy.slack.com/archives/C04JFJXECS1/p1688107961418059?thread_ts=1688105096.747349&cid=C04JFJXECS1
