### PR TITLE
Set semver to 6.3.1 due to security issue

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import remarkDirective from 'remark-directive';
 import remarkHeading from 'remark-heading-id';
 import { defineConfig } from 'astro/config';
+import { defaultLayout } from '/src/themes/accelerator/utilities/default-layout.mjs';
 import mdx from '@astrojs/mdx';
 import { attributeMarkdown, wrapTables } from '/src/themes/accelerator/utilities/custom-markdown.mjs';
 
@@ -15,6 +16,7 @@ export default defineConfig({
             theme: 'nord'
         },
         remarkPlugins: [
+            defaultLayout,
             remarkDirective,
             remarkHeading,
             attributeMarkdown,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
             "dependencies": {
                 "@astrojs/mdx": "^0.19.7",
                 "astro": "^2.7.2",
-                "astro-accelerator": "^0.0.104",
-                "astro-accelerator-utils": "^0.2.31",
+                "astro-accelerator": "^0.0.106",
+                "astro-accelerator-utils": "^0.2.33",
                 "hast-util-from-selector": "^2.0.1",
                 "remark-directive": "^2.0.1",
                 "remark-heading-id": "^1.0.0"
@@ -1367,13 +1367,13 @@
             }
         },
         "node_modules/astro-accelerator": {
-            "version": "0.0.104",
-            "resolved": "https://registry.npmjs.org/astro-accelerator/-/astro-accelerator-0.0.104.tgz",
-            "integrity": "sha512-Ka1NowGl1FloajmV1iFbtQaOpsj971F3WVbr1yG/wadevVX0AcoL3rTOcn0meN6ZQ8sEmxC1blTk+IY3jY4KPw==",
+            "version": "0.0.106",
+            "resolved": "https://registry.npmjs.org/astro-accelerator/-/astro-accelerator-0.0.106.tgz",
+            "integrity": "sha512-CWAZRUrd+Iqar0A3yuWWuKbGwiawtg6HVgnplthn6P1jfTSYvU2Sr4Cix0YxphE9TnPWvXcG+g75ft56PfuDNQ==",
             "dependencies": {
                 "@astrojs/mdx": "^0.19.7",
                 "astro": "^2.7.2",
-                "astro-accelerator-utils": "^0.2.31",
+                "astro-accelerator-utils": "^0.2.33",
                 "hast-util-from-selector": "^2.0.1",
                 "html-to-text": "^9.0.5",
                 "keyword-extractor": "^0.0.25",
@@ -1385,9 +1385,9 @@
             }
         },
         "node_modules/astro-accelerator-utils": {
-            "version": "0.2.31",
-            "resolved": "https://registry.npmjs.org/astro-accelerator-utils/-/astro-accelerator-utils-0.2.31.tgz",
-            "integrity": "sha512-jaQZHDERD9Yg/E0R6rDjha7DPjOriPYzokpM+glbbTEogUtv5qFGGqFQvT2xLItLnT4Ywj7QL1L9iUSnsuTkPg=="
+            "version": "0.2.33",
+            "resolved": "https://registry.npmjs.org/astro-accelerator-utils/-/astro-accelerator-utils-0.2.33.tgz",
+            "integrity": "sha512-z5Sq/s3FeZafVihX8xws+B5BLATWmDifpHGNKCj203zyeCMRzDGeaHQy11cHNA3T2YjyRIvf/RvLQqoNtHcrog=="
         },
         "node_modules/astro/node_modules/argparse": {
             "version": "2.0.1",
@@ -7549,13 +7549,13 @@
             }
         },
         "astro-accelerator": {
-            "version": "0.0.104",
-            "resolved": "https://registry.npmjs.org/astro-accelerator/-/astro-accelerator-0.0.104.tgz",
-            "integrity": "sha512-Ka1NowGl1FloajmV1iFbtQaOpsj971F3WVbr1yG/wadevVX0AcoL3rTOcn0meN6ZQ8sEmxC1blTk+IY3jY4KPw==",
+            "version": "0.0.106",
+            "resolved": "https://registry.npmjs.org/astro-accelerator/-/astro-accelerator-0.0.106.tgz",
+            "integrity": "sha512-CWAZRUrd+Iqar0A3yuWWuKbGwiawtg6HVgnplthn6P1jfTSYvU2Sr4Cix0YxphE9TnPWvXcG+g75ft56PfuDNQ==",
             "requires": {
                 "@astrojs/mdx": "^0.19.7",
                 "astro": "^2.7.2",
-                "astro-accelerator-utils": "^0.2.31",
+                "astro-accelerator-utils": "^0.2.33",
                 "hast-util-from-selector": "^2.0.1",
                 "html-to-text": "^9.0.5",
                 "keyword-extractor": "^0.0.25",
@@ -7564,9 +7564,9 @@
             }
         },
         "astro-accelerator-utils": {
-            "version": "0.2.31",
-            "resolved": "https://registry.npmjs.org/astro-accelerator-utils/-/astro-accelerator-utils-0.2.31.tgz",
-            "integrity": "sha512-jaQZHDERD9Yg/E0R6rDjha7DPjOriPYzokpM+glbbTEogUtv5qFGGqFQvT2xLItLnT4Ywj7QL1L9iUSnsuTkPg=="
+            "version": "0.2.33",
+            "resolved": "https://registry.npmjs.org/astro-accelerator-utils/-/astro-accelerator-utils-0.2.33.tgz",
+            "integrity": "sha512-z5Sq/s3FeZafVihX8xws+B5BLATWmDifpHGNKCj203zyeCMRzDGeaHQy11cHNA3T2YjyRIvf/RvLQqoNtHcrog=="
         },
         "bail": {
             "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,9 +212,9 @@
             }
         },
         "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -263,9 +263,9 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -1410,17 +1410,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/astro/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/astro/node_modules/p-limit": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -1434,25 +1423,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/astro/node_modules/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/astro/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/astro/node_modules/yocto-queue": {
             "version": "1.0.0",
@@ -5537,9 +5507,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-            "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -6753,9 +6723,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
                 }
             }
         },
@@ -6791,9 +6761,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "6.3.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
                 }
             }
         },
@@ -7563,14 +7533,6 @@
                         "argparse": "^2.0.1"
                     }
                 },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
                 "p-limit": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -7578,19 +7540,6 @@
                     "requires": {
                         "yocto-queue": "^1.0.0"
                     }
-                },
-                "semver": {
-                    "version": "7.5.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-                    "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 },
                 "yocto-queue": {
                     "version": "1.0.0",
@@ -10305,9 +10254,9 @@
             }
         },
         "semver": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-            "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "requires": {
                 "lru-cache": "^6.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "dependencies": {
         "@astrojs/mdx": "^0.19.7",
         "astro": "^2.7.2",
-        "astro-accelerator": "^0.0.104",
-        "astro-accelerator-utils": "^0.2.31",
+        "astro-accelerator": "^0.0.106",
+        "astro-accelerator-utils": "^0.2.33",
         "hast-util-from-selector": "^2.0.1",
         "remark-directive": "^2.0.1",
         "remark-heading-id": "^1.0.0"

--- a/src/components/LastUpdated.astro
+++ b/src/components/LastUpdated.astro
@@ -20,4 +20,6 @@ const accelerator = new Accelerator(SITE);
 
 const date = frontmatter.modDate ?? frontmatter.pubDate;
 ---
+{date &&
 <p class="last-updated"><time datetime={ date.toString() } itemprop="dateModified"></time>{ _(Translations.post.last_modified) } { accelerator.dateFormatter.formatDate(date, lang) }</time></p>
+}

--- a/src/pages/docs/octopus-rest-api/octopus-cli/delete-project.md
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/delete-project.md
@@ -1,5 +1,7 @@
 ---
 title: delete-project
+pubDate: 2023-07-17
+modDate: 2023-07-17
 description: Deletes a project.
 ---
 

--- a/src/pages/docs/octopus-rest-api/octopus-cli/disable-project.md
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/disable-project.md
@@ -1,5 +1,7 @@
 ---
 title: disable-project
+pubDate: 2023-07-17
+modDate: 2023-07-17
 description: Disables a project.
 ---
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "astro/tsconfigs/strict",
   "types": ["astro/client"],
+  "exclude": ["npm_modules"],
   "compilerOptions": {
       "baseUrl": ".",
       "paths": {


### PR DESCRIPTION
The result of `npm audit fix` on the semver issue.