### PR TITLE
Remove sticky sessions advice

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -18,6 +18,7 @@ lifecycles
 maxage
 msiexec
 MTTR
+Netscaler
 nologs
 NTLM
 Octo
@@ -26,6 +27,7 @@ Octopub
 octopusdeploy
 octopusid
 octopuslabs
+octopusservernodes
 Octostache
 OIDC
 onlylogs

--- a/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
+++ b/src/pages/docs/getting-started/best-practices/installation-guidelines.mdx
@@ -170,8 +170,6 @@ The recommendations for load balancers are:
 
 :::div{.hint}
 Octopus Deploy will return the name of the node in the `Octopus-Node` response header.
-
-We have noticed specific user actions, such as creating a new space or updating permissions, won't update the cache on all nodes, and you'll get odd permissions errors.  Typically the cache is updated after a few minutes, and those errors go away.  If that happens to you, look at the `Octopus-Node` header to determine which node has updated data vs. not updated.  If you see that jumping between nodes is the problem, and you update permissions a lot, we recommend switching over to sticky sessions.
 :::
 
 If you plan on having external [polling Tentacles](/docs/infrastructure/deployment-targets/tentacle/tentacle-communication/) connect to your instance through a load balancer / firewall you will need to configure passthrough ports to each node.  Our [high availability guides](/docs/administration/high-availability/design) provide steps on how to do this.


### PR DESCRIPTION
# Background

In previous versions of Octopus Server, permissions changes wouldn't appear on all nodes in a HA setup instantly, due to caches not being invalidated. This resulted in customers experiencing permission errors depending on which node answered their request. To avoid this, it was recommended to use load balancer "sticky sessions", which would ensure a user always talked to the same node.

The cache invalidation issue no longer exists, and has not for at least a year. Thus, the use of sticky sessions to avoid it is not required.

Using sticky sessions also carries other risks. If the node a user is "stuck" to experiences heavy load they may not be able to talk to the API at all.

# Results

Remove the advice to use sticky sessions.