### PR TITLE
Robe/azure cloud deprecation

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -66,6 +66,7 @@ systemprofile
 tabpanel
 Trivy
 upgradelog
+useronboarding
 WCAG
 webfonts
 WEBSVR

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-09-13
+modDate: 2023-11-20
 title: Deprecations
 description: Upcoming and past deprecations by version for Octopus Server
 navOrder: 300

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -18,7 +18,7 @@ Deprecations have the following lifecycle:
 - (+1 year) Remove deprecated functionality
 
 :::div{.warning}
-Deprecations are subject to change in detail or timeframe. If you need help assessing the impact of deprecation of a feature on your particular Octopus Server configuration, please contact our [support team](https://octopus.com/support).
+Deprecations are subject to change in detail or time frame. If you need help assessing the impact of deprecation of a feature on your particular Octopus Server configuration, please contact our [support team](https://octopus.com/support).
 :::
 
 ## Deprecations coming in 2024.1

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -23,6 +23,15 @@ Deprecations are subject to change in detail or timeframe. If you need help asse
 
 ## Deprecations coming in 2024.1
 
+### Azure Cloud Services (Classic)
+Azure have announced the sunsetting of the original _Cloud Services_ resource, renamed _Cloud Services (Classic)_, with the [final retirement date set as August 31, 2024](https://learn.microsoft.com/en-us/lifecycle/products/azure-cloud-services-classic). In a little over 6 months, teams that are still relying on this cloud service will be unable to deploy to them at all, with Octopus Deploy or otherwise.
+
+In the lead up to this, Octopus workloads making use of Azure Cloud Service Targets, Azure Cloud Service Steps or Management Certificates in Octopus Deploy will start to see in-app and in-task warnings appear in Octopus Server `2024.1`. 
+
+Once support has been fully dropped for these resources by Azure mid-year, then these warnings will turn into errors followed by the removal of these resources from Octopus instances entirely.
+
+The reccomended migration path outlined by Azure is to make use of the seperate [_Azure Cloud Services (extended support)_](https://learn.microsoft.com/en-us/azure/cloud-services-extended-support/overview) product, however at this time there are no plans to support this feature in Octopus natively.
+
 ### Mono based SSH Deployment Targets
 
 From `2024.1` SSH deployments will no longer support running tasks via Mono. Instead, Linux workers and targets will only execute using .NET Core compiled tooling, which for most cases can be enabled via a simple configuration change on the machine configuration page. Further details on the background for this update as well as the reasoning behind it are available on the [Deprecating Mono](https://octopus.com/blog/deprecating-mono) blog post.

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -24,13 +24,13 @@ Deprecations are subject to change in detail or timeframe. If you need help asse
 ## Deprecations coming in 2024.1
 
 ### Azure Cloud Services (Classic)
-Azure have announced the sunsetting of the original _Cloud Services_ resource, renamed _Cloud Services (Classic)_, with the [final retirement date set as August 31, 2024](https://learn.microsoft.com/en-us/lifecycle/products/azure-cloud-services-classic). In a little over 6 months, teams that are still relying on this cloud service will be unable to deploy to them at all, with Octopus Deploy or otherwise.
+Azure have announced the sun setting of the original _Cloud Services_ resource, renamed _Cloud Services (Classic)_, with the [final retirement date set as August 31, 2024](https://learn.microsoft.com/en-us/lifecycle/products/azure-cloud-services-classic). In a little over 6 months, teams that are still relying on this cloud service will be unable to deploy to them at all, with Octopus Deploy or otherwise.
 
 In the lead up to this, Octopus workloads making use of Azure Cloud Service Targets, Azure Cloud Service Steps or Management Certificates in Octopus Deploy will start to see in-app and in-task warnings appear in Octopus Server `2024.1`. 
 
 Once support has been fully dropped for these resources by Azure mid-year, then these warnings will turn into errors followed by the removal of these resources from Octopus instances entirely.
 
-The reccomended migration path outlined by Azure is to make use of the seperate [_Azure Cloud Services (extended support)_](https://learn.microsoft.com/en-us/azure/cloud-services-extended-support/overview) product, however at this time there are no plans to support this feature in Octopus natively.
+The recommended migration path outlined by Azure is to make use of the separate [_Azure Cloud Services (extended support)_](https://learn.microsoft.com/en-us/azure/cloud-services-extended-support/overview) product, however at this time there are no plans to support this feature in Octopus natively.
 
 ### Mono based SSH Deployment Targets
 

--- a/src/pages/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index.md
@@ -12,7 +12,7 @@ Azure Cloud Service deployment targets allow you to reference existing classic C
 :::div{.warning}
 Microsoft [announced](https://blogs.msdn.microsoft.com/appserviceteam/2018/03/12/deprecating-service-management-apis-support-for-azure-app-services/) that from June 30th 2018 they are retiring support for Azure Service Management API (which indicates Cloud Services). Microsoft stated that _"Cloud Services is similar to Service Fabric in degree of control versus ease of use, but it's now a legacy service and Service Fabric is recommended for new development"_ ([source](https://docs.microsoft.com/en-us/azure/app-service/choose-web-site-cloud-service-vm)).
 
-Octopus Deploy will begin the deprecation of this feature from the `2024.1` Octopus Server release.
+Support for this feature will be deprecated in Octopus Server from the `2024.1` release.
 :::
 
 ## Requirements

--- a/src/pages/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index.md
@@ -11,6 +11,8 @@ Azure Cloud Service deployment targets allow you to reference existing classic C
 
 :::div{.warning}
 Microsoft [announced](https://blogs.msdn.microsoft.com/appserviceteam/2018/03/12/deprecating-service-management-apis-support-for-azure-app-services/) that from June 30th 2018 they are retiring support for Azure Service Management API (which indicates Cloud Services). Microsoft stated that _"Cloud Services is similar to Service Fabric in degree of control versus ease of use, but it's now a legacy service and Service Fabric is recommended for new development"_ ([source](https://docs.microsoft.com/en-us/azure/app-service/choose-web-site-cloud-service-vm)).
+
+Octopus Deploy will begin the deprecation of this feature from the `2024.1` Octopus Server release.
 :::
 
 ## Requirements

--- a/src/pages/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/azure/cloud-service-targets/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-11-20
 title: Azure Cloud Service targets
 description: Azure Cloud Service deployment targets allow you to reference existing classic Cloud Services in your Azure subscription, that you can then reference by role during deployments.
 navOrder: 100

--- a/src/shared-content/deprecated-items/azure-cloud-services-deprecated.include.md
+++ b/src/shared-content/deprecated-items/azure-cloud-services-deprecated.include.md
@@ -4,4 +4,6 @@ Azure [announced](https://azure.microsoft.com/en-gb/updates/deprecating-service-
 We recommend reading the Azure [guide to choosing a compute service](https://docs.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree) to help choose a replacement you can [deploy to Azure](/docs/deployments/azure) with.
 
 This guide remains here for legacy applications.
+
+Support for this feature will be deprecated in Octopus Server from the `2024.1` release.
 :::


### PR DESCRIPTION
As outlined in the [internal document](https://docs.google.com/document/d/1kpi1OkAeqnNUDCUImKlejYWn5vmUJ5BMnvRCxhYv1QA/edit), the Azure Cloud Services feature will be deprecated from the `2024.1` release of Octopus server.

This PR adds some relevant content to start this process