### PR TITLE
Update calc description to describe wrapping variables in { }

### DIFF
--- a/src/pages/docs/projects/variables/variable-substitutions.mdx
+++ b/src/pages/docs/projects/variables/variable-substitutions.mdx
@@ -93,8 +93,8 @@ Basic mathematical calculations are supported in Octopus using the `calc` statem
 - Division - `/`
 
 :::div{.warning}
-When using a variable on the right-hand-side of a divide (`/`) or subtraction (`-`) calc operation,
-the variable name must be enclosed in *{...}* to ensure correct parsing, this ensures the operator symbol is recognised
+When using a variable on the left-hand-side of a divide (`/`) or subtraction (`-`) calc operation,
+the variable name must be enclosed in braces (`{ ... }`) to ensure correct parsing, this ensures the operator symbol is recognised
 as an operation, rather than part of the variable name. 
 :::
 
@@ -108,14 +108,14 @@ Given the variables:
 | `Numbers`             | `10,20,30,40,50` |       |
 | `My/Var`              | `15`             |       |
 
-`192.168.0.#{calc IPOffset[Primary] + 1}` would evaluate to `192.168.0.1`\
-`192.168.0.#{calc IPOffset[Secondary] + 1}` would evaluate to `192.168.0.181`\
-`#{calc 22 * ScaleFactor}` would evaluate to `264`\
-`#{each i in Numbers}#{calc i + 5} #{each}` would evaluate to `15 25 35 45 55 `\
-`#{calc {My/Var} / 3}` would evaluate to `5` \
-`#{calc 2 * My/Var}` would evaluate to `30` \
-`#{calc {My/Var} - 4}`  would evaluate to `11` \
-`#{calc 22 - My/Var}`  would evaluate to `7` \
+- `192.168.0.#{calc IPOffset[Primary] + 1}` would evaluate to `192.168.0.1`
+- `192.168.0.#{calc IPOffset[Secondary] + 1}` would evaluate to `192.168.0.181`
+- `#{calc 22 * ScaleFactor}` would evaluate to `264`
+- `#{each i in Numbers}#{calc i + 5} #{each}` would evaluate to `15 25 35 45 55 `
+- `#{calc {My/Var} / 3}` would evaluate to `5`
+- `#{calc 2 * My/Var}` would evaluate to `30`
+- `#{calc {My/Var} - 4}`  would evaluate to `11`
+- `#{calc 22 - My/Var}`  would evaluate to `7`
 
 :::div{.info}
 

--- a/src/pages/docs/projects/variables/variable-substitutions.mdx
+++ b/src/pages/docs/projects/variables/variable-substitutions.mdx
@@ -112,10 +112,11 @@ Given the variables:
 `192.168.0.#{calc IPOffset[Secondary] + 1}` would evaluate to `192.168.0.181`\
 `#{calc 22 * ScaleFactor}` would evaluate to `264`\
 `#{each i in Numbers}#{calc i + 5} #{each}` would evaluate to `15 25 35 45 55 `\
-`#{calc {My/Var} / 3}` would evaluate to `5`
-`#{calc 2 * My/Var}` would evaluate to `30`
-`#{calc {My/Var} - 4}`  would evaluate to `11`
-`#{calc 22 - My/Var}`  would evaluate to `7`
+`#{calc {My/Var} / 3}` would evaluate to `5` \
+`#{calc 2 * My/Var}` would evaluate to `30` \
+`#{calc {My/Var} - 4}`  would evaluate to `11` \
+`#{calc 22 - My/Var}`  would evaluate to `7` \
+
 :::div{.info}
 
 The `calc` operator is available from version 2023.2

--- a/src/pages/docs/projects/variables/variable-substitutions.mdx
+++ b/src/pages/docs/projects/variables/variable-substitutions.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-10-05
 title: Variable substitutions
 description: Variable substitutions are a flexible way to adjust configuration based on your variables and the context of your deployment.
 navOrder: 10

--- a/src/pages/docs/projects/variables/variable-substitutions.mdx
+++ b/src/pages/docs/projects/variables/variable-substitutions.mdx
@@ -92,6 +92,12 @@ Basic mathematical calculations are supported in Octopus using the `calc` statem
 - Multiplication - `*`
 - Division - `/`
 
+:::div{.warning}
+When using a variable on the right-hand-side of a divide (`/`) or subtraction (`-`) calc operation,
+the variable name must be enclosed in *{...}* to ensure correct parsing, this ensures the operator symbol is recognised
+as an operation, rather than part of the variable name. 
+:::
+
 Given the variables:
 
 | Name                  | Value            | Scope |
@@ -100,12 +106,16 @@ Given the variables:
 | `IPOffset[Secondary]` | `180`            |       |
 | `ScaleFactor`         | `12`             |       |
 | `Numbers`             | `10,20,30,40,50` |       |
+| `My/Var`              | `15`             |       |
 
-`192.168.0.#{calc IPOffset[Primary] + 1}` would evaluate to `192.168.0.1`
-`192.168.0.#{calc IPOffset[Secondary] + 1}` would evaluate to `192.168.0.181`
-`#{calc 22 * ScaleFactor}` would evaluate to `264`
-`#{each i in Numbers}#{calc i + 5} #{each}` would evaluate to `15 25 35 45 55 `
-
+`192.168.0.#{calc IPOffset[Primary] + 1}` would evaluate to `192.168.0.1`\
+`192.168.0.#{calc IPOffset[Secondary] + 1}` would evaluate to `192.168.0.181`\
+`#{calc 22 * ScaleFactor}` would evaluate to `264`\
+`#{each i in Numbers}#{calc i + 5} #{each}` would evaluate to `15 25 35 45 55 `\
+`#{calc {My/Var} / 3}` would evaluate to `5`
+`#{calc 2 * My/Var}` would evaluate to `30`
+`#{calc {My/Var} - 4}`  would evaluate to `11`
+`#{calc 22 - My/Var}`  would evaluate to `7`
 :::div{.info}
 
 The `calc` operator is available from version 2023.2

--- a/src/pages/docs/projects/variables/variable-substitutions.mdx
+++ b/src/pages/docs/projects/variables/variable-substitutions.mdx
@@ -93,7 +93,7 @@ Basic mathematical calculations are supported in Octopus using the `calc` statem
 - Division - `/`
 
 :::div{.warning}
-When using a variable on the left-hand-side of a divide (`/`) or subtraction (`-`) calc operation,
+When using a variable on the left-hand-side of a divide (`/`) or subtraction (`-`) operation,
 the variable name must be enclosed in braces (`{ ... }`) to ensure correct parsing, this ensures the operator symbol is recognised
 as an operation, rather than part of the variable name. 
 :::


### PR DESCRIPTION
The calc variable substitution has been updated such that if a variable appears on the lhs of a calc divide or subtraction operation - they can be wrapped in braces such that the parse can determine if the "/" or "-" is part of the variable, or the operation being performed.

This has necessitated an update to the docs to explain how to best to make use of this solution.

Don't _love_ the code block `{...}` in the warning section, but couldn't _quickly_ work out how to escape the braces!

![image](https://github.com/OctopusDeploy/docs/assets/37158202/83a576eb-49cf-47bc-87d0-22bbe364b96a)
