### PR TITLE
Fix markdown in MDX file for nested list

### DIFF
--- a/src/pages/docs/security/hardening-octopus.mdx
+++ b/src/pages/docs/security/hardening-octopus.mdx
@@ -38,8 +38,8 @@ Depending on your familiarity with Octopus Server, or SQL Server, or networking,
 
 1. Upgrade to the latest version.
 1. Securely expose your Octopus Server to your users, infrastructure, and external services
-    a. Use HTTPS over SSL.
-    b. Configure HTTP security.
+   1. Use HTTPS over SSL.
+   1. Configure HTTP security.
 1. Configure your workers.
 1. Configure the way Octopus Server communicates with deployment targets.
 


### PR DESCRIPTION
The syntax for lists doesn't include an option to us `a. `, `b. `, etc. This may have been a custom extension written for the old docs site.

This list has been updated to use the standard syntax. We can add CSS rules about the numbering system deployed at different levels of nesting if required.