### PR TITLE
Missing spaces and invalid double id markdup fixed

### DIFF
--- a/src/pages/docs/administration/data/octopus-database/index.md
+++ b/src/pages/docs/administration/data/octopus-database/index.md
@@ -9,7 +9,7 @@ navOrder: 150
 
 To store environments, projects, variables, releases, and deployment history, Octopus Deploy uses a Microsoft SQL Server database.
 
-## Install Octopus Server {#Octopusdatabase-InstallingOctopusServer}{#installing}
+## Install Octopus Server {#installing}
 
 Octopus Server requires access to a SQL Server to use for storing relational data. You can create the database ahead of time, or you can let the installer create the database on your behalf. Refer to [SQL Server Database requirements](/docs/installation/sql-server-database) for more information on the SQL Server editions supported by Octopus Deploy and installation instructions.
 
@@ -17,11 +17,11 @@ Octopus Server requires access to a SQL Server to use for storing relational dat
 
 You are responsible for the routine maintenance of your Octopus database. Performance problems with your SQL Server will make Octopus run and feel slow and sluggish. You should implement a routine maintenance plan for your Octopus database. Here is a [sure guide](https://oc.to/SQLServerMaintenanceGuide) (free e-book) for maintaining SQL Server. Our [Performance](/docs/administration/managing-infrastructure/performance/#sql-maintenance) section has some general recommendations that may help get you started.
 
-### Database backups {#Octopusdatabase-DatabaseBackups}{#backups}
+### Database backups {#backups}
 
 You are responsible for taking database backups and testing your disaster recovery plans. Refer to [Backup and restore](/docs/administration/data/backup-and-restore) for more information about backing up Octopus Deploy and recovering from failure.
 
-### High availability databases {#Octopusdatabase-highavailability}{#highavailability}
+### High availability databases {#highavailability}
 
 If you are looking for a highly-available database solution, we recommend using [Always On Availability Groups](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server?view=sql-server-2017). Unfortunately, Octopus Server does not support running against a SQL database with Database Mirroring or SQL Replication enabled.  
 

--- a/src/pages/docs/deployments/custom-scripts/script-modules.md
+++ b/src/pages/docs/deployments/custom-scripts/script-modules.md
@@ -87,7 +87,7 @@ Make sure to select a **Role**, an **Environment** and to put a **Step Name**
 :::
 
 
-## Using script modules{#ScriptModules-using}
+## Using script modules {#ScriptModules-using}
 
 Each language has a slightly different syntax for using the Script Module. Please see the language specific section below.
 
@@ -97,7 +97,7 @@ Each language has a slightly different syntax for using the Script Module. Pleas
 * [F#](#ScriptModules-FSharp)
 * [Python](#ScriptModules-Python)
 
-## PowerShell script modules{#ScriptModules-PowerShell}
+## PowerShell script modules {#ScriptModules-PowerShell}
 
 PowerShell script modules get automatically loaded once for every PowerShell script step in your deployment process - the functions and cmdlets will automatically be in scope for your script.
 
@@ -127,7 +127,7 @@ function Say-Hello($name) {
 }
 ```
 
-## Bash script modules{#ScriptModules-Bash}
+## Bash script modules {#ScriptModules-Bash}
 
 Bash Script Modules are written as a `.sh` file next to your script. Import them
 via `source MyScriptModule.sh`, where `MyScriptModule` is the name of your Script
@@ -147,7 +147,7 @@ source BashScriptModule.sh
 say_hello George
 ```
 
-## C# script modules{#ScriptModules-CSharp}
+## C# script modules {#ScriptModules-CSharp}
 
 C# Script Modules are written as a `.csx` file next to your script. Import them
 via `#load "MyScriptModule.csx"`, where `MyScriptModule` is the name of your Script
@@ -169,7 +169,7 @@ Call it from your Script Step with:
 SayHello("George");
 ```
 
-## F# script modules{#ScriptModules-FSharp}
+## F# script modules {#ScriptModules-FSharp}
 
 F# Script Modules are written as an `.fsx` file next to your script. Import them
 via `#load "MyScriptModule.fsx"`, where `MyScriptModule` is the name of your Script
@@ -205,7 +205,7 @@ open MyFSharpScriptModule
 sayhello "George";
 ```
 
-## Python script modules{#ScriptModules-Python}
+## Python script modules {#ScriptModules-Python}
 
 Python Script Modules are written as a `.py` file next to your script. Import them
 via `import MyScriptModule`, where `MyScriptModule` is the name of your Script


### PR DESCRIPTION
See discussion at: https://octopusdeploy.slack.com/archives/C03UDS16R6G/p1693205676000199

When adding a custom ID to a heading, it must have a space to be recognised.

Invalid: `### Heading{#heading-id}`

Valid: `### Heading {#heading-id}`

I looked for other issues and found cases where people were trying to add two ids to the same heading, which isn't possible.

Invalid: `### Heading {#heading-id}{#another-id}`

Fixes included in this PR.