### PR TITLE
Add clarifying warning about no "latest" version in deploy release

### DIFF
--- a/src/pages/docs/octopus-rest-api/cli/octopus-release-deploy.mdx
+++ b/src/pages/docs/octopus-rest-api/cli/octopus-release-deploy.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-06-19
+modDate: 2023-07-25
 title: octopus release deploy
 description: Deploy releases
 navOrder: 90

--- a/src/pages/docs/octopus-rest-api/cli/octopus-release-deploy.mdx
+++ b/src/pages/docs/octopus-rest-api/cli/octopus-release-deploy.mdx
@@ -49,9 +49,11 @@ $ octopus release deploy --project MyProject --version 1.0 --environment Dev
 $ octopus release deploy --project MyProject --version 1.0 --tenant-tag Regions/East --tenant-tag Regions/South
 $ octopus release deploy -p MyProject --version 1.0 -e Dev --skip InstallStep --variable VarName:VarValue
 $ octopus release deploy -p MyProject --version 1.0 -e Dev --force-package-download --guided-failure true -f basic
-
-
 ```
+
+:::div{.warning}
+The new CLI does not support specifying `latest` for `version` as this is risky in an automation context and may cause the wrong version to be selected. 
+:::
 
 ## Learn more
 


### PR DESCRIPTION
Internally, some discussion was had about the new go CLI lacking the ability to specify `--version=latest` when deploying a release. This is a feature the old dotnet CLI had.

R&D Perspective: The  "latest" option was deliberately left out of the new CLI, along with other dynamic kinds of features like it.

If someone is using the CLI to do ad-hoc things, then the new CLI has interactive mode to help with this.
  - E.g. when deploying a release, the latest version sorts to the top, so if that's what you want you can just hit enter on the prompt.

If someone is using the CLI as part of CI/CD tooling, we deliberately want to be explicit at all points. 
A common workflow is to have a CI system like Github Actions create a release, then follow up and deploy it. 
This happens:
 - Job A: Create release 1
    - Job B in background: Create release 2
 - Job A: Deploy "latest" release; the intent is to deploy release 1, but 2 ends up being deployed instead.
 
For context, [the "latest" option was removed from the TFS extension](https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension#UsetheTeamFoundationBuildCustomTask-AddaDeployOctopusReleaseStep) for this same reason.

In something like Github actions, it is likely that an earlier step/job already knows the release version; something like step outputs passing it through are the preferred solution.

If someone wants to grab the latest release for some other reason (e.g. batch job adding some new environments and deploying the latest release to bring them up to speed), then the preferred option would be to capture the release number up-front in a variable: E.g. in powershell

```powershell
$currentRelease = octopus release list -p "My Project" -f basic | select -index 0

... more things in here ...

octopus release deploy -p "My Project" -e "Some Environment" --version $currentRelease
```

This ensures that the value of `$currentRelease` is the same for all actions performed in the script, and if you're deploying multiple times you can't wind up with different versions caused by other releases getting created in the background (edited)

----

This PR updates the docs to add a small note about why the new CLI doesn't have this feature. We don't want to go too deep into explanations and run the risk of setting false expectations; people can always ask and discuss more if need be.