### PR TITLE
fixed header typo - build-info-in-release-notes

### DIFF
--- a/src/pages/docs/packaging-applications/build-servers/build-information/index.md
+++ b/src/pages/docs/packaging-applications/build-servers/build-information/index.md
@@ -88,7 +88,7 @@ For packages pushed to the Octopus built-in repository, the build information ca
 ![Build information on package version page](/docs/packaging-applications/build-servers/build-information/images/build-information-package-version-2.png "width=500")
 :::
 
-## Using build information in release notes #{build-info-in-release-notes}
+## Using build information in release notes {#build-info-in-release-notes}
 
 The build information associated with packages is available for use in [release notes](/docs/releases/release-notes) (and [release notes templates](/docs/releases/release-notes/#Release-Notes-Templates)) as Octopus variables.
 


### PR DESCRIPTION
@steve-fenton-octopus 

https://octopus.com/docs/packaging-applications/build-servers/build-information#using-build-information-in-release-notes-build-info-in-release-notes

<img width="905" alt="Screenshot 2023-07-13 at 15 02 21" src="https://github.com/OctopusDeploy/docs/assets/78527975/2174ec20-1458-4c34-b5b6-58be4da86cdd">
