### PR TITLE
Change Dynamic Worker defaults to Linux

### DIFF
--- a/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-10-05
 title: Dynamic Worker pools
 description: Dynamic Worker pools are used in our cloud product to dynamically create and assign workers to running tasks.  This page describes how dynamic worker pools work.
 navOrder: 50

--- a/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -28,7 +28,7 @@ Each worker is provisioned exclusively to a specific customer, and is completely
 
 ## Dynamic Worker Images
 
-Each dynamic worker pool can specify the worker image used. Windows Server Core 2019 is the default. Ubuntu Linux 22.04 worker images are also available.
+Each dynamic worker pool can specify the worker image used. Ubuntu Linux 22.04 is the default. Windows Server Core 2019 worker images are also available.
 
 Editing a dynamic worker pool allows you to modify the image used. 
 

--- a/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -28,18 +28,18 @@ Each worker is provisioned exclusively to a specific customer, and is completely
 
 ## Dynamic Worker Images
 
-Each dynamic worker pool can specify the worker image used. Windows Server Core 2019 is the default. Ubuntu Server 22.04 worker images are also available.
+Each dynamic worker pool can specify the worker image used. Windows Server Core 2019 is the default. Ubuntu Linux 22.04 worker images are also available.
 
 Editing a dynamic worker pool allows you to modify the image used. 
 
-The available worker images list specific operating system versions (e.g., `Windows Server Core 2019`) but also generic "default" options such as `Windows (default)`. Choosing the default option means that your worker will get the latest stable worker image released. This is a good option to choose if you're running a basic script that doesn't have any dependencies on specific tool or operating system versions.
+The available worker images list specific operating system versions (e.g., `Ubuntu Linux 22.04`) but also generic "default" options such as `Ubuntu (default)`. Choosing the default option means that your worker will get the latest stable worker image released. This is a good option to choose if you're running a basic script that doesn't have any dependencies on specific tool or operating system versions.
 
 If you're writing a script that relies on a specific version of tooling (e.g., helm), then we recommend choosing a specific worker image, instead of the "default" options, to prevent worker image upgrades from impacting your deployments.
 
 |Type | Pros | Cons |
 |-----|------|------|
-| Default (eg `Windows (default)`) | Automatically uses the latest image. Deployments will continue to work even when a worker image is marked as deprecated or decommissioned.| The versions of dependencies (e.g., helm) are not fixed. Deployments that rely on specific versions of dependencies or operating system specific features may break during upgrades. |
-| Specific (e.g., `Windows Server Core 2019`) | The version of the operating system and dependencies are fixed and can be relied upon. | When a worker image is marked as deprecated, warnings will start to appear in your deployment logs. When a worker image is decommissioned, you will need to take action to update your worker pool or deployments will fail. |
+| Default (eg `Ubuntu (default)`) | Automatically uses the latest image. Deployments will continue to work even when a worker image is marked as deprecated or decommissioned.| The versions of dependencies (e.g., helm) are not fixed. Deployments that rely on specific versions of dependencies or operating system specific features may break during upgrades. |
+| Specific (e.g., `Ubuntu Linux 22.04`) | The version of the operating system and dependencies are fixed and can be relied upon. | When a worker image is marked as deprecated, warnings will start to appear in your deployment logs. When a worker image is decommissioned, you will need to take action to update your worker pool or deployments will fail. |
 
 ## Deprecation
 
@@ -47,7 +47,7 @@ When an image is marked as deprecated, you will see warnings in the Octopus UI, 
 
 When you start getting warnings in your deployments and/or see deprecation warnings in the Octopus portal, please plan to modify your worker pool to use a different image and test your scripts on the new image.
 
-If your Worker Pool is set to use the Operating System default, for example, `Windows (default)`, the default will be swapped over to a new Operating System version by Octopus Deploy. Your deployments and runbooks will automatically use the new version.
+If your Worker Pool is set to use the Operating System default, for example, `Ubuntu (default)`, the default will be swapped over to a new Operating System version by Octopus Deploy. Your deployments and runbooks will automatically use the new version.
 
 You should validate that your deployments and runbooks work with the new version prior to the cutover date. The new image will be made available prior to the cutover date and we will notify you of the cutover date to give you time to undertaking any required testing.
 

--- a/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
+++ b/src/pages/docs/infrastructure/workers/dynamic-worker-pools.md
@@ -64,6 +64,28 @@ The Worker Type can be modified by editing the Worker Pool and changing the Work
 
 Worker images are rebuilt on a regular basis, so that the operating system is up to date with the latest security patches.
 
+### Ubuntu 22.04
+
+This is the default for the Ubuntu operating system, referenced as `Ubuntu (default)`.
+
+Each `Ubuntu Server 22.04` worker is provisioned with a baseline of tools including (but not limited to):
+
+- .NET 6
+- Docker (latest)
+- Powershell Core (latest)
+- Python 3 (latest)
+- GCloud CLI (367.0.0)
+
+:::div{.hint}
+Ubuntu workers are designed to use [execution worker containers](https://octopus.com/blog/execution-containers) for tooling such as `kubectl` and `helm`. This makes it much easier to choose the appropriate runtime environment with the tools you need for your use case.
+:::
+
+### Ubuntu 18.04
+
+:::div{.warning}
+Ubuntu 18.04 images are no longer available as of 3 April 2023. Please refer to [Ubuntu 18.04 End-of-life](/docs/infrastructure/workers/dynamic-worker-pools/ubuntu-1804-end-of-life) for further details.
+:::
+
 ### Windows Server Core 2019
 
 This is the default for the Windows operating system, referenced as `Windows (default)`.
@@ -91,28 +113,6 @@ Windows 2019 workers are capable of running [execution worker containers](/docs/
 
 :::div{.hint}
 We recommend execution containers as the preferred option for steps requiring external tools. This allows you to control which version of the tools will be used as your scripts will rely on a specific version that they are compatible with to function correctly.
-:::
-
-### Ubuntu 18.04
-
-:::div{.warning}
-Ubuntu 18.04 images are no longer available as of 3 April 2023. Please refer to [Ubuntu 18.04 End-of-life](/docs/infrastructure/workers/dynamic-worker-pools/ubuntu-1804-end-of-life) for further details.
-:::
-
-### Ubuntu 22.04
-
-This is the default for the Ubuntu operating system, referenced as `Ubuntu (default)`.
-
-Each `Ubuntu Server 22.04` worker is provisioned with a baseline of tools including (but not limited to):
-
-- .NET 6
-- Docker (latest)
-- Powershell Core (latest)
-- Python 3 (latest)
-- GCloud CLI (367.0.0)
-
-:::div{.hint}
-Ubuntu workers are designed to use [execution worker containers](https://octopus.com/blog/execution-containers) for tooling such as `kubectl` and `helm`. This makes it much easier to choose the appropriate runtime environment with the tools you need for your use case.
 :::
 
 ## kubectl on Windows Images
@@ -144,7 +144,7 @@ By default, every dynamic worker is destroyed after it has been allocated for ov
 For deployments and runbook runs that require additional software dependencies on a Dynamic worker, our recommendation is to leverage [execution containers for workers](/docs/projects/steps/execution-containers-for-workers).  Octopus provides execution containers with a baseline of tools (`octopusdeploy/worker-tools`) pre-installed. These tools won't include every possible software combination you might need. If you require a specific set of software and tooling we recommend [building your own custom docker images for use with execution containers](/docs/projects/steps/execution-containers-for-workers/#custom-docker-images).
 
 :::div{.hint}
-**Octopus worker-tools cached on Dynamic Workers**
+**Octopus worker-tools are cached on Dynamic Workers**  
 The `octopusdeploy/worker-tools` images provided for the execution containers feature cache the five latest Ubuntu and two latest Windows [Worker Tool](/docs/infrastructure/workers/worker-tools-versioning-and-caching) images on a Dynamic Worker when it's created. This makes them an excellent choice over installing additional software on a Dynamic Worker.
 
 :::


### PR DESCRIPTION
[sc-59991]

We are changing the default worker pool on Octopus Cloud from `Windows (default)` to `Ubuntu (default)`. This PR updates the implied default by changing the examples in the docs to emphasise `Ubuntu`.

This actual change will only affect new customers who sign up from the cut-over date (TBC). We will add a note about the cut-over date in a [follow up task](https://app.shortcut.com/octopusdeploy/story/61174/add-cutover-date-to-public-documentation).

Changes required before merging:

- [x] Update modified date on all pages
