### PR TITLE
Fix image urls on new pages

### DIFF
--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-targets.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-targets.md
@@ -13,13 +13,13 @@ hideInThisSectionHeader: true
 In the Infrastructure section, we can see three tentacle targets in the Production environment used to host these tenants. Each target is currently hosting five tenants. By associating a Hosting Group tag to each target, the tenants with those tags are automatically associated to the targets. This makes adding or removing a tenant from a target very easy.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/target-list.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/target-list.png "width=500")
 :::
 
 Edit a target and choose the appropriate tag in the `Associated Tenants` section to associate all tenants with that tag to the target.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/target-details.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/target-details.png "width=500")
 :::
 
 <span><a class="button btn-secondary" href="/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-tenants">Previous</a></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span><a class="button btn-success" href="/docs/tenants/guides/tenants-sharing-machine-targets/deploying-before-concurrency-tag">Next</a></span>

--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-tenants.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-tenants.md
@@ -15,13 +15,13 @@ We have included the hosting group name in the tenant name to help illustrate th
 This tag will make it easy to choose to deploy to all tenants in a group easily and also map those tenants to the correct infrastucture easily.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/tenant-list.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/tenant-list.png "width=500")
 :::
 
 Edit a tenant and click the `Manage Tags` button to manage what tags are associated with a tenant.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/tenant-details.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/tenant-details.png "width=500")
 :::
 
 <span><a class="button btn-secondary" href="/docs/tenants/guides/tenants-sharing-machine-targets/creating-the-tenant-tag-set">Previous</a></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span><a class="button btn-success" href="/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-targets">Next</a></span>

--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/creating-the-tenant-tag-set.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/creating-the-tenant-tag-set.md
@@ -17,7 +17,7 @@ Tenant Tag Sets are stored in the Library of Octopus Deploy.  To create Tenant T
 Give the **Tag Set** a name, an optional description, and create some tags.  In this scenario, we are creating a tag set named Hosting Group, with tags Hosting Group 1, Hosting Group 2, and Hosting Group 3. These groups could also represent different regions where the infrastructure is hosted.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/tag-set.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/tag-set.png "width=500")
 :::
 
 <span><a class="button btn-secondary" href="/docs/tenants/guides/tenants-sharing-machine-targets">Previous</a></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span><a class="button btn-success" href="/docs/tenants/guides/tenants-sharing-machine-targets/assign-tags-to-tenants">Next</a></span>

--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/deploying-after-concurrency-tag.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/deploying-after-concurrency-tag.md
@@ -13,7 +13,7 @@ hideInThisSectionHeader: true
 If we deploy a release to all tenants at the same time now, we see that three tasks are running while the others are queued. That is one task per hosting group. While the other tasks are queued, tasks from other projects are able to run. Before making the change to the concurrency tag, all of these tasks would run concurrently and potentially block tasks from other projects from running.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/all-groups-sequential-in-progress.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/all-groups-sequential-in-progress.png "width=500")
 :::
 
 Once the deployments are complete, we can see that each of the deployments took about 45 seconds. That's an improvement from the 2-3 minutes that we saw before. But since these are running sequentially, the total time from the first deployment starting to the last deployment finishing is about 4 minutes. We can't guarantee that this approach will lead to a shorter total deployment time, though we would expect that result as the number of tenants, steps, and hosting groups grow.
@@ -23,13 +23,13 @@ What this approach does give us is a consistent deployment time for all tasks, a
 For example, since this setup only uses 3 of our active tasks, we can add many hosting groups before we reach our task cap. Until we have reached the task cap, we can expect that many groups of 5 tenants would still take about 4 minutes to complete. The default concurrent approach would saturate the task cap and eventually take longer than the sequential approach.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/all-groups-sequential-complete.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/all-groups-sequential-complete.png "width=500")
 :::
 
 If we look at the deployment to Group 1 - Tenant E, we see that it no longer had to wait for other tasks, and each of the steps finish quickly. This is important if you need to minimize the times between certain steps running.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/deployment-details-sequential.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/deployment-details-sequential.png "width=500")
 :::
 
 <span><a class="button btn-secondary" href="/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag">Previous</a></span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span><a class="button btn-success" href="/docs/tenants/guides/tenants-sharing-machine-targets/summary">Next</a></span>

--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/deploying-before-concurrency-tag.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/deploying-before-concurrency-tag.md
@@ -13,19 +13,19 @@ hideInThisSectionHeader: true
 If we deploy a release to all tenants at the same time, we see that all tasks are running concurrently. This will depend on your task cap and number of other tasks running at the same time.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/all-groups-concurrent-in-progress.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/all-groups-concurrent-in-progress.png "width=500")
 :::
 
 Once the deployments are complete, we can see that each of the deployments took 2-3 minutes. Since they were running concurrently, the total time for the deployment was a little over 3 minutes.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/all-groups-concurrent-complete.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/all-groups-concurrent-complete.png "width=500")
 :::
 
 If we look at one of the specific task logs, we can see that each step in the deployment to Group 1 - Tenant E had to wait for one or more other tasks to finish before it could start.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/deployment-details-concurrent.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/deployment-details-concurrent.png "width=500")
 :::
 
 The time required to complete a deployment in this scenario will grow based on the number of steps targeting the shared infrastructure and the number of tenants in that group being deployed at once. It can also cause tasks to queue for longer than expected since all of the tasks are running, they are consuming part of the task cap. If you have a task cap of 20, and three infrastructure groups that each host 50 tenants, the tasks for one group can cause the tasks for the other two groups to wait in the queue for quite a while.

--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag.md
@@ -19,7 +19,7 @@ If we change the value for a tenanted deployment to `#{Octopus.Project.Id}/#{Pro
 In this scenario, we want to run one task per hosting group concurrently. We can do that by scoping different values to the Hosting Group tenant tags.
 
 :::figure
-![](/docs/tenants/guides/tenants-sharing-machine-targets/images/variable.png "width=500")
+![](/docs/tenants/guides/tenants-sharing-machine-targets/variable.png "width=500")
 :::
 
 Now the deployments for each tenant in the same hosting group will run sequentially.


### PR DESCRIPTION
The image URLs came up in the test suite. They had a `/images/` part of the path that isn't needed.

I also tested the pages and previous / next buttons. All looks good.