### PR TITLE
Improve on page search experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@astrojs/mdx": "^1.0.0",
         "astro": "^3.0.3",
-        "astro-accelerator": "^0.3.0",
+        "astro-accelerator": "^0.3.1",
         "astro-accelerator-utils": "^0.2.39",
         "hast-util-from-selector": "^3.0.0",
         "remark-directive": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.0.3
     version: 3.0.3
   astro-accelerator:
-    specifier: ^0.3.0
-    version: 0.3.0
+    specifier: ^0.3.1
+    version: 0.3.1
   astro-accelerator-utils:
     specifier: ^0.2.39
     version: 0.2.39
@@ -1025,8 +1025,9 @@ packages:
     resolution: {integrity: sha512-8akM88AxoPkw7FDs8J8rm9A2jxthn2/tiBTnQsr6lhw+y5md/hDQokqiSMNCVaS5L7M99EaI46CyE3DEYdw1pg==}
     dev: false
 
-  /astro-accelerator@0.3.0:
-    resolution: {integrity: sha512-VUkpCvKhhYI8FdAD8QpY52zcNDJIXheOZcuegoqNClG7BQ4v6ajiuYa1ptXU4yFGmZ+1RF94uX/fdZ+uyScz5g==}
+  /astro-accelerator@0.3.1:
+    resolution: {integrity: sha512-gsJVAkCPZ3tBviWXPTBqNK1eBGmGpvxWEoPi3dtDvE/K8jayMm4RHSdV4/yge4US66CfeSx8J153kvLbcOb9Gw==}
+    engines: {node: '>=18.14.1', pnpm: '>=8.6.12'}
     dependencies:
       '@astrojs/mdx': 1.0.0(astro@3.0.3)
       astro: 3.0.3

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -58,7 +58,6 @@ const site_features = SITE.featureFlags;
         <Header frontmatter={ frontmatter } headings={ headings } lang={ lang } />
         <Title frontmatter={ frontmatter } headings={ headings } lang={ lang } />
         <div class="content-group">
-            <Navigation lang={ lang } />
             <main id="site-main">
                 <Breadcrumbs frontmatter={ frontmatter } headings={ headings } lang={ lang } breadcrumbs={ breadcrumbs } />
                 <article itemscope itemtype="https://schema.org/Article">
@@ -79,6 +78,7 @@ const site_features = SITE.featureFlags;
                     </div>
                 </article>
             </main>
+            <Navigation lang={ lang } />
             <div class="side-nav">
                 <TableOfContents expanded={ 930 } frontmatter={ frontmatter } headings={ headings } lang={ lang } />
             </div>

--- a/src/pages/docs/search.json.ts
+++ b/src/pages/docs/search.json.ts
@@ -62,9 +62,12 @@ const getData = async () => {
         });
     }
 
-    return {
-        body: JSON.stringify(items)
-    }
+    return new Response(JSON.stringify(items), {
+        status: 200,
+        headers: {
+        'Content-Type': "application/json"
+        }
+    });
 }
 
-export const get = getData;
+export const GET = getData;

--- a/src/pages/docs/sitemap.xml.ts
+++ b/src/pages/docs/sitemap.xml.ts
@@ -30,15 +30,18 @@ async function getData() {
     }
   }
 
-  return {
-      body: `<?xml version="1.0" encoding="UTF-8"?>
+  return new Response(`<?xml version="1.0" encoding="UTF-8"?>
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
                                   http://www.sitemaps.org/schemas/sitemap/0.9.xsd">
 ${pages.join('')}
-</urlset>`
-  };
+</urlset>`, {
+      status: 200,
+      headers: {
+        'Content-Type': "application/xml"
+      }
+  });
 }
 
-export const get = getData;
+export const GET = getData;


### PR DESCRIPTION
When using on-page search, for example `CTRL` + `F` the page flow means the whole navigation must be searched before the main content is reached. This changes the page flow to improve the exprience by putting the content first.

Examples use: https://octopus.com/docs/getting-started

## Before

![All matches in the extensive navigation must be passed before the first useful result is found](https://github.com/OctopusDeploy/docs/assets/99181436/60e0b219-5c26-4071-80a1-6b137692c8da)

## After

![The search takes you to the content first, before the navigation](https://github.com/OctopusDeploy/docs/assets/99181436/50f1efdd-d8a4-4a8d-8687-5553af115167)

## Credits

Kudos to Lauren and Finnian for pointing out this issue.

cc @laurencagneyoctopus  @FinnianDempsey 

