### PR TITLE
Allows zero-file checks to pass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "img": "node --no-experimental-fetch ./src/themes/accelerator/utilities/img.mjs",
         "dev": "node --no-experimental-fetch ./src/themes/accelerator/utilities/img.mjs && astro dev",
         "test": "astro build && npx playwright install --with-deps && npx playwright test",
-        "spellcheck": "git fetch origin main:refs/remotes/origin/main && git diff origin/main --name-only --diff-filter=ACMRTUXB | cspell --file-list stdin",
+        "spellcheck": "git fetch origin main:refs/remotes/origin/main && git diff origin/main --name-only --diff-filter=ACMRTUXB | cspell --no-must-find-files --file-list stdin",
         "build": "astro build",
         "preview": "astro preview",
         "astro": "astro",


### PR DESCRIPTION
If all the changes found in the branch are excluded from checking, it raises an error.

This change supresses errors caused by zero files in the list to check.

## Before

![image](https://github.com/OctopusDeploy/docs/assets/99181436/3f851553-2aee-44d9-a5f9-88417d0bc41a)

## After

![image](https://github.com/OctopusDeploy/docs/assets/99181436/91087ac6-1b4f-4d6a-bfcb-982cd829894a)
