### PR TITLE
Add "Bento" as in "Project Bento" to the dictionary.

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -1,6 +1,7 @@
 apikey
 astro
 augeas
+Bento
 bootstrap
 bootstrapped
 bootstrapper


### PR DESCRIPTION
Allows the use of "Bento" as in "Project Bento" for project export/import.