### PR TITLE
Fixes edge case for navigation on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies": {
         "@astrojs/mdx": "^1.0.0",
         "astro": "^3.0.3",
-        "astro-accelerator": "^0.3.9",
+        "astro-accelerator": "^0.3.10",
         "astro-accelerator-utils": "^0.3.0",
         "hast-util-from-selector": "^3.0.0",
         "remark-directive": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^3.0.3
     version: 3.0.3
   astro-accelerator:
-    specifier: ^0.3.9
-    version: 0.3.9
+    specifier: ^0.3.10
+    version: 0.3.10
   astro-accelerator-utils:
     specifier: ^0.3.0
     version: 0.3.0
@@ -1077,8 +1077,8 @@ packages:
     resolution: {integrity: sha512-qN1EiESBi4GXBO5hvNINtNaOBbPMIYrFUhq7ouFXfCxJ01+WYy0FyST3p+JclB3AxhaFTCs1zzLuTA4IFKlo/Q==}
     dev: false
 
-  /astro-accelerator@0.3.9:
-    resolution: {integrity: sha512-hdmW8t490YUYWoJ4XGYndblIFanDNPoEboK1b/qn4wSj93ZfE70KtH2gr0izjGR8QwCO6TGiBxfNWi3zk5dQMA==}
+  /astro-accelerator@0.3.10:
+    resolution: {integrity: sha512-BR082aHKh3jmIloYch0KrXDk4XFNJ7+XvaWKsiwl1GBWtVP9u9x9jbLly4aqhuJIbbKvFPDqu2nKG1gwYcs0SA==}
     engines: {node: '>=18.14.1', pnpm: '>=8.6.12'}
     dependencies:
       '@astrojs/mdx': 1.0.0(astro@3.0.5)

--- a/public/docs/js/modules/nav-mobile.js
+++ b/public/docs/js/modules/nav-mobile.js
@@ -128,7 +128,7 @@ function addMobileNav(resizedEventName) {
 
     function closeMobileMenu() {
         const menuElement = qs('#' + navigationSelector);
-        menuElement.style.display = 'block';
+        menuElement.style.display = '';
         document.body.style.overflow = 'auto';
         document.documentElement.style.paddingInlineEnd = '0';
 


### PR DESCRIPTION
By setting the source navigation's display property, it overrides the CSS. This prevents that.