### PR TITLE
document worker lease cap

### DIFF
--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -436,11 +436,10 @@ The name of the Trigger that created the deployment. It is possible for a deploy
 
 `Octopus.Deployment.WorkerLeaseCap`
 
-This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled,
-and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
+This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
-Example: 1 - achieves a similar effect to round robin.  
-Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
+Example: `1` - achieves a similar effect to round robin.  
+Example: `5` - a balance between avoiding unnecessary package transfer and overloading a single worker.
 
 Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 
@@ -1463,11 +1462,10 @@ Example: `c:\temp\octopus-debug`
 
 `Octopus.Deployment.WorkerLeaseCap`
 
-This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled,
-and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
+This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
-Example: 1 - achieves a similar effect to round robin.  
-Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
+Example: `1` - achieves a similar effect to round robin.  
+Example: `5` - a balance between avoiding unnecessary package transfer and overloading a single worker.
 
 Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -439,7 +439,7 @@ The name of the Trigger that created the deployment. It is possible for a deploy
 This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
 Example: `1` - achieves a similar effect to round robin.  
-Example: `5` - a balance between avoiding unnecessary package transfer and overloading a single worker.
+Example: `5` - a balance between minimizing package transfer and overloading a single worker.
 
 Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 
@@ -1465,7 +1465,7 @@ Example: `c:\temp\octopus-debug`
 This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
 Example: `1` - achieves a similar effect to round robin.  
-Example: `5` - a balance between avoiding unnecessary package transfer and overloading a single worker.
+Example: `5` - a balance between minimizing package transfer and overloading a single worker.
 
 Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -436,7 +436,7 @@ The name of the Trigger that created the deployment. It is possible for a deploy
 
 `Octopus.Deployment.WorkerLeaseCap`
 
-This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
+This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evenly. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
 Example: `1` - achieves a similar effect to round robin.  
 Example: `5` - a balance between reducing package transfer and distributing load.
@@ -1462,7 +1462,7 @@ Example: `c:\temp\octopus-debug`
 
 `Octopus.Deployment.WorkerLeaseCap`
 
-This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
+This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evenly. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
 Example: `1` - achieves a similar effect to round robin.  
 Example: `5` - a balance between reducing package transfer and distributing load.

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -442,6 +442,8 @@ and the same worker will be reused for all steps referencing the same package. O
 Example: 1 - achieves a similar effect to round robin.  
 Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
 
+Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
+
 `Octopus.Endpoint.\_type\_.\_property\_`
 
 Properties describing the endpoint being deployed.
@@ -1466,6 +1468,8 @@ and the same worker will be reused for all steps referencing the same package. O
 
 Example: 1 - achieves a similar effect to round robin.  
 Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
+
+Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 
 `Octopus.Task.ConcurrencyTag`
 

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -434,6 +434,14 @@ The name of the Trigger that created the deployment. It is possible for a deploy
 
 *Nightly Deploy to Dev*
 
+`Octopus.Deployment.WorkerLeaseCap`
+
+This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled,
+and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
+
+Example: 1 - this achieves a similar effect to round robin.  
+Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
+
 `Octopus.Endpoint.\_type\_.\_property\_`
 
 Properties describing the endpoint being deployed.
@@ -1450,6 +1458,14 @@ Example: True
 Set to a file-path and the Calamari working directory will be copied to the configured location. **Copied files include the one-time key to decrypt sensitive variables** [More details.](/docs/support/copy-working-directory).
 
 Example: `c:\temp\octopus-debug`
+
+`Octopus.Deployment.WorkerLeaseCap`
+
+This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled,
+and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
+
+Example: 1 - this achieves a similar effect to round robin.  
+Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
 
 `Octopus.Task.ConcurrencyTag`
 

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-09-01
+modDate: 2023-09-20
 title: System variables
 description: System variables are variables provided by Octopus that can be used in your deployments.
 navOrder: 20

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -439,7 +439,7 @@ The name of the Trigger that created the deployment. It is possible for a deploy
 This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled,
 and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
-Example: 1 - this achieves a similar effect to round robin.  
+Example: 1 - achieves a similar effect to round robin.  
 Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
 
 `Octopus.Endpoint.\_type\_.\_property\_`
@@ -1464,7 +1464,7 @@ Example: `c:\temp\octopus-debug`
 This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled,
 and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
-Example: 1 - this achieves a similar effect to round robin.  
+Example: 1 - achieves a similar effect to round robin.  
 Example: 5 - a balance between avoiding unnecessary package transfer and overloading a single worker.
 
 `Octopus.Task.ConcurrencyTag`

--- a/src/pages/docs/projects/variables/system-variables.md
+++ b/src/pages/docs/projects/variables/system-variables.md
@@ -439,7 +439,7 @@ The name of the Trigger that created the deployment. It is possible for a deploy
 This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
 Example: `1` - achieves a similar effect to round robin.  
-Example: `5` - a balance between minimizing package transfer and overloading a single worker.
+Example: `5` - a balance between reducing package transfer and distributing load.
 
 Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 
@@ -1465,7 +1465,7 @@ Example: `c:\temp\octopus-debug`
 This is an opt-in variable to help distribute multiple steps referencing the same package (including container) across a worker pool. By setting this, a worker will be reused for steps up to the cap, after which another worker will be selected and reused in the same way. If all workers have reached the cap, additional steps will be spread out evently. By default this behaviour is disabled, and the same worker will be reused for all steps referencing the same package. Opt in by setting the variable to a number higher than 0.
 
 Example: `1` - achieves a similar effect to round robin.  
-Example: `5` - a balance between minimizing package transfer and overloading a single worker.
+Example: `5` - a balance between reducing package transfer and distributing load.
 
 Note: This value applies to both deployment processes and runbooks, as long as it's scoped to the particular scenario.
 


### PR DESCRIPTION
Adds high level documentation for the `Octopus.Deployment.WorkerLeaseCap` variable added in https://github.com/OctopusDeploy/OctopusDeploy/pull/18809.