### PR TITLE
Fix image paths

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -1,11 +1,11 @@
-name: Deploy
+name: Tests
 
 on:
   # Disable on push temporarily while we're doing the migration
   workflow_dispatch:
-    push:
-        branches-ignore:
-        - master
+  push:
+      branches-ignore:
+      - master
 
 # Allow this job to clone the repo
 permissions:

--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -1,0 +1,59 @@
+name: Deploy
+
+on:
+  # Disable on push temporarily while we're doing the migration
+  workflow_dispatch:
+    push:
+        branches-ignore:
+        - master
+
+# Allow this job to clone the repo
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.7.0
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: PNPM and Playwright install
+        run: |
+          echo; echo "cd to workspace"
+          cd $GITHUB_WORKSPACE
+          echo; echo "listing"
+          ls
+          echo; echo "NPM install"
+          pnpm install
+
+      - name: Astro build and test
+        run: |
+          export NODE_OPTIONS=--max_old_space_size=4096
+          pnpm test

--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -1,11 +1,6 @@
 name: Tests
 
-on:
-  # Disable on push temporarily while we're doing the migration
-  workflow_dispatch:
-  push:
-      branches-ignore:
-      - master
+on: pull_request
 
 # Allow this job to clone the repo
 permissions:

--- a/src/pages/docs/packaging-applications/package-repositories/guides/container-registries/proget-container-registry.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/container-registries/proget-container-registry.md
@@ -14,31 +14,31 @@ ProGet from Inedo is an package repository technology which contains a number of
 From the ProGet web portal, click on **Feeds ➜ Create New Feed** 
 
 :::figure
-![Create New Feed](/docs/packaging-applications/package-repositories/guides/images/proget-create-feed.png)
+![Create New Feed](/docs/packaging-applications/package-repositories/images/proget-create-feed.png)
 :::
 
 Select the **Container Images** option from the `Container-based Applications & Images` category
 
 :::figure
-![Container Images](/docs/packaging-applications/package-repositories/guides/container-repository/images/proget-container-images.png)
+![Container Images](/docs/packaging-applications/package-repositories/guides/container-registries/images/proget-container-images.png)
 :::
 
 Select **No Connectors (private container images only)** from the wizard
 
 :::figure
-![No Connectors](/docs/packaging-applications/package-repositories/guides/container-repository/images/proget-connect-proget-feed.png)
+![No Connectors](/docs/packaging-applications/package-repositories/guides/container-registries/images/proget-connect-proget-feed.png)
 :::
 
 Enter a name for your Feed, eg: ProGet-Docker, then click **Create Feed**
 
 :::figure
-![Feed Name](/docs/packaging-applications/package-repositories/guides/container-repository/images/proget-docker-repository.png)
+![Feed Name](/docs/packaging-applications/package-repositories/guides/container-registries/images/proget-docker-repository.png)
 :::
 
 The next screen allows you to set optional features for your registry, configure these features or click **Close**.  Once the feed has been created, ProGet will display the required Image Prefix to push images in the form of `<ProGet Server DNS>/<FeedName>`.  In this example it's `proget.octopusdemos.app/proget-docker`
 
 :::figure
-![Image Prefix](/docs/packaging-applications/package-repositories/guides/container-repository/images/proget-container-registry-image-prefix.png)
+![Image Prefix](/docs/packaging-applications/package-repositories/guides/container-registries/images/proget-container-registry-image-prefix.png)
 :::
 
 

--- a/src/pages/docs/packaging-applications/package-repositories/guides/maven-repositories/artifactory-maven-feed.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/maven-repositories/artifactory-maven-feed.md
@@ -27,7 +27,7 @@ From the Package Type selection screen, choose **Maven**:
 Give the repository a name in the **Repository Key** field, and fill out any other settings for the repository.
 
 :::figure
-![Artifactory local repository settings](/docs/packaging-applications/package-repositories/guides/nuget-repositories/images/artifactory-local-maven-repo-configure.png)
+![Artifactory local repository settings](/docs/packaging-applications/package-repositories/guides/maven-repositories/images/artifactory-local-maven-repo-configure.png)
 :::
 
 When you've entered all of the settings, click **Save & Finish**.

--- a/src/pages/docs/packaging-applications/package-repositories/guides/maven-repositories/proget-maven-feed.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/maven-repositories/proget-maven-feed.md
@@ -31,10 +31,6 @@ Select **No Connectors (private artifacts only)** from the wizard
 
 Enter a name for your Feed, eg: ProGet-Docker, then click **Create Feed**
 
-:::figure
-![Feed Name](/docs/packaging-applications/package-repositories/guides/maven-repositories/images/proget-maven-repositories.png)
-:::
-
 The next screen allows you to set optional features for your registry, configure these features or click **Close**.  Once the feed has been created, ProGet will display the `API endpoint URL` to push packages.  In this example it's `https://proget.octopusdemos.app/maven2/ProGet-Maven/`
 
 :::figure

--- a/src/pages/docs/packaging-applications/package-repositories/guides/maven-repositories/proget-maven-feed.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/maven-repositories/proget-maven-feed.md
@@ -14,7 +14,7 @@ ProGet from Inedo is an package repository technology which contains a number of
 From the ProGet web portal, click on **Feeds ➜ Create New Feed** 
 
 :::figure
-![Create New Feed](/docs/packaging-applications/package-repositories/guides/images/proget-create-feed.png)
+![Create New Feed](/docs/packaging-applications/package-repositories/images/proget-create-feed.png)
 :::
 
 Select the **Maven Artifacts** option from the `Developer Libraries` category

--- a/src/pages/docs/packaging-applications/package-repositories/guides/nuget-repositories/proget-nuget-feed.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/nuget-repositories/proget-nuget-feed.md
@@ -38,7 +38,7 @@ Enter a name for your Feed, eg: ProGet-NuGet, then click **Create Feed**
 The next screen allows you to set optional features for your feed, configure these features or click **Close**.  Once the feed has been created, ProGet will display the `API endpoint URL` to push packages.  In this example it's `https://proget.octopusdemos.app/nuget/ProGet-NuGet/v3/index.json`
 
 :::figure
-![API endpoint URL](/docs/packaging-applications/package-repositories/guides/nuget-repository/images/proget-nuget-api-endpoint.png)
+![API endpoint URL](/docs/packaging-applications/package-repositories/guides/nuget-repositories/images/proget-nuget-api-endpoint.png)
 :::
 
 ## Adding a ProGet NuGet as an Octopus External Feed

--- a/src/pages/docs/packaging-applications/package-repositories/guides/nuget-repositories/proget-nuget-feed.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/nuget-repositories/proget-nuget-feed.md
@@ -14,7 +14,7 @@ ProGet from Inedo is an package repository technology which contains a number of
 From the ProGet web portal, click on **Feeds ➜ Create New Feed** 
 
 :::figure
-![Create New Feed](/docs/packaging-applications/package-repositories/guides/images/proget-create-feed.png)
+![Create New Feed](/docs/packaging-applications/package-repositories/images/proget-create-feed.png)
 :::
 
 Select the **NuGet (.NET) Packages** option from the `Developer Libraries` category

--- a/src/pages/docs/packaging-applications/package-repositories/guides/nuget-repositories/proget-nuget-feed.md
+++ b/src/pages/docs/packaging-applications/package-repositories/guides/nuget-repositories/proget-nuget-feed.md
@@ -26,7 +26,7 @@ Select the **NuGet (.NET) Packages** option from the `Developer Libraries` categ
 Select **No Connectors (private container packages only)** from the wizard
 
 :::figure
-![No Connectors](/docs/packaging-applications/package-repositories/guides/nuget-repositories/images/proget-connect-proget-feed.png)
+![No Connectors](/docs/packaging-applications/package-repositories/guides/container-registries/images/proget-connect-proget-feed.png)
 :::
 
 Enter a name for your Feed, eg: ProGet-NuGet, then click **Create Feed**


### PR DESCRIPTION
Fixes image paths in ProGet articles.

Notes:

I couldn't find a matching image for the following figure, which has been removed. Please add the image if this needs to be shown.

src\pages\docs\packaging-applications\package-repositories\guides\maven-repositories\proget-maven-feed.md

```
Enter a name for your Feed, eg: ProGet-Docker, then click **Create Feed**

:::figure
![Feed Name](/docs/packaging-applications/package-repositories/guides/maven-repositories/images/proget-maven-repositories.png)
:::
```