### PR TITLE
Docs cleanup of tenants section

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -5,6 +5,7 @@ bootstrap
 bootstrapped
 bootstrapper
 cicd
+combinational
 cscfg
 cspkg
 cutover

--- a/src/pages/docs/tenants/tenant-creation/connecting-projects.md
+++ b/src/pages/docs/tenants/tenant-creation/connecting-projects.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-10-05
+modDate: 2023-12-07
 title: Connecting projects
 description: By connecting tenants to projects, you can control which projects will be deployed into which environments for each tenant.
 navOrder: 20

--- a/src/pages/docs/tenants/tenant-creation/connecting-projects.md
+++ b/src/pages/docs/tenants/tenant-creation/connecting-projects.md
@@ -29,11 +29,11 @@ The project connection feature was updated to allow bulk selection in Octopus De
 Not seeing the environment you want? Make sure at least one lifecycle used by your project includes that environment.
 :::
 
-6. A preview of the selected projects and environments is shown in the Connection preview panel. The selected environments will be assigned to each project based on whether they are part of any lifecycle in the project. If an environment is not part of any lifecycle in the project, it will not be assigned to the project.
+6. A preview of the selected projects and environments is shown in the connection preview panel. The selected environments will be assigned to each project based on whether they are part of any lifecycle in the project. If an environment is not part of any lifecycle in the project, it will not be assigned to the project.
 7. Click **CONNECT <N> PROJECTS**
 
-You can connect each tenant to any number of projects and for each project, any combination of environments that can be targeted by each project. This gives you the most flexibility when designing your multi-tenant deployments.
+You can connect each tenant to any number of projects and, for each project, any combination of environments that each project can target. This gives you the most flexibility when designing your multi-tenant deployments.
 
 - You can offer specific projects to some tenants and not to others.
-- You can also provide most of your tenants with a single environment while offering specific customers extra environments. For example, you could give particular customers with a test/staging/acceptance environment where they can test new releases before upgrading their production environment.
+- You can also provide most of your tenants with a single environment while offering specific customers extra environments. For example, you could give particular customers a test/staging/acceptance environment where they can test new releases before upgrading their production environment.
 

--- a/src/pages/docs/tenants/tenant-creation/index.mdx
+++ b/src/pages/docs/tenants/tenant-creation/index.mdx
@@ -14,12 +14,12 @@ import TenantsCreateTenant from 'src/shared-content/tenants/tenants-create-tenan
 Now that you've created a tenant, you can enable [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments/) and then [connect the tenant to a project](/docs/tenants/tenant-creation/connecting-projects).
 
 :::div{.hint}
-It's also possible to create a tenant using the [Octopus REST API](/docs/octopus-rest-api/). To learn more, see our [Create a Tenant](/docs/octopus-rest-api/examples/tenants/create-tenant) example.
+It's also possible to create a tenant using the [Octopus REST API](/docs/octopus-rest-api/). Learn more in our [create a tenant](/docs/octopus-rest-api/examples/tenants/create-tenant) example.
 :::
 
 ## Tenant logo \{#tenant-logo}
 
-Try adding a logo for your tenant - this will make it much easier to distinguish your tenants. You can do this within the Octopus Tenant section by clicking on the tenant's logo placeholder or going to the Settings tab on the tenant.
+Try adding a logo for your tenant - this will make it much easier to distinguish your tenants. You can do this by navigating to a tenant and clicking the **Settings** tab.
 
 Your tenants will likely be other businesses, and you could use their logo to help quickly identify the correct tenant.
 
@@ -28,7 +28,3 @@ You could consider using logos based on:
 - Customer logos
 - Data center region(s) or flags
 - Individual tester(s) photo/avatar
-
-## Learn more
-
-The following topics on creating your first tenant are explained further in this section:

--- a/src/pages/docs/tenants/tenant-creation/index.mdx
+++ b/src/pages/docs/tenants/tenant-creation/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-12-07
 title: Tenant creation
 description: How to create a tenant in Octopus Deploy.
 navOrder: 20

--- a/src/pages/docs/tenants/tenant-creation/tenanted-deployments.md
+++ b/src/pages/docs/tenants/tenant-creation/tenanted-deployments.md
@@ -17,7 +17,7 @@ You can change the setting for tenanted deployments for a project by navigating 
 
 Tenanted deployments will be enabled when [connecting tenants to a project](/docs/projects/tenants/bulk-connection).
 
-## Tenanted and Untenanted deployments {#tenanted-and-untenanted-deployments}
+## Tenanted and untenanted deployments {#tenanted-and-untenanted-deployments}
 
 On the deployment screen, if you choose **Tenanted** from the **Tenants** option, you are performing a [**tenanted deployment**](https://octopus.com/use-case/tenanted-deployments) - deploying a release of a project to an environment for one or more tenants. 
 
@@ -27,9 +27,9 @@ On the deployment screen, if you choose **Tenanted** from the **Tenants** option
 
 When you perform a tenanted deployment, the selected tenant can impact the entire process, including which steps are run, which variable values are used, and which deployment targets are included, all depending on your deployment design.
 
-Also, note Octopus will create a deployment per-tenant. This means if you select 20 tenants, Octopus will create 20 separate deployments: one for each tenant. Each of those deployments will execute in its own task.
+Also, note that Octopus will create a deployment per-tenant. If you select 20 tenants, Octopus will create 20 separate deployments, one for each tenant. Each of those deployments will execute in its own task.
 
-When you choose **one or more environments** to deploy to, you are performing an **untenanted deployment** - this is the same kind of deployment Octopus has always performed where you deploy a release of a project to an environment there is no tenant for the deployment. There will be no tenant influence on the deployment process.
+When you choose **one or more environments** to deploy to, you are performing an **untenanted deployment**. This is the same kind of deployment Octopus always performs, where you deploy a release to an environment where there is no tenant for the deployment. There will be no tenant influence on the deployment process.
 
 :::figure
 ![](/docs/tenants/tenant-creation/images/multi-tenant-deploy-multiple-environments.png)

--- a/src/pages/docs/tenants/tenant-creation/tenanted-deployments.md
+++ b/src/pages/docs/tenants/tenant-creation/tenanted-deployments.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-10-05
+modDate: 2023-12-07
 title: Tenanted deployments
 description: Control how the multi-tenancy feature in Octopus is used in your Projects.
 navOrder: 10

--- a/src/pages/docs/tenants/tenant-deployment-faq.md
+++ b/src/pages/docs/tenants/tenant-deployment-faq.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-10-04
+modDate: 2023-12-07
 title: Multi-tenant deployments FAQ
 description: Questions we are often asked relating to multi-tenant deployments.
 navOrder: 90

--- a/src/pages/docs/tenants/tenant-deployment-faq.md
+++ b/src/pages/docs/tenants/tenant-deployment-faq.md
@@ -9,7 +9,7 @@ navOrder: 90
 
 This page contains some of the questions we are often asked relating to multi-tenant deployments in Octopus Deploy.
 
-## Is there anything special about multi-tenant projects or environments? {#Multi-tenantdeploymentsFAQ-Isthereanythingspecialaboutmulti-tenantprojectsorenvironments?}
+## Is there anything special about multi-tenant projects or environments?
 
 No, not really. Any Octopus project or environment can work with tenants. To start deploying a project using tenants:
 
@@ -18,13 +18,13 @@ No, not really. Any Octopus project or environment can work with tenants. To sta
 
 For more information refer to [creating your first tenant](/docs/tenants/tenant-creation/) and [deploying a multi-tenant project](/docs/tenants/tenant-creation/tenanted-deployments).
 
-## Can I deploy to multiple tenants in a single deployment? {#Multi-tenantdeploymentsFAQ-CanIdeploytomultipletenantsinasingledeployment?}
+## Can I deploy to multiple tenants in a single deployment?
 
-No. A tenant is treated like a smaller slice of an environment. Octopus creates a new deployment for every tenant/environment combination you are deploying a release into. For more information refer to our [tenated deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
+No. A tenant is treated like a smaller slice of an environment. Octopus creates a new deployment for every tenant/environment combination you are deploying a release into. For more information refer to our [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
 
-## Can I deploy to multiple tenants at the same time? {#Multi-tenantdeploymentsFAQ-CanIdeploytomultipletenantsatthesametime?}
+## Can I deploy to multiple tenants at the same time?
 
-Yes! You can create multiple tenanted deployments at the same time very easily by using the Octopus UI, The Octopus CLI or any of the build server extensions. You can choose multiple tenants using [Tenant Tags](/docs/tenants/tenant-tags/) or all of the tenants in an environment. For more information refer to [deploying releases with the Octopus CLI](/docs/octopus-rest-api/octopus-cli/deploy-release) and [deploying to multiple tenants using tags](/docs/tenants/tenant-tags/#deploying-to-multiple-tenants-tags).
+Yes! You can create multiple tenanted deployments at the same time very easily by using the Octopus UI, The Octopus CLI or any of the build server extensions. You can choose multiple tenants using [tenant tags](/docs/tenants/tenant-tags/) or all of the tenants in an environment. For more information refer to [deploying releases with the Octopus CLI](/docs/octopus-rest-api/octopus-cli/deploy-release) and [deploying to multiple tenants using tags](/docs/tenants/tenant-tags/#deploying-to-multiple-tenants-tags).
 
 ## Can I control the order in which tenanted deployments execute?
 
@@ -40,7 +40,7 @@ There are a few ways you can achieve a predictable order of tenanted deployments
 
 We recommend avoiding order dependence of your deployments wherever possible.
 
-## Can I Perform tenanted deployments in batches?
+## Can I perform tenanted deployments in batches?
 
 Yes! This is a practice we recommend. You can use [tenant tags](/docs/tenants/tenant-tags) to group your tenants together into batches and then promote your releases through your tenants in batches. It can be convenient to deploy to some of your tenants first in order to detect any problems with your release before you promote to all of your other tenants.
 
@@ -64,11 +64,11 @@ No. Each tenanted deployment is independent. There is no built-in way to perform
 
 - I want to send an email when a batch of tenanted deployments complete with the results of those deployments.
 - I want to send an email once release **1.2.6** has been successfully deployed to all of my tenants in production.
-- I want to upgrade a batch of tenants, and if one fails, I want them all to roll-back to the last known good version.
+- I want to upgrade a batch of tenants and, if one fails, I want them all to roll-back to the last known good version.
 
 You can achieve these behaviors using a custom script/application which leverages the [Octopus REST API](/docs/octopus-rest-api/) and taking advantage of [Subscriptions](/docs/administration/managing-infrastructure/subscriptions). This way you can use the information provided by Octopus to perform a complex deployment orchestration with any custom logic that suits your scenario perfectly. For example, you could write a script/application which starts a batch of tenanted deployments using a specific tag, then monitor the progress of those deployments, and finally take any action based on the results.
 
-## Can I have a combination of tenanted and untenanted projects? {#Multi-tenantdeploymentsFAQ-CanIhaveacombinationoftenantedanduntenantedprojects?}
+## Can I have a combination of tenanted and untenanted projects?
 
 Yes! Each project can control its interaction with tenants. By default the multi-tenant deployment features are disabled. You can allow deployments with/without a tenant, which is a hybrid mode that is useful when you are transitioning to a fully multi-tenant project. There is also a mode where you can require a tenant for all deployments, which disables untenanted deployments for that project.
 
@@ -76,17 +76,17 @@ Yes! Each project can control its interaction with tenants. By default the multi
 ![](/docs/tenants/images/multi-tenant-project-settings.png)
 :::
 
-## What is an "untenanted deployment"? Don't I have to choose a Tenant when deploying my project? {#Multi-tenantdeploymentsFAQ-Whatisanun-tenanteddeploymentDontIhavetochooseatenantwhendeployingmyproject?}
+## What is an "untenanted deployment"? Don't I have to choose a tenant when deploying my project?
 
-When you first enable multi-tenant deployments you won't have any tenants, and we don't want that to stop you from deploying your existing projects. Perhaps you are using an environment-per-tenant model and will migrate to tenants over a period of time, so some deployments will start to have a tenant whilst others do not. Essentially an "untenanted deployment" is the same kind of deployment Octopus always performed: *there is no tenant for this deployment*. When you deploy using a tenant Octopus includes variables from the tenant, and the selected tenant can impact which steps are run, which variable values are used, and which deployment targets are included, at your discretion. For more information refer to our [tenated deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
+When you first enable multi-tenant deployments you won't have any tenants, and we don't want that to stop you from deploying your existing projects. Perhaps you are using an environment-per-tenant model and will migrate to tenants over a period of time, so some deployments will start to have a tenant whilst others do not. Essentially an "untenanted deployment" is the same kind of deployment Octopus always performed: *there is no tenant for this deployment*. When you deploy using a tenant, Octopus includes variables from the tenant. The selected tenant can impact which steps are run, which variable values are used, and which deployment targets are included, at your discretion. For more information refer to our [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
 
-## Can I prevent "untenanted deployments" of a project? {#Multi-tenantdeploymentsFAQ-CanIpreventun-tenanteddeploymentsofaproject?}
+## Can I prevent "untenanted deployments" of a project?
 
-Yes. Choose the **Require a tenant for all deployments** option in the Project settings. For more information refer to our [tenated deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
+Yes. Choose the **Require a tenant for all deployments** option in the project settings. For more information refer to our [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
 
-## Can I require a tenant for all deployments of a project? {#Multi-tenantdeploymentsFAQ-CanIrequireatenantforalldeploymentsofaproject?}
+## Can I require a tenant for all deployments of a project?
 
-Yes, see the previous question. For more information refer to our [tenated deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
+Yes, see the previous question. For more information refer to our [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
 
 ## Can I deploy a tenanted project on an untenanted machine?
 
@@ -96,60 +96,56 @@ Yes!
 
 Yes!
 
-## Why can't I connect a tenant to my project, or perform a tenanted deployment of my project? {#Multi-tenantdeploymentsFAQ-WhycantIconnectatenanttomyproject,orperformatenanteddeploymentofmyproject?}
+## Why can't I connect a tenant to my project, or perform a tenanted deployment of my project?
 
-As long as you have _Project View_ permissions for the project, and that project is configured to enable tenanted deployments, you should be able to connect your tenants to that project. Each project can opt-in to tenanted deployment features, perhaps your project needs to enable tenanted deployments? See above for more details.
+As long as you have ProjectView permissions for the project, and that project is configured to enable tenanted deployments, you should be able to connect your tenants to that project. You may need to enable tenanted deployments for the project. See above for more details.
 
 ## Why can't I connect a tenant to one of the environments for my project?
 
-Firstly check you can select a project for your tenant (see above for more details). As long as you have _Environment View_ permissions for the environment, and that environment is included in one of the lifecycles used by your project, you should be able to connect your tenants to that environment. Check each of the lifecycles used by your project (each channel can specify a different lifecycle) and make sure at least one of them includes the environment.
+Firstly, check you can select a project for your tenant (see above for more details). As long as you have EnvironmentView permissions for the environment and the environment is included in one of the lifecycles used by your project, you should be able to connect your tenants to that environment. Check each of the lifecycles used by your project (each channel can specify a different lifecycle) and make sure at least one of them includes the environment.
 
-## I want to deploy my project to a tenant, but I can't see that tenant in the list? {#Multi-tenantdeploymentsFAQ-Iwanttodeploymyprojecttoatenant,butIcantseethattenantinthelist?}
+## I want to deploy my project to a tenant, but I can't see that tenant in the list?
 
-Granted, multi-tenant deployments can get complicated very quickly, so we've written a [troubleshooting guide](/docs/tenants/troubleshooting-multi-tenant-deployments/) to help when you get stuck. At the very least, make sure your tenant is connected to the correct project and environment(s). For more information refer to our [tenant creation](/docs/tenants/tenant-creation/) and [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) sections.
+Make sure your tenant is connected to the correct project and environment(s). Multi-tenant deployments can get complicated very quickly, so we've written a [troubleshooting guide](/docs/tenants/troubleshooting-multi-tenant-deployments/) to help when you get stuck. For more information refer to our [tenant creation](/docs/tenants/tenant-creation/) and [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) sections.
 
-## Is licensing affected by the number of tenants I have? {#Multi-tenantdeploymentsFAQ-IslicensingaffectedbythenumberoftenantsIhave?}
-
-No, you can create an unlimited number of tenants without any impact on licensing.
-
-## Can I provide third-party self-service sign in, so my tenants can manage their own deployments? {#Multi-tenantdeploymentsFAQ-CanIprovide3rd-partyself-servicesignin,somytenantscanmanagetheirowndeployments?}
+## Can I provide third-party self-service sign in, so my tenants can manage their own deployments?
 
 Yes, take a look at our [guide on enabling self-service sign in for your tenants](/docs/tenants/tenant-roles-and-security).
 
-## How are deployment targets selected for each deployment? {#Multi-tenantdeploymentsFAQ-Howaredeploymenttargetsselectedforeachdeployment?}
+## How are deployment targets selected for each deployment?
 
 Octopus uses this rule to determine which deployment targets should be included in a deployment:
 
 - Tenanted deployments will include tenanted deployment targets matching the deployment's tenant
-- Untenanted deployments will include untenanted deployment targets (just like good old Octopus)
+- Untenanted deployments will include untenanted deployment targets
 
 For more information refer to our [tenant infrastructure](/docs/tenants/tenant-infrastructure) section.
 
-## Can I configure deployment targets that are dedicated/limited to a single tenant? {#Multi-tenantdeploymentsFAQ-CanIconfiguredeploymenttargetsthatarededicated/limitedtoasingletenant?}
+## Can I configure deployment targets that are dedicated/limited to a single tenant?
 
 Yes. Set the tenant filter on each of the deployment targets to a specific tenant. Octopus will ensure these deployment targets are only used in deployments for that specific tenant.
 
 For more information refer to our [tenant infrastructure](/docs/tenants/tenant-infrastructure) section.
 
-## Can I configure accounts that are dedicated/limited to a single tenant? {#Multi-tenantdeploymentsFAQ-CanIconfigureaccountsthatarededicated/limitedtoasingletenant?}
+## Can I configure accounts that are dedicated/limited to a single tenant?
 
 Yes. The same logic is applied to accounts as deployment targets.
 
 For more information refer to our [tenant infrastructure](/docs/tenants/tenant-infrastructure) section.
 
-## Can I deploy a mixture of projects to my tenants? {#Multi-tenantdeploymentsFAQ-CanIdeployamixtureofprojectstomytenants?}
+## Can I deploy a mixture of projects to my tenants?
 
 Yes, you can connect your tenants to as many or as few projects as you desire. The tenant-to-project/environment connection for each tenant can be configured individually, allowing you to connect each tenant to the projects and environments they require. For more information refer to our [connecting tenants to projects](/docs/tenants/tenant-creation/connecting-projects) section.
 
-## Can I provide my tenants with a staging and production environment? {#Multi-tenantdeploymentsFAQ-CanIprovidemytenantswithastagingandproductionenvironment?}
+## Can I provide my tenants with a staging and production environment?
 
 Yes, simply connect the tenant to a project and any number of environments that project can deploy into. For more information refer to our [connecting tenants to projects](/docs/tenants/tenant-creation/connecting-projects) section.
 
-## Can I configure a standard set of variables that are required by each tenant like an alias or contact details? {#Multi-tenantdeploymentsFAQ-CanIconfigureastandardsetofvariablesthatarerequiredbyeachtenantlikeanaliasorcontactdetails?}
+## Can I configure a standard set of variables that are required by each tenant like an alias or contact details?
 
 Yes, we recommend creating some variable templates in a library variable set, and connecting that library variable set to all of the projects where you require those variables. Now Octopus will prompt you for those standard variables, once for each tenant. We cover this in more detail in the [tenant variables](/docs/tenants/tenant-variables) section.
 
-## Can I use tenants and channels together? {#Multi-tenantdeploymentsFAQ-CanIusetenantsandchannelstogether?}
+## Can I use tenants and channels together?
 
 Yes, you can apply a tenant filter to a channel as a way of expressing: "Releases in this channel may only be deployed to tenants matching the filter." For examples of working with tenants and channels see our guides:
 
@@ -157,13 +153,13 @@ Yes, you can apply a tenant filter to a channel as a way of expressing: "Release
 - [Implementing an early access program](/docs/tenants/tenant-lifecycles/#early-access-program)
 - [Pinning tenants to a release](/docs/tenants/tenant-lifecycles/#pinning-tenants)
 
-## Can I pin or lock a tenant to a specific release? {#Multi-tenantdeploymentsFAQ-CanIpinorlockatenanttoaspecificrelease?}
+## Can I pin or lock a tenant to a specific release?
 
-Yes, you can determine which types of releases should be deployed to a your tenants by using a combination of channels and tag sets. This is part of an advanced topic which is covered in our [Pinning tenants to a release](/docs/tenants/tenant-lifecycles/#pinning-tenants) section.
+Yes, you can determine which types of releases should be deployed to a your tenants by using a combination of channels and tag sets. This is part of an advanced topic which is covered in our [pinning tenants to a release](/docs/tenants/tenant-lifecycles/#pinning-tenants) section.
 
-## Are there any known limitations or problems with multi-tenant deployments? {#LimitationsAndBugs?}
+## Are there any known limitations or problems with multi-tenant deployments?
 
-Whenever we discover a limitation or problem with multi-tenant deployments we create a GitHub Issue labeled with the `feature/tenants` to track its progress. [These issues](https://github.com/OctopusDeploy/Issues/issues?q=is%3Aopen+is%3Aissue+label%3Afeature%2Ftenants) represent anything we have agreed is a limitation or problem, and we intend to implement it in the near future. We recommend investigating whether these limitations will impact your specific scenario.
+Whenever we discover a limitation or problem with multi-tenant deployments we create a GitHub Issue labeled with the `feature/tenants` to track its progress. [These issues](https://github.com/OctopusDeploy/Issues/issues?q=is%3Aopen+is%3Aissue+label%3Afeature%2Ftenants) represent anything we have agreed is a limitation or problem. We recommend investigating whether these limitations will impact your specific scenario.
 
 ## Learn more
 

--- a/src/pages/docs/tenants/tenant-deployment-faq.md
+++ b/src/pages/docs/tenants/tenant-deployment-faq.md
@@ -84,7 +84,7 @@ When you first enable multi-tenant deployments you won't have any tenants, and w
 
 Yes. Choose the **Require a tenant for all deployments** option in the project settings. For more information refer to our [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
 
-## Can I require a tenant for all deployments of a project?
+## Can I require a tenant for all deployments of a project? {#always-require-tenant}
 
 Yes, see the previous question. For more information refer to our [tenanted deployments](/docs/tenants/tenant-creation/tenanted-deployments) section.
 

--- a/src/pages/docs/tenants/tenant-infrastructure.md
+++ b/src/pages/docs/tenants/tenant-infrastructure.md
@@ -62,7 +62,7 @@ Dedicated hosting ensures the applications for some tenants are completely isola
 To configure deployment targets as dedicated hosts for one or more tenants:
 
 1. Go to **Infrastructure ➜ Deployment Targets** and find the deployment targets that will be used to host the applications for the tenant. 
-1. Configure each deployment target as a dedicated host for the tenant:
+2. Configure each deployment target as a dedicated host for the tenant:
    ![](/docs/tenants/images/multi-tenant-dedicated-deployment-target.png)
 
 ### Step 2: Deploy {#dedicated-hosting-deploy}
@@ -77,14 +77,14 @@ The final step is to deploy a connected project for this tenant and see the resu
 
 Shared hosting allows you to host the applications of multiple tenants on the same machines to reduce hosting costs by increasing density. To implement shared hosting, you need to create a shared server farm and indicate which tenants will be hosted on that farm. 
 
-This is very similar to the dedicated hosting scenario. Instead of choosing a single-tenant, you use a tenant tag to indicate these servers will be hosting applications for multiple tenants.
+This is very similar to the dedicated hosting scenario. Instead of choosing a single tenant, you use a tenant tag to indicate these servers will be hosting applications for multiple tenants.
 
 ### Step 1: Create a hosting tag set {#shared-hosting-create-tagset}
 
 Firstly let's create a tag set to identify which tenants should be hosted on which shared server farms:
 
 1. Go to **Library ➜ Tenant Tag Sets** and create a new tag set called **Hosting**.
-1. Add a tag called **Shared-Farm-1** and set the color to green to help identify tenants on shared hosting more quickly:
+2. Add a tag called **Shared-Farm-1** and set the color to green to help identify tenants on shared hosting more quickly:
    ![](/docs/tenants/images/multi-tenant-shared-tag.png)
 
 ### Step 2: Configure the shared server farm {#shared-hosting-configure-shared-farm}
@@ -92,7 +92,7 @@ Firstly let's create a tag set to identify which tenants should be hosted on whi
 Now let's configure some shared servers in a farm:
 
 1. Go to **Infrastructure ➜ Deployment Targets** and find the deployment targets that will be used to host the applications for these tenants.
-1. Select the **Shared-Farm-1** tag:
+2. Select the **Shared-Farm-1** tag:
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-infra.png)
@@ -102,9 +102,7 @@ These deployment targets will now be included in deployments for any tenants mat
 
 ### Step 3: Configure the Tenants to deploy onto the shared server farm {#shared-hosting-configure-tenants}
 
-Now let's select some tenants that should be hosted on **Shared-Farm-1**:
-
-1. Create some new tenants (or find existing ones) and tag them with **Shared-Farm-1**:
+Now let's select some tenants that should be hosted on **Shared-Farm-1**. Create some new tenants (or find existing ones) and tag them with **Shared-Farm-1**:
 ![](/docs/tenants/images/multi-tenant-shared-server.png)
 
 ### Step 4: Deploy {#shared-hosting-deploy}

--- a/src/pages/docs/tenants/tenant-infrastructure.md
+++ b/src/pages/docs/tenants/tenant-infrastructure.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-10-04
+modDate: 2023-12-07
 title: Tenant infrastructure
 description: Tenant infrastructure can be modeled in both a dedicated or shared way in Octopus using environments, deployment targets, and tenant tags.
 navOrder: 50

--- a/src/pages/docs/tenants/tenant-infrastructure.md
+++ b/src/pages/docs/tenants/tenant-infrastructure.md
@@ -2,7 +2,7 @@
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
 modDate: 2023-10-04
-title: Tenant Infrastructure
+title: Tenant infrastructure
 description: Tenant infrastructure can be modeled in both a dedicated or shared way in Octopus using environments, deployment targets, and tenant tags.
 navOrder: 50
 ---

--- a/src/pages/docs/tenants/tenant-lifecycles.md
+++ b/src/pages/docs/tenants/tenant-lifecycles.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-12-07
 title: Tenant lifecycles
 description: You can control release promotion using safe tenant-aware lifecycles.
 navOrder: 60

--- a/src/pages/docs/tenants/tenant-lifecycles.md
+++ b/src/pages/docs/tenants/tenant-lifecycles.md
@@ -7,7 +7,7 @@ description: You can control release promotion using safe tenant-aware lifecycle
 navOrder: 60
 ---
 
-You can control which [releases](/docs/releases/) will be deployed to certain Tenants using [Channels](/docs/releases/channels). 
+You can control which [releases](/docs/releases/) will be deployed to certain tenants using [channels](/docs/releases/channels).
 
 :::figure
 ![](/docs/tenants/images/channel-restrict-by-tenant.png)
@@ -15,29 +15,29 @@ You can control which [releases](/docs/releases/) will be deployed to certain Te
 
 This page discusses some scenarios for controlling release promotion for tenants:
 
-- Implementing an Early access program (EAP)
+- Implementing an early access program (EAP)
 - Restricting test releases to the test team
 - Pinning tenants to a release
 
 ## Implementing an early access program {#early-access-program}
 
-Quite often, you want to involve certain customers in testing early releases of major upgrades. By using a combination of [Channels](/docs/releases/channels/) and [Tenant Tags](/docs/tenants/tenant-tags) you can implement an opt-in early access program using tenants, making sure the beta releases are only deployed to the correct tenants and environments.
+Quite often, you want to involve certain customers in testing early releases of major upgrades. By using a combination of [channels](/docs/releases/channels/) and [tenant tags](/docs/tenants/tenant-tags) you can implement an opt-in early access program using tenants, making sure the beta releases are only deployed to the correct tenants and environments.
 
 ### Step 1: Create the lifecycle {#eap-step-1-lifecycle}
 
-Firstly we will create a new [Lifecycle](/docs/releases/lifecycles).
+Firstly we will create a new [lifecycle](/docs/releases/lifecycles).
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-limited-lifecycle.png)
 :::
 
 :::div{.hint}
-Learn more about [defining a limited Lifecycle for your test Channel](/docs/releases/channels).
+Learn more about [defining a limited lifecycle for your test channel](/docs/releases/channels).
 :::
 
 ### Step 2: Configure the tenant tags {#eap-step-2-configure-tenant-tag}
 
-Add a new tag called **2.x Beta** to a new or existing Tenant tag set.
+Add a new tag called **2.x Beta** to a new or existing tenant tag set.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-beta-tenant-tags.png)
@@ -53,7 +53,7 @@ Add the **2.x Beta** tag to one or more tenants who are included in the beta pro
 
 ### Step 4: Configure a channel for the beta program {#eap-step-4-configure-channel}
 
-Create a channel called **2.x Beta** and restrict its use to Tenants tagged with **2.x Beta**
+Create a channel called **2.x Beta** and restrict its use to tenants tagged with **2.x Beta**
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-beta-channel.png)
@@ -77,23 +77,23 @@ Now when you are deploying **2.0.0-beta.1**, you will be able to select tenants 
 
 ## Restricting test releases {#restricting-test-releases}
 
-You may decide to use channels as a safety measure, to restrict test releases to a limited set of test tenants. By using a combination of [Channels](/docs/releases/channels/) and [Tenant Tags](/docs/tenants/tenant-tags) you can make sure test releases are only deployed to the correct tenants and environments.
+You may decide to use channels as a safety measure, to restrict test releases to a limited set of test tenants. By using a combination of [channels](/docs/releases/channels/) and [tenant tags](/docs/tenants/tenant-tags) you can make sure test releases are only deployed to the correct tenants and environments.
 
 ### Step 1: Create the lifecycle {#test-step-1-lifecycle}
 
-Firstly we will create a new [Lifecycle](/docs/releases/lifecycles).
+Firstly we will create a new [lifecycle](/docs/releases/lifecycles).
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-limited-lifecycle.png)
 :::
 
 :::div{.hint}
-Learn more about [defining a limited Lifecycle for your test Channel](/docs/releases/channels).
+Learn more about [defining a limited lifecycle for your test channel](/docs/releases/channels).
 :::
 
 ### Step 2: Configure the tenant tags {#test-step-2-configure-tenant-tag}
 
-Add a new tag called **Tester** to a new or existing Tenant tag set.
+Add a new tag called **Tester** to a new or existing tenant tag set.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-tester-tenant-tags.png)
@@ -109,7 +109,7 @@ Add the **Tester** tag to one or more tenants who are included in the test progr
 
 ### Step 4: Configure a channel for the test program {#test-step-4-configure-channel}
 
-Create a channel called **1.x Test** and restrict its use to Tenants tagged with **Tester**
+Create a channel called **1.x Test** and restrict its use to tenants tagged with **Tester**
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-test-channel.png)
@@ -133,11 +133,11 @@ When you deploy this release, you will be able to choose from the limited set of
 
 ## Pinning tenants to a release {#pinning-tenants}
 
-Quite often, you will want to disable/prevent deployments to a tenant during a period of time where the customer wants guarantees of stability. You can prevent deployments to tenants using a combination of [Channels](/docs/releases/channels/) and [Tenant Tags](/docs/tenants/tenant-tags).
+Often, you will want to disable/prevent deployments to a tenant during a period of time where the customer wants guarantees of stability. You can prevent deployments to tenants using a combination of [channels](/docs/releases/channels/) and [tenant tags](/docs/tenants/tenant-tags).
 
 ### Step 1: Create the upgrade ring/pinned tag {#pinned-step-1-configure-tenant-tag}
 
-Add a new tag called **Pinned** to a new or existing Tenant tag set with a color that stands out.
+Add a new tag called **Pinned** to a new or existing tenant tag set with a color that stands out.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-upgrade-ring-pinned.png)
@@ -148,7 +148,7 @@ Add a new tag called **Pinned** to a new or existing Tenant tag set with a color
 Now we will configure the project channels to make sure we never deploy any releases to pinned tenants. We will do this using a similar method to the [EAP Beta program](#early-access-program), but in this case, we are making sure none of the channels allow deployments to tenants tagged as pinned.
 
 1. Find the channel in your project that represents normal releases - this is called **1.x Normal** in this example.
-1. Restrict deployments of releases in this channel to the following Tenant tags: 
+1. Restrict deployments of releases in this channel to the following tenant tags: 
     - **Early adopter**
     - **Stable**
     - **Tester**

--- a/src/pages/docs/tenants/tenant-roles-and-security.md
+++ b/src/pages/docs/tenants/tenant-roles-and-security.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-12-07
 title: Tenant roles and security
 description: Common approaches to structuring roles and teams to secure a multi-tenant Octopus instance.
 navOrder: 70

--- a/src/pages/docs/tenants/tenant-roles-and-security.md
+++ b/src/pages/docs/tenants/tenant-roles-and-security.md
@@ -17,7 +17,7 @@ To get the most out of this guide you will need to understand how to [manage use
 
 Toby is a member of the sales team for [Vet Clinic](https://samples.octopus.app/app#/Spaces-682/projects/vet-clinic/deployments) and manages the relationships for several of the largest customers. In his role Toby:
 
-- The main point of contact for specific tenants.
+- Is the main point of contact for specific tenants.
 - Manages the details/variables of particular tenants and keeps them up to date.
 - Works with customers to deploy releases to their environments on their behalf.
 
@@ -60,31 +60,31 @@ It is usually a good idea to build smaller roles that can be composed together i
 
 ### Step 2: Configure the account managers team {#step-2-configure-account-managers-team}
 
-Now we will create a team for all the Account Managers and add the role we created in the last step.
+Now we will create a team for all the account managers and add the role we created in the last step.
 
-1. In **Configuration ➜ Teams** click Add team and call it **Toby's clients**. Be sure to select "Accessible in the X space only" unless you have tenants spread over multiple [Spaces](/docs/administration/spaces) and then select **Save**.
+1. In **Configuration ➜ Teams** click **ADD TEAM** and call it **Toby's clients**. Be sure to select "Accessible in the X space only" unless you have tenants spread over multiple [Spaces](/docs/administration/spaces) and then click **Save**.
 
 :::figure
 ![](/docs/tenants/images/add-account-manager-team.png)
 :::
 
-2. Under **User Roles** select **Include User Role** button.
+2. Navigate to **USER ROLES** click **INCLUDE USER ROLE**.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-include-user-role.png)
 :::
 
-3. From the dropdown, select the **Tenant project deployer role**.
+3. From the dropdown, select the **Tenant project deployer** role.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-select-user-role.png)
 :::
 
-4. Under **Members ➜ Add member**  and add any user accounts that will form part of this team.
+4. Navigate to **MEMBERS ➜ ADD MEMBER** and add any user accounts that will form part of this team.
 
 ### Step 3: Reduce the scope of the team {#step-3-reduce-team-scope}
 
-After adding the **Tenant project deployer** role, we'll see that Toby has access to all tenants.  Toby only needs access to the accounts that he's responsible for; Midland Veterinary and Valley Veterinary Clinic.  To limit Toby to his accounts, click on the **ellipses ➜ Edit**
+After adding the **Tenant project deployer** role, we'll see that Toby has access to all tenants. Toby only needs access to the accounts that he's responsible for: Midland Veterinary and Valley Veterinary Clinic. To limit Toby to his accounts, click on the overflow menu (`...`) and select **Edit**
 
 :::figure
 ![](/docs/tenants/images/edit-tenant-team.png)
@@ -115,8 +115,8 @@ Similarly to the previous example, we will create a custom role with minimum per
 
 In this example, we will create a new team and combine multiple roles to achieve the desired result.
 
-1. Create a new team called Tenant Environment Managers.
-2. Add the Tenant viewer and Environment manager roles to the team:
+1. Create a new team called **Tenant Environment Managers**.
+2. Add the **Tenant viewer** and **Environment manager** roles to the team:
    ![](/docs/tenants/images/multi-tenant-environment-managers-team.png)
 3. Add any specific tenant/environment scoping that makes sense.
 4. Add any specific members

--- a/src/pages/docs/tenants/tenant-tags.md
+++ b/src/pages/docs/tenants/tenant-tags.md
@@ -35,7 +35,7 @@ Go to **Library ➜ Tenant Tag Sets** to create, modify and reorder tag sets and
 :::
 
 
-### Design your tag sets carefully {#design-tagsets-carefully}
+### Design your tag sets carefully {#design-tag-sets-carefully}
 
 We suggest taking some time to design your tag sets based on how you will apply them to your projects and environments. Our recommendation is to make sure each of your tag sets are orthogonal, like different axes on a chart. This kind of design is important because of [how tags are combined in tag filters](#tag-based-filters).
 
@@ -47,7 +47,7 @@ Let's look at an example tag set design :
 
 This kind of tag set design will make it easier for each different class of Octopus user to understand which tags apply to their area, and the impact it will have on your tenanted deployments.
 
-### Ordering tag sets and tags {#ordering-tagsets}
+### Ordering tag sets and tags {#ordering-tag-sets}
 
 Order is important for tag sets, and tags within those tag sets. Octopus will sort tag sets and tags based on the order you define in the library. This allows you to tailor the Octopus user interface to your own situation.
 

--- a/src/pages/docs/tenants/tenant-tags.md
+++ b/src/pages/docs/tenants/tenant-tags.md
@@ -7,31 +7,28 @@ description: Tenant Tags help you to classify your tenants with custom tags so y
 navOrder: 40
 ---
 
-In Octopus, tenant tags help you to classify your tenants using custom tags that meet your needs, and tailor tenanted deployments for your projects and environments. Tenant tags also make it easier to work with tenants as groups instead of individuals. Using tags you can apply meaningful metadata to tenants, to describe them using your own terminology, improve search and filtering, and tailor the deployment process to their needs.
+Tenant tags are a form of metadata you can add to tenants to classify them. Tenant tags allow you to:
 
-## What can you do with tenant tags? {#what-can-you-do}
-
-Octopus allows you to group similar tags together into tag sets. This enables you to more easily understand which tags fit together, what effect they should have on tenanted deployments, and design powerful tag-based queries using combinations of tags:
-
-:::figure
-![](/docs/tenants/images/tag-sets.png)
-:::
-
-With tenant tags you can:
-
-- Classify your tenants using custom tags that match your situation.
-- Find tenants more quickly by searching and filtering with tags.
-- Group the project overview by tag set.
+- Find tenants faster using tenant tag filters.
+- Group a project's deployments overview by tag set.
 - Deploy to multiple tenants at the same time - read more [below](#deploying-to-multiple-tenants-tags).
-- Customize the deployment process for tenants.
+- Customize deployment processes for tenants.
 - Scope project variables to tags.
 - Design a multi-tenant hosting model - read more in our [tenant infrastructure](/docs/tenants/tenant-infrastructure) section.
 - Design a multi-tenant deployment process for SaaS applications, regions and more - for further details, see our [guides](/docs/tenants/guides/#guides).
 - Control which releases can be deployed to tenants using [channels](/docs/releases/channels/) - read more in our [tenant lifecycle](/docs/tenants/tenant-lifecycles) section.
 
-## Managing Tenant Tags {#managing-tenant-tags}
+## Tag sets
 
-Go to **Library ➜ Tenant tag sets** to create, modify and reorder tag sets and tags.
+Octopus allows you to group similar tags into tag sets, making it easier to work with tenants as groups instead of individuals. This enables you to understand which tags fit together, what effect they should have on tenanted deployments, and design powerful tag-based queries using combinations of tags.
+
+:::figure
+![](/docs/tenants/images/tag-sets.png)
+:::
+
+## Managing tenant tags {#managing-tenant-tags}
+
+Go to **Library ➜ Tenant Tag Sets** to create, modify and reorder tag sets and tags.
 
 :::figure
 ![](/docs/tenants/images/tenant-importance.png)
@@ -40,13 +37,13 @@ Go to **Library ➜ Tenant tag sets** to create, modify and reorder tag sets and
 
 ### Design your tag sets carefully {#design-tagsets-carefully}
 
-We suggest taking some time to design your tag sets based on how you will apply them to your projects and environments. Our recommendation is to make sure each of your **tag sets are orthogonal**, like different axes on a chart. This kind of design is important because of [how tags are combined in tag filters](#tag-based-filters).
+We suggest taking some time to design your tag sets based on how you will apply them to your projects and environments. Our recommendation is to make sure each of your tag sets are orthogonal, like different axes on a chart. This kind of design is important because of [how tags are combined in tag filters](#tag-based-filters).
 
-Let's look at an Example tag set design :
+Let's look at an example tag set design :
 
 - **Importance (VIP, Standard, Trial):** concerned with classifying tenants so they can be found easily.
 - **Hosting Region (West US, East US 2):** concerned with how the tenant software is hosted - read more about this in our [tenant infrastructure](/docs/tenants/tenant-infrastructure) section.
-- **Release ring (Alpha, Beta, Stable):** concerned with when the tenant's applications are upgraded in relationship to other tenants - read more about this in our [guide](/docs/tenants/guides/multi-tenant-region/deploying-to-release-ring).
+- **Release Ring (Alpha, Beta, Stable):** concerned with when the tenant's applications are upgraded in relationship to other tenants - read more about this in our [guide](/docs/tenants/guides/multi-tenant-region/deploying-to-release-ring).
 
 This kind of tag set design will make it easier for each different class of Octopus user to understand which tags apply to their area, and the impact it will have on your tenanted deployments.
 
@@ -66,6 +63,7 @@ Once you have defined some tag sets and tags you can start leveraging those tags
 
 :::div{.hint}
 **Combinational logic**
+
 When filtering tenants, Octopus will combine tags within the same tag set using the **`OR`** operator, and combine tag sets using the **`AND`** operator.
 :::
 
@@ -85,14 +83,15 @@ When paired with a well-structured tag design, this logic will enable you to tai
 
 :::div{.hint}
 **Tips for working with tenant filters**
+
 - Only specify a tenant "by name" (explicitly) if you absolutely want that tenant included in the result, otherwise leave it blank
 - A filter with tags in the same tag set will be more inclusive since they are combined using **`OR`**
 - A filter with tags across different tag sets will become more reductive since they are combined using **`AND`**
-  :::
+:::
 
 ## Referencing tenant tags {#referencing-tenant-tags}
 
-If you want to use tenant tags to automate Octopus Deploy you should use the **Canonical Name** for the Tag which looks like this: `Tag Set Name/Tag Name`
+If you want to use tenant tags to automate Octopus Deploy you should use the **canonical name** for the tag which looks like this: `Tag Set Name/Tag Name`
 
 Consider an example deploying a release to the tenants tagged with the **Alpha** tag in the **Release Ring** tag set.
 
@@ -113,14 +112,14 @@ Some places you can use tags are:
 
 ## Deploying to multiple tenants using tags {#deploying-to-multiple-tenants-tags}
 
-You can create tenant tag sets specifically to help with deployments and rolling out upgrades. Quite often, you want to deploy targeted releases to your testers, and once testing is finished, you want to flight/prove that upgrade with a smaller group of tenants before rolling it out to the rest of your tenants. This is also useful when breaking down large amounts of tenants into smaller deployments. Here we outline the steps needed to design that kind of process using tenant tags.
+You can create tenant tag sets specifically to help with deployments and rolling out upgrades. Often, you want to deploy targeted releases to your testers, and once they've finished testing, prove that upgrade with a smaller group of tenants before rolling it out to the rest of your tenants. This is also useful to split up a large number of tenants into smaller groups for deployment. We've outlined the steps to design this process using tenant tags:
 
-### Step 1: Create a tag set called Upgrade ring {#deploy-step-1-create-tagset}
+### Step 1: Create a tag set called Upgrade Ring {#deploy-step-1-create-tagset}
 
-Firstly we create a tag set called **Upgrade ring** with tags allowing each tenant to choose how early in the development/test cycle they want to receive upgrades.
+First, we create a tag set called **Upgrade Ring** with tags that allow each tenant to choose how early in the development/test cycle they want to receive upgrades.
 
-1. Create a new tenant tag set called **Upgrade ring** and add tags for **Tester**, **Early adopter**, and **Stable**.
-1. Make sure to choose colors that highlight different tenants.
+1. Create a new tenant tag set called **Upgrade Ring** and add tags for **Tester**, **Early Adopter**, and **Stable**.
+2. Make sure to choose colors that highlight different tenants.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-upgrade-ring.png)
@@ -128,15 +127,11 @@ Firstly we create a tag set called **Upgrade ring** with tags allowing each tena
 
 ### Step 2: Configure a test tenant {#deploy-step-2-configure-test-tenant}
 
-Either create a new tenant, or configure an existing tenant. This tenant will receive upgrades before any of the other configured tenants.
-
-1. Tag your test tenant(s) with **Tester**.
+Either create a new tenant or configure an existing tenant. Tag your test tenant(s) with **Tester** - this tenant will receive upgrades before any other configured tenants.
 
 ### Step 3: Configure some early adopter tenants and stable tenants {#deploy-step-3-configure-other-tenants}
 
-*Optionally*, configure some external tenants as opting into early or stable releases to see the effect.
-
-1. Find or create some tenants and tag them as either **Stable** or **Early adopter**.
+*Optionally*, configure some external tenants as opting into early or stable releases to see the effect. Find or create some tenants and tag them as either **Stable** or **Early Adopter**.
 
 ### Step 4: Deploy {#deploy-step-4-deployment}
 
@@ -146,7 +141,7 @@ Now it's time to deploy using tenant tags as a way to select multiple tenants ea
 ![](/docs/tenants/images/multi-tenant-deploy-test.png)
 :::
 
-You can also use the Project Overview to deploy to groups of tenants by grouping the dashboard, selecting a release, and clicking the **Deploy to all** button.
+You can also use the project overview to deploy to groups of tenants by grouping the dashboard, selecting a release, and clicking the **DEPLOY ALL...** button.
 
 :::figure
 ![](/docs/tenants/images/multi-tenant-deploy-all.png)
@@ -154,4 +149,4 @@ You can also use the Project Overview to deploy to groups of tenants by grouping
 
 ## Learn more {#learn-more}
 
-- [Deployment patterns blog posts](https://octopus.com/blog/tag/Deployment%20Patterns).
+- [Deployment patterns blog posts](https://octopus.com/blog/tag/Deployment%20Patterns)

--- a/src/pages/docs/tenants/tenant-tags.md
+++ b/src/pages/docs/tenants/tenant-tags.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-12-07
 title: Tenant tags
 description: Tenant Tags help you to classify your tenants with custom tags so you can tailor your tenanted deployments accordingly.
 navOrder: 40

--- a/src/pages/docs/tenants/tenant-types.md
+++ b/src/pages/docs/tenants/tenant-types.md
@@ -11,14 +11,14 @@ Tenants in Octopus can represent multiple use cases:
 
 - Software as a Service (SaaS)
 - Geographical regions or datacenters
-- Developers, testers, or Teams
+- Developers, testers, or teams
 - Feature branches
 
 This section covers some of the common tenancy types you can model with Octopus.
 
 ## Software as a Service (SaaS) {#saas}
 
-Software as a Service (SaaS) is perhaps the most common implementation of multi-tenancy with Octopus Deploy.  The SaaS model is where the same software is deployed to multiple customers (tenants).  The deployment process can include items such as custom branding per tenant or scoping specific steps to tenant tags so that modules can be deployed to tenants that have purchased them.
+Software as a Service (SaaS) is perhaps the most common implementation of multi-tenancy with Octopus Deploy. The SaaS model is where the same software is deployed to multiple customers (tenants). The deployment process can include items such as custom branding per tenant or scoping specific steps to tenant tags so that modules can be deployed to tenants that have purchased them.
 
 :::figure
 ![](/docs/tenants/images/saas-tenants.png)
@@ -32,21 +32,21 @@ Tenants using the SaaS model typically fall into three distinct categories:
 
 ### Code-based multi-tenancy {#saas-code-based}
 
-Code-based tenancy is where all tenants share the same infrastructure and it's up to the code to determine what a tenant sees and has access to.  Code based multi-tenancy can be the easiest option to deploy and maintain, but there are tradeoffs. There is a risk for cross tenant contamination. A missed "where" clause makes for a terrible day. You also cannot deploy different versions of the application to different tenants.
+Code-based tenancy is where all tenants share the same infrastructure and it's up to the code to determine what a tenant sees and has access to. Code based multi-tenancy can be the easiest option to deploy and maintain, but there are tradeoffs. There is a risk for cross tenant contamination. A missed "where" clause makes for a terrible day. You also cannot deploy different versions of the application to different tenants.
 
 ### Database multi-tenancy {#saas-database}
 
-Database based tenancy is similar to Code based, however, each tenant has their own database.  Deploying the application is easy, but deploying the database changes can be harder than the first approach. Database changes need to be deployed to all databases prior an application update. Having a large number of databases will create a bottleneck in the deployment.
+Database based tenancy is similar to Code based, however, each tenant has their own database. Deploying the application is easy, but deploying the database changes can be harder than the first approach. Database changes need to be deployed to all databases prior an application update. Having a large number of databases will create a bottleneck in the deployment.
 
 ### Isolated multi-tenancy {#saas-isolated}
 
-Isolated is where each tenant has their own, dedicated infrastructure.  This removes the risk of cross tenant data contamination, but it complicates deployments. The deployment process itself may not change, but the application now has to be deployed per tenant. Each deployment has to configure the application instance for that tenant. The complication to the deployment process offers flexibility and scalability to the application and its deployments. Tenants can now be upgraded independently and be hosted on hardware that fits their needs.
+Isolated is where each tenant has their own, dedicated infrastructure. This removes the risk of cross tenant data contamination, but it complicates deployments. The deployment process itself may not change, but the application now has to be deployed per tenant. Each deployment has to configure the application instance for that tenant. The complication to the deployment process offers flexibility and scalability to the application and its deployments. Tenants can now be upgraded independently and be hosted on hardware that fits their needs.
 
 Learn more about how to to configure multi-tenancy for a SaaS application in Octopus with our [multi-tenant SaaS guide](/docs/tenants/guides/multi-tenant-saas-application).
 
 ## Geographical regions or datacenters {#regions}
 
-Another pattern for multi-tenancy is to treat geographic regions of the same organization as tenants.  Using this model, something like an e-commerce application can test out new or beta features in a specific region before releasing them out to the rest of the organization.  Scheduling deployments during a maintenance window is another way this pattern can be used as each region may have different hours when they are least busy.
+Another pattern for multi-tenancy is to treat geographic regions of the same organization as tenants. Using this model, something like an e-commerce application can test out new or beta features in a specific region before releasing them out to the rest of the organization. Scheduling deployments during a maintenance window is another way this pattern can be used as each region may have different hours when they are least busy.
 
 :::figure
 ![](/docs/tenants/images/region-tenants.png)
@@ -56,7 +56,7 @@ Learn more about how to to configure multi-tenancy for regions in Octopus with o
 
 ## Teams {#teams}
 
-Concurrent application development is another multi-tenant use-case.  Using tenants for teams allows an Octopus Administrator to re-use the same deployment process as well as Environments giving each team the autonomy to deploy.  Deployment targets can be assigned tenant tags or even be dedicated to specific tenants so that each team can deploy without affecting the other.
+Concurrent application development is another multi-tenant use-case. Using tenants for teams allows an Octopus administrator to re-use the same deployment process as well as environments giving each team the autonomy to deploy. You can assign tenant tags or dedicate specific tenants to deployment targets so each team can deploy without affecting the other.
 
 :::figure
 ![](/docs/tenants/images/team-tenants.png)

--- a/src/pages/docs/tenants/tenant-types.md
+++ b/src/pages/docs/tenants/tenant-types.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-12-07
 title: Tenant types
 description: There are several different types of tenants that can be supported with Octopus Deploy.
 navOrder: 10

--- a/src/pages/docs/tenants/tenant-types.md
+++ b/src/pages/docs/tenants/tenant-types.md
@@ -10,7 +10,7 @@ navOrder: 10
 Tenants in Octopus can represent multiple use cases:
 
 - Software as a Service (SaaS)
-- Geographical regions or datacenters
+- Geographical regions or data centers
 - Developers, testers, or teams
 - Feature branches
 
@@ -44,7 +44,7 @@ Isolated is where each tenant has their own, dedicated infrastructure. This remo
 
 Learn more about how to to configure multi-tenancy for a SaaS application in Octopus with our [multi-tenant SaaS guide](/docs/tenants/guides/multi-tenant-saas-application).
 
-## Geographical regions or datacenters {#regions}
+## Geographical regions or data centers {#regions}
 
 Another pattern for multi-tenancy is to treat geographic regions of the same organization as tenants. Using this model, something like an e-commerce application can test out new or beta features in a specific region before releasing them out to the rest of the organization. Scheduling deployments during a maintenance window is another way this pattern can be used as each region may have different hours when they are least busy.
 

--- a/src/pages/docs/tenants/tenant-variables.mdx
+++ b/src/pages/docs/tenants/tenant-variables.mdx
@@ -30,7 +30,7 @@ Both of these methods use the [variable templates](/docs/projects/variables/vari
 
 ## Project variables \{#project-variables}
 
-Project variables allow you to specify a variable which a tenant can change. A perfect example would be a connection string or a database server. With project variables you define them at the project level using [project templates](/docs/projects/variables/variable-templates/#project-templates).
+Project variables allow you to specify a variable that a tenant can change. A perfect example would be a connection string or a database server. You define project variables using [project templates](/docs/projects/variables/variable-templates/#project-templates).
 
 :::figure
 ![](/docs/tenants/images/project-template-screen.png "width=500")
@@ -42,7 +42,7 @@ You can specify the variable type for the project template, just like regular va
 ![](/docs/tenants/images/project-template-edit.png "width=500")
 :::
 
-On the tenant variable screen, you can set those variables.
+On the tenant variable screen, you can set values for these variables.
 
 :::figure
 ![](/docs/tenants/images/project-template-tenant-value.png "width=500")
@@ -57,7 +57,7 @@ The great thing about project template variables is that they are treated like a
 
 ## Common variables \{#common-variables}
 
-Common variables are similar to project variables. The main difference between the two is that common variables can be used across multiple projects, and they aren't scoped to environments. Common variables are defined using [Library variable set templates](/docs/projects/variables/variable-templates/#adding-a-variable-template)
+Common variables are similar to project variables. The main difference between the two is that common variables can be used across multiple projects, and they aren't scoped to environments. Common variables are defined using [library variable set templates](/docs/projects/variables/variable-templates/#adding-a-variable-template)
 
 For example, if we wanted to define an abbreviation for the tenant to use in a deployment or runbook, we can configure a variable template for the library set.
 
@@ -72,17 +72,17 @@ To include common variables for a tenant, you must add the library variable set 
 Just like project variables, common variable values are supplied at the tenant level.
 
 ![](/docs/tenants/images/common-variable-tenant-value.png "width=500")
-  
+
 ### Common variable permissions
 
 When editing common variables for a tenant, a user requires variable editing permission (`VariableEdit`) for the tenant as well as **all projects** linked to the tenant. 
 
-This can be achieved by scoping a User Role to:
+This can be achieved by scoping a user role to:
 - All projects individually 
-- The correct Project Groups 
-- A combination of individual projects and Project Groups
+- The correct project groups 
+- A combination of individual projects and project groups
 
-If you don't have the necessary permissions, you might receive an error like this:
+If you don't have the necessary permissions, you will receive an error like this:
 
 :::figure
 ![](/docs/tenants/images/common-variable-permissions-error.png "width=500")

--- a/src/pages/docs/tenants/tenant-variables.mdx
+++ b/src/pages/docs/tenants/tenant-variables.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2023-12-07
 title: Tenant variables
 description: Tenant variables in Octopus allow you to specify which variables are required to deploy a project to a tenant successfully; Project variables are values that differ between projects and environments. Common variables are common across multiple tenants that require a unique value per tenant.
 navOrder: 30


### PR DESCRIPTION
The following pages are being updated in this PR:

- https://octopus.com/docs/tenants/tenant-creation
- https://octopus.com/docs/tenants/tenant-creation/connecting-projects
- https://octopus.com/docs/tenants/tenant-creation/tenanted-deployments
- https://octopus.com/docs/tenants/tenant-deployment-faq
- https://octopus.com/docs/tenants/tenant-infrastructure
- https://octopus.com/docs/tenants/tenant-lifecycles
- https://octopus.com/docs/tenants/tenant-roles-and-security
- https://octopus.com/docs/tenants/tenant-tags **This one has the largest content changes**
- https://octopus.com/docs/tenants/tenant-types
- https://octopus.com/docs/tenants/tenant-variables

The main goal is to align the pages with the suggested Octopus writing style, so this means:

- Removing unnecessary capitalizations
- Reducing sentence length
- Grammar improvements

Most pages have fairly small changes. Tags is a page I decided to spend more time on since it was particularly confusing.