### PR TITLE
Allow people to download microsite

### DIFF
--- a/.github/workflows/build-astro.yml
+++ b/.github/workflows/build-astro.yml
@@ -93,6 +93,13 @@ jobs:
         with:
           packages: ${{ steps.package.outputs.package_file_path }}
 
+      - name: Let people download package
+        uses: actions/upload-artifact@v3
+        if: ${{ ! env.SHOULD_DEPLOY }}
+        with:
+          name: docs-microsite
+          path: ${{ steps.package.outputs.package_file_path }}
+
       - name: Push build information to Octopus Deploy 🐙
         uses: OctopusDeploy/push-build-information-action@v3
         if: ${{ env.SHOULD_DEPLOY }}


### PR DESCRIPTION
There's a step `Push a package to Octopus Deploy 🐙` which is now optional.
For forks that can't do that step, it's nice to be able to access the zips: https://github.com/jsoref/OctopusDeploy-docs/actions/runs/6394199002