### PR TITLE
Fix tenant link

### DIFF
--- a/src/pages/docs/projects/tenants/index.mdx
+++ b/src/pages/docs/projects/tenants/index.mdx
@@ -14,7 +14,7 @@ hideInThisSection: true
 The Project Tenants page and bulk tenant connection wizard were added in Octopus Deploy **2023.3**
 :::
 
-[Tenants](/docs/infrastructure/tenants) in Octopus allow you to easily create customer specific deployment pipelines without duplicating project configuration. 
+[Tenants](/docs/tenants) in Octopus allow you to easily create customer specific deployment pipelines without duplicating project configuration. 
 
 :::figure
 ![](/docs/projects/tenants/project-tenants-page.png)


### PR DESCRIPTION
Fixes the tenant link in the Project tenants page.