### PR TITLE
Tidy up AD page.

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -32,6 +32,7 @@ maintenanceconfiguration
 maxage
 msiexec
 MTTR
+NETBIOS
 Netscaler
 nologs
 noninteractive
@@ -64,6 +65,7 @@ Runbook
 runbook
 runbooks
 Schannel
+setspn
 SIEM
 signingkeys
 sthumb


### PR DESCRIPTION
Tidy up of Active Directory page.

1. Remove fragments not linked internally or through oc.to short links
2. Fix fragments that are used (lower case, word-separated, and readable)
3. A couple of bold items changed to headings
4. General markdown layout improvements
5. New terms added to the dictionary for NETBIOS and setspn
6. Example domains and usernames improved readability

No fragement domains for /docs/security/authentication/active-directory in short.io:

![image](https://github.com/OctopusDeploy/docs/assets/99181436/c08de6c1-e703-4a9d-9ca5-4a3064c59ea3)
