### PR TITLE
Updates accelerator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "dependencies": {
         "@astrojs/mdx": "^1.0.0",
         "astro": "^3.0.3",
-        "cspell": "^7.3.7",
-        "astro-accelerator": "^0.3.12",
+        "astro-accelerator": "^0.3.13",
         "astro-accelerator-utils": "^0.3.2",
+        "cspell": "^7.3.7",
         "hast-util-from-selector": "^3.0.0",
         "remark-directive": "^2.0.1",
         "remark-heading-id": "^1.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ dependencies:
     specifier: ^3.0.3
     version: 3.0.3
   astro-accelerator:
-    specifier: ^0.3.12
-    version: 0.3.12
+    specifier: ^0.3.13
+    version: 0.3.13
   astro-accelerator-utils:
     specifier: ^0.3.2
     version: 0.3.2
@@ -1403,8 +1403,8 @@ packages:
     resolution: {integrity: sha512-34L9rFyjFpTCpn7qj2p3Gl8tO2TxvzBuoHUTKzfoP6Jh/aiecYDpKaxjwOj4tnr627PKU33qL9xCL8eqv/WLRg==}
     dev: false
 
-  /astro-accelerator@0.3.12:
-    resolution: {integrity: sha512-FF9V5IS7lqgq7Mp8RHW5ux6WWeoN6hNMEgHVMtZTPzLRdeU2A60FqAAuBvIpizE/MPPOEndLoJsuZFiKNcz4eg==}
+  /astro-accelerator@0.3.13:
+    resolution: {integrity: sha512-9YCp4ty+OUnYfYKetaFSqXkz32XQ+oPtetVZ1BKd8Aze6dE+D5+MFW6170p9RSDieHeG0gkl6dis7/KVTg7ZIw==}
     engines: {node: '>=18.14.1', pnpm: '>=8.6.12'}
     dependencies:
       '@astrojs/mdx': 1.1.1(astro@3.2.4)

--- a/public/docs/js/modules/youtube.js
+++ b/public/docs/js/modules/youtube.js
@@ -6,6 +6,11 @@ function enhanceYoutubeLinks() {
     const videos = qsa('a[href^="https://www.youtube.com/watch?v="]');
 
     for (var video of videos) {
+        if (video.parentNode.childNodes.length > 1) {
+            // Don't turn video into embed if it's part of a longer paragraph, for example.
+            continue;
+        }
+
         const id = new URL(video.href).searchParams.get('v');
         video.setAttribute('data-youtube', id);
         video.classList.add('init');


### PR DESCRIPTION
This resolves the issue with YT videos that aren't on their own line being expanded.

```markdown
[This video will auto-embed.](https://www.youtube.com/watch?v=FjPO1k0Y-xA)

This video won't [as it is accompanied by text nodes](https://www.youtube.com/watch?v=FjPO1k0Y-xA)

[The full stop is outside the link, so this won't embed](https://www.youtube.com/watch?v=FjPO1k0Y-xA).
```