### PR TITLE
Set location for free trial start button

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -33,7 +33,7 @@ const search = accelerator.posts.all().filter(PostFiltering.isSearch).shift() ??
       <li><a href="https://octopus.com/enterprise">Enterprise</a></li>
     </ul>
   </nav>
-  <a href="https://octopus.com/start" class="button trial">Free trial</a>
+  <a href="https://octopus.com/start?location=docs" class="button trial">Free trial</a>
   <a href="#octo-site-nav" class="navigation-icon" title={ _(Translations.header.open_menu) } data-navigationid="octo-site-nav"><svg xmlns="http://www.w3.org/2000/svg" 
     width="40" height="40" viewBox="0 0 24 24" stroke-width="1.5" 
     fill="none" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Sets the location to "docs" for the free trial start button so that we can record if someone started a free trial after looking at the docs.