### PR TITLE
Updating cli docs for octopus.migrator.exe

### DIFF
--- a/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/export.md
+++ b/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/export.md
@@ -10,7 +10,7 @@ This command exports configuration data to a directory.
 
 Usage:
 
-```
+```text
 Usage: octopus.migrator export [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/import.md
+++ b/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/import.md
@@ -12,7 +12,7 @@ The export must have been made from an Octopus Server running the same release v
 
 Usage:
 
-```
+```text
 Usage: octopus.migrator import [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/index.md
+++ b/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/index.md
@@ -26,11 +26,11 @@ C:\Program Files\Octopus Deploy\Octopus
 
 `octopus.migrator.exe` supports the following commands:
 
-- **[export](/docs/octopus-rest-api/octopus.migrator.exe-command-line/export)**:  Exports all configuration data to a directory.
-- **[import](/docs/octopus-rest-api/octopus.migrator.exe-command-line/import)**:  Imports data from an Octopus 3.0+ export directory.
-- **[migrate](/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate)**:  Imports data from an Octopus 2.6 backup.
-- **[partial-export](/docs/octopus-rest-api/octopus.migrator.exe-command-line/partial-export)**:  Exports configuration data to a directory filtered by projects.
-- **[version](/docs/octopus-rest-api/octopus.migrator.exe-command-line/version)**:  Shows the version information for this release of the Octopus Migrator.
+- **[export](/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/export.md)**:  Exports all configuration data to a directory.
+- **[import](/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/import.md)**:  Imports data from an Octopus 3.0+ export directory.
+- **[migrate](/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md)**:  Imports data from an Octopus 2.6 backup.
+- **[partial-export](/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/partial-export.md)**:  Exports configuration data to a directory filtered by projects.
+- **[version](/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/version.md)**:  Shows the version information for this release of the Octopus Migrator.
 
 ## General usage {#Octopus.Migrator.exeCommandLine-Generalusage}
 

--- a/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md
+++ b/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/migrate.md
@@ -10,7 +10,7 @@ Imports data from an Octopus 2.6 backup
 
 **migrate options**
 
-```
+```text
 Usage: octopus.migrator migrate [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/partial-export.md
+++ b/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/partial-export.md
@@ -10,7 +10,7 @@ This command exports configuration data to a directory filtered by a single proj
 
 Usage:
 
-```
+```text
 Usage: octopus.migrator partial-export [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/version.md
+++ b/src/pages/docs/octopus-rest-api/octopus.migrator.exe-command-line/version.md
@@ -10,7 +10,7 @@ Shows the version information for this release of the Octopus Migrator
 
 **version options**
 
-```
+```text
 Usage: octopus.migrator version [<options>]
 
 Where [<options>] is any of:


### PR DESCRIPTION
An automated update of the command line docs for octopus.migrator.exe version 2023.2.12868.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 469