### PR TITLE
Updating Linux Tentacle install commands to remove deprecated command

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -61,9 +61,22 @@ Many of the steps described below require elevated permissions, or must be run a
 <summary>Debian/Ubuntu repository</summary>
 
 ```bash
-apt-key adv --fetch-keys https://apt.octopus.com/public.key
+apt update && apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+  install -m 0755 -d /etc/apt/keyrings
 
-add-apt-repository "deb https://apt.octopus.com/ stretch main"
+curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg
+
+chmod a+r /etc/apt/keyrings/octopus.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
+  stable main" | \
+  tee /etc/apt/sources.list.d/octopus.list > /dev/null
+
+# for legacy Ubuntu (< 18.04) use
+# apt-key adv --fetch-keys https://apt.octopus.com/public.key
+# add-apt-repository "deb https://apt.octopus.com/ stretch main"
+
 # for Raspbian use
 # sh -c "echo 'deb https://apt.octopus.com/ buster main' >> /etc/apt/sources.list"
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -75,7 +75,7 @@ echo \
 
 # for legacy Ubuntu (< 18.04) use
 # apt-key adv --fetch-keys https://apt.octopus.com/public.key
-# add-apt-repository "deb https://apt.octopus.com/ stretch main"
+# add-apt-repository "deb https://apt.octopus.com/ stable main"
 
 # for Raspbian use
 # sh -c "echo 'deb https://apt.octopus.com/ buster main' >> /etc/apt/sources.list"

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -61,7 +61,7 @@ Many of the steps described below require elevated permissions, or must be run a
 <summary>Debian/Ubuntu repository</summary>
 
 ```bash
-apt update && apt install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+apt-get update && apt-get install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
   install -m 0755 -d /etc/apt/keyrings
 
 curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg

--- a/src/pages/docs/runbooks/runbook-examples/terraform/provision-aws-with-terraform.md
+++ b/src/pages/docs/runbooks/runbook-examples/terraform/provision-aws-with-terraform.md
@@ -278,8 +278,22 @@ workerPool="#{Project.Octopus.Server.WorkerPool}"
 machinePolicy="#{Project.Octopus.Server.MachinePolicy}"
 space="#{Project.Octopus.Server.Space}"
 
-sudo apt-key adv --fetch-keys "https://apt.octopus.com/public.key"
-sudo add-apt-repository "deb https://apt.octopus.com/ stretch main"
+apt-get update && apt-get install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+  install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg
+
+chmod a+r /etc/apt/keyrings/octopus.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
+  stable main" | \
+  tee /etc/apt/sources.list.d/octopus.list > /dev/null
+
+# for legacy Ubuntu (< 18.04) use
+# apt-key adv --fetch-keys https://apt.octopus.com/public.key
+# add-apt-repository "deb https://apt.octopus.com/ stable main"
+
 sudo apt-get update
 sudo apt-get install tentacle
 

--- a/src/shared-content/infrastructure/quickstart-debian.include.md
+++ b/src/shared-content/infrastructure/quickstart-debian.include.md
@@ -14,8 +14,22 @@ role="web server"   # The role to assign to the Tentacle
 configFilePath="/etc/octopus/default/tentacle-default.config"
 applicationPath="/home/Octopus/Applications/"
 
-apt-key adv --fetch-keys https://apt.octopus.com/public.key
-add-apt-repository "deb https://apt.octopus.com/ stretch main"
+apt-get update && apt-get install --no-install-recommends gnupg curl ca-certificates apt-transport-https && \
+  install -m 0755 -d /etc/apt/keyrings
+
+curl -fsSL https://apt.octopus.com/public.key | sudo gpg --dearmor -o /etc/apt/keyrings/octopus.gpg
+
+chmod a+r /etc/apt/keyrings/octopus.gpg
+
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/octopus.gpg] https://apt.octopus.com/ \
+  stable main" | \
+  tee /etc/apt/sources.list.d/octopus.list > /dev/null
+
+# for legacy Ubuntu (< 18.04) use
+# apt-key adv --fetch-keys https://apt.octopus.com/public.key
+# add-apt-repository "deb https://apt.octopus.com/ stretch main"
+
 apt-get update
 apt-get install tentacle
 

--- a/src/shared-content/infrastructure/quickstart-debian.include.md
+++ b/src/shared-content/infrastructure/quickstart-debian.include.md
@@ -28,7 +28,7 @@ echo \
 
 # for legacy Ubuntu (< 18.04) use
 # apt-key adv --fetch-keys https://apt.octopus.com/public.key
-# add-apt-repository "deb https://apt.octopus.com/ stretch main"
+# add-apt-repository "deb https://apt.octopus.com/ stable main"
 
 apt-get update
 apt-get install tentacle


### PR DESCRIPTION
Updating install commands to not use apt-key command as this is deprecated (instead using the gpg command).