### PR TITLE
Fix linux tentacle pre-req link and systemd header

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -29,6 +29,7 @@ msiexec
 MTTR
 Netscaler
 nologs
+noninteractive
 NTLM
 nupkg
 Octo
@@ -46,6 +47,7 @@ onlylogs
 passout
 pkcs
 PROGRAMFILES
+quickstart
 reprioritize
 reprovisioned
 reprovisioning
@@ -69,3 +71,4 @@ WIXUI
 workertools
 xlarge
 xmark
+xvzf

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-11-07
 title: Linux Tentacle
 description: How to install and configure Octopus Tentacles on Linux Servers in either listening or polling mode.
 navOrder: 20

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -20,7 +20,7 @@ Before you can configure a Linux Tentacle, the Linux server must meet the [requi
 
 - Octopus Server **2019.8.3** or newer
 
-Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs) that may need to be installed.
+Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md) that may need to be installed.
 
 ## Known limitations
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -20,7 +20,7 @@ Before you can configure a Linux Tentacle, the Linux server must meet the [requi
 
 - Octopus Server **2019.8.3** or newer
 
-Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/master/Documentation/prereqs/) that may need to be installed.
+Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs) that may need to be installed.
 
 ## Known limitations
 
@@ -123,7 +123,7 @@ Start the Tentacle interactively by running:
 /opt/octopus/tentacle/Tentacle run --instance <instance name>
 ```
 
-### Running Tentacle as a service (syst/)
+### Running Tentacle as a service (systemd)
 
 Tentacle has command line options for configuring a systemd service:
 


### PR DESCRIPTION
I found a broken link and this PR fixes that and what looks like a erroneous update to the systemd header for linux tentacle