### PR TITLE
Removed some console logs

### DIFF
--- a/public/docs/js/modules/headers.js
+++ b/public/docs/js/modules/headers.js
@@ -11,7 +11,7 @@ function enhanceHeaders() {
         linkContainer.href = `#${elem.id}`;
         linkContainer.className = 'bookmark-link';
         linkContainer.innerHTML = 'Bookmark'
-        console.log(elem, typeof elem);
+        
         elem.appendChild(linkContainer);
     });
 

--- a/public/docs/js/modules/nav-sticky.js
+++ b/public/docs/js/modules/nav-sticky.js
@@ -34,12 +34,12 @@ function addStickyNavigation(headerSelector, navigationSelector, navigationListS
         // && where the browser is more than 860px wide
         if (dimensions.navigationHeight < ((dimensions.browserHeight - Math.max(dimensions.headerHeight, site_features.stickyNav.top)) - buffer)
             && dimensions.browserWidth > 860) {
-            console.log('Navigation: Sticky Mode');
+            // Navigation: Sticky Mode
             navigation.classList.add(className);
             const top = site_features.stickyNav.top ?? 220;
             navigation.style.top = top + 'px';
         } else {
-            console.log('Navigation: Fixed Mode');
+            // Navigation: Fixed Mode
             navigation.classList.remove(className);
         }
     }

--- a/public/docs/js/modules/toc.js
+++ b/public/docs/js/modules/toc.js
@@ -71,7 +71,6 @@ function recheck() {
     const item = validItems.pop();
 
     if (item && item.id !== current) {
-        console.log('Reading', item.id);
         current = item.id;
         highlight(item.id);
     }

--- a/public/docs/js/search.js
+++ b/public/docs/js/search.js
@@ -293,7 +293,6 @@ async function replaceSynonyms(queryTerms) {
  */
 async function search(s, r) {
     const numberOfResults = r ?? 12;
-    console.log('search:' + s, numberOfResults);
 
     /** @type {SearchEntry[]} */
     const needles =  [];
@@ -318,8 +317,6 @@ async function search(s, r) {
     }
 
     const allTerms = queryTerms.concat(stemmedTerms);
-
-    console.log(allTerms);
 
     cleanQuery.length > 0 && haystack.forEach( (item) => {
 
@@ -512,7 +509,7 @@ async function search(s, r) {
     more.addEventListener('click', function() {
         currentQuery = '';
         const newTotal = numberOfResults + 12;
-        console.log('More', newTotal);
+
         search(s, newTotal);
     })
 
@@ -594,8 +591,6 @@ fetch(dataUrl)
             return false;
         });
 
-        console.log('Search ready');
-
         const params = new URLSearchParams(window.location.search);
         if (params.has('q')) {
             siteSearchQuery.value = params.get('q') ?? '';
@@ -606,8 +601,6 @@ fetch(dataUrl)
                 scoring[key] = parseInt(params.get(`s_${key}`) ?? scoring[key].toString(), 10)  ;
             }
         }
-
-        console.log(scoring);
 
         debounceSearch();
     })

--- a/src/themes/accelerator/components/RecentlyUpdated.astro
+++ b/src/themes/accelerator/components/RecentlyUpdated.astro
@@ -22,8 +22,6 @@ const pages = allPages
   .sort(PostOrdering.sortByModDateDesc)
   .slice(0, Math.min(count, pageCount));
 
-console.log('Recent Pages: ' + pageCount);
-
 stats.stop();
 ---
 <ul class="recent-updates">

--- a/src/themes/accelerator/utilities/img.mjs
+++ b/src/themes/accelerator/utilities/img.mjs
@@ -13,8 +13,6 @@ const imagePath = path.join('public', imagePaths.src);
 const outputPath = path.join('public', imagePaths.dest);
 const imageDirectory = path.join(workingDirectory, imagePath);
 
-console.log(imageDirectory);
-
 const filesToProcess = [];
 
 function getDestinationFilePathless(source, s) {
@@ -25,7 +23,7 @@ function getDestinationFilePathless(source, s) {
 
 async function createDestinationFolder(destinationFile) {
     const file = path.parse(destinationFile + '.txt');
-    console.log(file.dir);
+    
     await fs.promises.mkdir(file.dir, { recursive: true });
 }
 
@@ -80,7 +78,6 @@ await recurseFiles('');
 console.log(`Found ${filesToProcess.length} files to process`);
 
 for (const file of filesToProcess) {
-    console.log(file.path);
     const source = path.join(imageDirectory, file.path);
     const destination = getDestinationFilePathless(file.path, 'x');
     await createDestinationFolder(destination);
@@ -138,5 +135,3 @@ for (const file of filesToProcess) {
         }
     }
 }
-
-console.log(`Finished`);


### PR DESCRIPTION
@steve-fenton-octopus  correct me if I'm wrong but I don't think we need these console logs. I figured maybe it's better to get rid of those from production.

Before:
<img width="1706" alt="Screenshot 2024-01-17 at 15 13 56" src="https://github.com/OctopusDeploy/docs/assets/148771144/2a5bce23-3b6b-4d7b-bda2-9f5328de6d6e">

After:
<img width="1717" alt="Screenshot 2024-01-17 at 15 14 19" src="https://github.com/OctopusDeploy/docs/assets/148771144/735cb4a1-c4b0-4637-8ced-075ffac5c784">
