### PR TITLE
Astro 3 auto-collapses spaces that we depended on

### DIFF
--- a/src/components/LastUpdated.astro
+++ b/src/components/LastUpdated.astro
@@ -25,5 +25,5 @@ const date = frontmatter.modDate ?? frontmatter.pubDate;
 stats.stop();
 ---
 {date &&
-<p class="last-updated"><time datetime={ date.toString() } itemprop="dateModified"></time>{ _(Translations.post.last_modified) } { accelerator.dateFormatter.formatDate(date, lang) }</time></p>
+<p class="last-updated"><time datetime={ date.toString() } itemprop="dateModified"></time>{ _(Translations.post.last_modified) + ' ' + accelerator.dateFormatter.formatDate(date, lang) }</time></p>
 }


### PR DESCRIPTION
Tokens separated by spaces used to be preserved:

    { item.A } { item.B }
              ^

But since Astro 3 these spaces are stripped, so you need to force it:

    { item.A + ' ' + item.B }