### PR TITLE
Updating cli docs for tentacle.exe

### DIFF
--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/agent.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/agent.md
@@ -10,7 +10,7 @@ Starts the Tentacle Agent in debug mode.
 
 **agent options**
 
-```
+```text
 Usage: tentacle agent [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/checkservices.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/checkservices.md
@@ -10,7 +10,7 @@ The checkservices command checks the Octopus Tentacle instances to see if they a
 
 **checkservices options**
 
-```
+```text
 Usage: tentacle checkservices [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/configure.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/configure.md
@@ -10,7 +10,7 @@ Sets Tentacle settings such as the port number and thumbprints.
 
 **Configure options**
 
-```
+```text
 Usage: tentacle configure [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/create-instance.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/create-instance.md
@@ -10,7 +10,7 @@ Registers a new instance of the Tentacle service.
 
 **Create instance options**
 
-```
+```text
 Usage: tentacle create-instance [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/delete-instance.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/delete-instance.md
@@ -10,7 +10,7 @@ Deletes an instance of the Tentacle service.
 
 **Delete instance options**
 
-```
+```text
 Usage: tentacle delete-instance [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/deregister-from.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/deregister-from.md
@@ -10,7 +10,7 @@ Deregisters this deployment target from an Octopus Server.
 
 **Deregister from options**
 
-```
+```text
 Usage: tentacle deregister-from [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/deregister-worker.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/deregister-worker.md
@@ -10,7 +10,7 @@ Deregisters this Worker from an Octopus Server.
 
 **Deregister Worker options**
 
-```
+```text
 Usage: tentacle deregister-worker [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/extract.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/extract.md
@@ -10,7 +10,7 @@ Extracts a NuGet package.
 
 **extract options**
 
-```
+```text
 Usage: tentacle extract [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/import-certificate.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/import-certificate.md
@@ -10,7 +10,7 @@ Replace the certificate that Tentacle uses to authenticate itself.
 
 **Import certificate options**
 
-```
+```text
 Usage: tentacle import-certificate [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/index.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/index.md
@@ -14,29 +14,29 @@ hideInThisSection: true
 
 `tentacle` supports the following commands:
 
-- **[agent](/docs/octopus-rest-api/tentacle.exe-command-line/agent)**:  Starts the Tentacle Agent in debug mode.
-- **[checkservices](/docs/octopus-rest-api/tentacle.exe-command-line/checkservices)**:  Checks the Tentacle instances are running.
-- **[configure](/docs/octopus-rest-api/tentacle.exe-command-line/configure)**:  Sets Tentacle settings such as the port number and thumbprints.
-- **[create-instance](/docs/octopus-rest-api/tentacle.exe-command-line/create-instance)**:  Registers a new instance of the Tentacle service.
-- **[delete-instance](/docs/octopus-rest-api/tentacle.exe-command-line/delete-instance)**:  Deletes an instance of the Tentacle service.
-- **[deregister-from](/docs/octopus-rest-api/tentacle.exe-command-line/deregister-from)**:  Deregisters this deployment target from an Octopus Server.
-- **[deregister-worker](/docs/octopus-rest-api/tentacle.exe-command-line/deregister-worker)**:  Deregisters this worker from an Octopus Server.
-- **[extract](/docs/octopus-rest-api/tentacle.exe-command-line/extract)**:  Extracts a NuGet package.
-- **[import-certificate](/docs/octopus-rest-api/tentacle.exe-command-line/import-certificate)**:  Replace the certificate that Tentacle uses to authenticate itself.
-- **[list-instances](/docs/octopus-rest-api/tentacle.exe-command-line/list-instances)**:  Lists all installed Tentacle instances.
-- **[new-certificate](/docs/octopus-rest-api/tentacle.exe-command-line/new-certificate)**:  Creates and installs a new certificate for this Tentacle.
-- **[polling-proxy](/docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy)**:  Configure the HTTP proxy used by polling Tentacles to reach the Octopus Server.
-- **[poll-server](/docs/octopus-rest-api/tentacle.exe-command-line/poll-server)**:  Configures an Octopus Server that this Tentacle will poll.
-- **[proxy](/docs/octopus-rest-api/tentacle.exe-command-line/proxy)**:  Configure the HTTP proxy used by Octopus.
-- **[register-with](/docs/octopus-rest-api/tentacle.exe-command-line/register-with)**:  Registers this machine as a deployment target with an Octopus Server.
-- **[register-worker](/docs/octopus-rest-api/tentacle.exe-command-line/register-worker)**:  Registers this machine as a worker with an Octopus Server.
-- **[server-comms](/docs/octopus-rest-api/tentacle.exe-command-line/server-comms)**:  Configure how the Tentacle communicates with an Octopus Server.
-- **[service](/docs/octopus-rest-api/tentacle.exe-command-line/service)**:  Start, stop, install and configure the Tentacle service.
-- **[show-configuration](/docs/octopus-rest-api/tentacle.exe-command-line/show-configuration)**:  Outputs the Tentacle configuration.
-- **[show-thumbprint](/docs/octopus-rest-api/tentacle.exe-command-line/show-thumbprint)**:  Show the thumbprint of this Tentacle's certificate.
-- **[update-trust](/docs/octopus-rest-api/tentacle.exe-command-line/update-trust)**:  Replaces the trusted Octopus Server thumbprint of any matching polling or listening registrations with a new thumbprint to trust.
-- **[version](/docs/octopus-rest-api/tentacle.exe-command-line/version)**:  Show the Tentacle version information.
-- **[watchdog](/docs/octopus-rest-api/tentacle.exe-command-line/watchdog)**:  Configure a scheduled task to monitor the Tentacle service(s).
+- **[agent](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/agent.md)**:  Starts the Tentacle Agent in debug mode.
+- **[checkservices](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/checkservices.md)**:  Checks the Tentacle instances are running.
+- **[configure](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/configure.md)**:  Sets Tentacle settings such as the port number and thumbprints.
+- **[create-instance](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/create-instance.md)**:  Registers a new instance of the Tentacle service.
+- **[delete-instance](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/delete-instance.md)**:  Deletes an instance of the Tentacle service.
+- **[deregister-from](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/deregister-from.md)**:  Deregisters this deployment target from an Octopus Server.
+- **[deregister-worker](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/deregister-worker.md)**:  Deregisters this worker from an Octopus Server.
+- **[extract](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/extract.md)**:  Extracts a NuGet package.
+- **[import-certificate](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/import-certificate.md)**:  Replace the certificate that Tentacle uses to authenticate itself.
+- **[list-instances](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/list-instances.md)**:  Lists all installed Tentacle instances.
+- **[new-certificate](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/new-certificate.md)**:  Creates and installs a new certificate for this Tentacle.
+- **[polling-proxy](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy.md)**:  Configure the HTTP proxy used by polling Tentacles to reach the Octopus Server.
+- **[poll-server](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md)**:  Configures an Octopus Server that this Tentacle will poll.
+- **[proxy](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/proxy.md)**:  Configure the HTTP proxy used by Octopus.
+- **[register-with](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/register-with.md)**:  Registers this machine as a deployment target with an Octopus Server.
+- **[register-worker](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/register-worker.md)**:  Registers this machine as a worker with an Octopus Server.
+- **[server-comms](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/server-comms.md)**:  Configure how the Tentacle communicates with an Octopus Server.
+- **[service](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/service.md)**:  Start, stop, install and configure the Tentacle service.
+- **[show-configuration](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/show-configuration.md)**:  Outputs the Tentacle configuration.
+- **[show-thumbprint](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/show-thumbprint.md)**:  Show the thumbprint of this Tentacle's certificate.
+- **[update-trust](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/update-trust.md)**:  Replaces the trusted Octopus Server thumbprint of any matching polling or listening registrations with a new thumbprint to trust.
+- **[version](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/version.md)**:  Show the Tentacle version information.
+- **[watchdog](/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/watchdog.md)**:  Configure a scheduled task to monitor the Tentacle service(s).
 
 ## General Usage {#Tentacle.exeCommandLine-Generalusage}
 

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/list-instances.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/list-instances.md
@@ -11,7 +11,7 @@ Lists all installed Octopus Tentacle instances.
 
 **List instances options**
 
-```
+```text
 Usage: tentacle list-instances [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/new-certificate.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/new-certificate.md
@@ -10,7 +10,7 @@ Creates and installs a new certificate for this Tentacle.
 
 **New certificate options**
 
-```
+```text
 Usage: tentacle new-certificate [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md
@@ -10,7 +10,7 @@ Configures an Octopus Server that this Tentacle will poll.
 
 **Poll server options**
 
-```
+```text
 Usage: tentacle poll-server [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy.md
@@ -10,7 +10,7 @@ Configure the HTTP proxy used by Polling Tentacles to reach the Octopus Server
 
 **Polling proxy options**
 
-```
+```text
 Usage: tentacle polling-proxy [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/proxy.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/proxy.md
@@ -10,7 +10,7 @@ Configure the HTTP proxy used by Octopus.
 
 **Proxy options**
 
-```
+```text
 Usage: tentacle proxy [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/register-with.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/register-with.md
@@ -10,7 +10,7 @@ Registers this machine as a deployment target with an Octopus Server.
 
 **Register with options**
 
-```
+```text
 Usage: tentacle register-with [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/register-worker.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/register-worker.md
@@ -10,7 +10,7 @@ Registers this machine as a Worker with an Octopus Server.
 
 **Register with options**
 
-```
+```text
 Usage: tentacle register-worker [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/server-comms.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/server-comms.md
@@ -10,7 +10,7 @@ Configure how the Tentacle communicates with an Octopus Server.
 
 **Server communication options**
 
-```
+```text
 Usage: tentacle server-comms [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/service.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/service.md
@@ -10,7 +10,7 @@ Start, stop, install and configure the Tentacle service.
 
 **Service options**
 
-```
+```text
 Usage: tentacle service [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/show-configuration.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/show-configuration.md
@@ -13,7 +13,7 @@ For Workers, the server-side configuration includes the associated worker pools,
 
 **Show configuration options**
 
-```
+```text
 Usage: tentacle show-configuration [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/show-thumbprint.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/show-thumbprint.md
@@ -10,7 +10,7 @@ Show the thumbprint of the Tentacle's certificate.
 
 **New certificate options**
 
-```
+```text
 Usage: tentacle show-thumbprint [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/update-trust.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/update-trust.md
@@ -10,7 +10,7 @@ Replaces the trusted Octopus Server thumbprint of any matching polling or listen
 
 **update-trust options**
 
-```
+```text
 Usage: tentacle update-trust [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/version.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/version.md
@@ -10,7 +10,7 @@ Show the Tentacle version information.
 
 **version options**
 
-```
+```text
 Usage: tentacle version [<options>]
 
 Where [<options>] is any of:

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/watchdog.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/watchdog.md
@@ -10,7 +10,7 @@ Configure a scheduled task to monitor the Tentacle service(s).
 
 **watchdog options**
 
-```
+```text
 Usage: tentacle watchdog [<options>]
 
 Where [<options>] is any of:


### PR DESCRIPTION
An automated update of the command line docs for tentacle.exe version 6.4.100.

Created by TeamCity project 'Automated Documentation Updates::Update CLI Docs', build 469