### PR TITLE
Removes the credits file (lots of names in there) from spellcheck.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ For example, if you added `MySQL` to an article and it was flagged as an unknown
 
 Some consideration should be given as to whether it should be `MySQL` or `MySql` and just a single entry should be added to `dictionary-octopus.txt` to promote consistency.
 
+### Exclusions
+
+You can see files excluded from the spell check in `cspell.json`.
+
 ## Deploying to preview environment (Octopus Developers)
 
 Before merging to `main` it's possible you'd like to see your changes in a preview environment. It's simple to do this:

--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,7 @@
         "package.json",
         "package-lock.yaml",
         "pnpm-lock.yaml",
+        "docs/credits.md",
         "node_modules/**"
     ]
 }


### PR DESCRIPTION
The credits file is auto-generated and includes many author names. It's better to exclude it from spellcheck.