### PR TITLE
Add warning message about known Helm upgrade limitations

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -12,6 +12,7 @@ bootstrapper
 childelement
 cicd
 cloudapi
+Cloudsmith
 Cmdn
 combinational
 comms
@@ -96,6 +97,7 @@ octoterra
 OIDC
 onlylogs
 passout
+petclinic
 PKCE
 pkcs
 podannotation
@@ -115,6 +117,7 @@ RSASSA
 Runbook
 runbook
 runbooks
+runtimes
 Schannel
 servedby
 setspn

--- a/src/pages/docs/deployments/kubernetes/helm-update/index.md
+++ b/src/pages/docs/deployments/kubernetes/helm-update/index.md
@@ -18,7 +18,7 @@ A Helm Feed in Octopus refers to a [Helm Chart repository](https://helm.sh/docs/
 
 :::div{.info}
 
-The built-in repository is [capable of storing Helm Charts](/docs/packaging-applications/#supported-formats). However, the mechanism for determining the **PackageID** and **Version** may differ depending on the contents of the `.tgz` file.  If the `.tgz` file contains a `chart.yaml` file, the PackageID is determined by the `name`, and the version is determined by the `version` sections of the YAML.  
+The built-in repository is [capable of storing Helm Charts](/docs/packaging-applications/#supported-formats). However, the mechanism for determining the **PackageID** and **Version** may differ depending on the contents of the `.tgz` file.  If the `.tgz` file contains a `chart.yaml` file, the PackageID is determined by the `name`, and the version is determined by the `version` sections of the YAML.
 
 ```yaml
 apiVersion: v2
@@ -113,6 +113,10 @@ Although the helm client tool can be overridden for use during the step executio
 :::div{.warning}
 Helm deployments using Tar.gz packages can fail if the path is 100+ characters, to get around this problem use ZIP packages or shorter paths/filenames instead.
 See [https://github.com/OctopusDeploy/Issues/issues/8132](https://github.com/OctopusDeploy/Issues/issues/8132) for more info.  
+:::
+
+:::div{.warning}
+Due to how deployment cancellation currently works, the Helm `--atomic` argument does not result in automatic rollbacks when a deployment is cancelled. Furthermore, if the Octopus deployment timeout is set lower than the Helm timeout, a similar issue may arise. To ensure a smooth deployment experience, we recommend setting a larger Octopus timeout than the Helm timeout.
 :::
 
 ## Learn more

--- a/src/pages/docs/deployments/kubernetes/helm-update/index.md
+++ b/src/pages/docs/deployments/kubernetes/helm-update/index.md
@@ -116,7 +116,10 @@ See [https://github.com/OctopusDeploy/Issues/issues/8132](https://github.com/Oct
 :::
 
 :::div{.warning}
-Due to how deployment cancellation currently works, the Helm `--atomic` argument does not result in automatic rollbacks when a deployment is cancelled. Furthermore, if the Octopus deployment timeout is set lower than the Helm timeout, a similar issue may arise. To ensure a smooth deployment experience, we recommend setting a larger Octopus timeout than the Helm timeout.
+Due to how deployment cancellation currently works, the Helm `--atomic` argument does not result in automatic rollbacks when a deployment is cancelled. 
+This means that any Helm chart changes that were being deployed may become stuck or only partially deployed, and require manual clean-up.
+Furthermore, if the Octopus deployment timeout is set lower than the Helm timeout, a similar issue may arise if the Helm chart deployment is interrupted midway. 
+To ensure a smooth deployment experience, we recommend setting a larger Octopus timeout than the Helm timeout.
 :::
 
 ## Learn more


### PR DESCRIPTION
[sc-66477]

This PR adds a warning message about a known limitation with the Helm `--atomic` flag and its interaction with Octopus's step cancellation mechanism. Octopus sends a SIGKILL to terminate processes when they are cancelled, and this results in the Helm process not being able to perform an automatic rollback. This can happen when either:

1. The user clicks on the cancel button during the deployment
2. The deployment times out (before the Helm `--timeout` limit is reached)