### PR TITLE
Add link to K8s use case page

### DIFF
--- a/src/pages/docs/deployments/kubernetes/index.md
+++ b/src/pages/docs/deployments/kubernetes/index.md
@@ -8,7 +8,7 @@ navOrder: 80
 hideInThisSectionHeader: true
 ---
 
-Octopus Deploy makes it easy to manage your Kubernetes resources, whether you're starting simple or want complete control over a complex setup. You can deploy Kubernetes resources such as [deployments](/docs/deployments/kubernetes/deploy-container/), [services](/docs/deployments/kubernetes/deploy-service/), and [ingress](/docs/deployments/kubernetes/deploy-ingress), and run scripts against a Kubernetes cluster.
+Octopus Deploy makes it easy to manage your Kubernetes resources, whether you're starting simple or want complete control over a complex setup. You can [deploy Kubernetes resources](https://octopus.com/use-case/kubernetes) such as [deployments](/docs/deployments/kubernetes/deploy-container/), [services](/docs/deployments/kubernetes/deploy-service/), and [ingress](/docs/deployments/kubernetes/deploy-ingress), and run scripts against a Kubernetes cluster.
 
 - Centralize your Kubernetes clusters and resources in a single place so you can focus on your applications and customers
 - Adopt development best practices:


### PR DESCRIPTION
Adding a link to the K8s use case page. I've added it to what is essentially the K8s overview page in Docs which I think gives us license to add a link to a 'marketing' page. 

This docs page is also the first Octopus page that appears in search when someone searches for deployments to kubernetes, so I want to try and speed up the new page being recognised by search engines and also pass some of the authority from the docs page to the use case page.