### PR TITLE
edited format of PATH line

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -104,3 +104,5 @@ workertools
 xlarge
 xmark
 xvzf
+pycryptodome
+mozroots

--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
@@ -17,7 +17,9 @@ When connecting to a target over SSH, the Octopus Server connects then executes 
 
 For example, with targets on a Mac the default $PATH variable may be missing `/usr/sbin`. This can be added in the `.bashrc` script with the line:
 
-> PATH=$PATH:/usr/sbin
+```
+PATH=$PATH:/usr/sbin
+```
 
 If the `.bashrc` file doesn't already exist, create it in the user folder of the user that is connecting to the Max OSX instance. If the remote user is called `octopus`, then this file will be located at `/Users/octopus/.bashrc`.
 


### PR DESCRIPTION
Use of `>` adjusted to be code block instead 

<img width="581" alt="Screenshot 2023-12-15 at 11 20 12 am" src="https://github.com/OctopusDeploy/docs/assets/78527975/46114cb7-3e4a-4963-8d5f-3df1215ab4ce">
