### PR TITLE
Code block update for light/dark modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Before merging to `main` it's possible you'd like to see your changes in a previ
 
 You can generate a static copy of the site using `pnpm build` and run it in a browser with `pnpm preview`.
 
+Note! We use _Sharp_ to generate images. You may need to install a specific flavour of _Sharp_ depending on your operating system. If you see an error, such as "Error: Could not load the "sharp" module using the linux-x64 runtime", you can follow the instruction on the [Sharp cross-platform page](https://sharp.pixelplumbing.com/install#cross-platform). You can also refer to [issue 2142](https://github.com/OctopusDeploy/docs/issues/2142).
+
 ## Astro hints and tips
 
 ### Editor setup

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
     ],
     markdown: {
         shikiConfig: {
-            theme: 'nord'
+            theme: 'light-plus'
         },
         remarkPlugins: [
             remarkDirective,

--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -5,6 +5,7 @@ appsettings
 ASPNET
 aspnetcore
 astro
+astrojs
 augeas
 Bento
 bootstrap
@@ -132,6 +133,7 @@ runtimes
 Schannel
 servedby
 setspn
+shiki
 SIEM
 signingkeys
 sthumb

--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -97,11 +97,24 @@ code {
 pre {
     padding: 0.5rem 1rem;
     white-space: break-spaces;
+    background-color: var(--blue-100) !important;
+    border-radius: var(--standard-radius);
 }
 
 pre code {
     background-color: unset;
     font-size: var(--font-size-small);
+}
+
+.dark pre {
+    background-color: var(--white) !important;
+    filter: invert(98%) hue-rotate(180deg);
+}
+
+@media (prefers-color-scheme: dark) {
+    pre {
+        filter: invert(98%) hue-rotate(180deg);
+    }
 }
 
 em {
@@ -251,7 +264,7 @@ strong {
 }
 
 .bookmark-link {
-    border-radius: var(--block-radius);
+    border-radius: var(--standard-radius);
     color: var(--fore-link);
     display: inline-block;
     font-size: 1.2rem;
@@ -904,7 +917,7 @@ nav.skip-links a:focus {
 .search-dialog {
     margin: auto;
     padding: 2rem 3rem;
-    border-radius: var(--block-radius);
+    border-radius: var(--standard-radius);
     box-shadow: var(--box-shadow);
     height: calc(90vh - 4em);
     width: calc(80vw - 6em);
@@ -1016,7 +1029,7 @@ nav.skip-links a:focus {
     background-image: url(https://img.youtube.com/vi/VOWnhMxJMMk/0.jpg);
     background-position: center;
     background-size: cover;
-    border-radius: var(--block-radius);
+    border-radius: var(--standard-radius);
     box-shadow: var(--octo-shadow-standard-box);
     color: var(--fore-link);
     font-size: 5em;


### PR DESCRIPTION

## Before

![Code blocks were always dark mode](https://github.com/OctopusDeploy/docs/assets/99181436/b2398001-9c7a-42fc-9156-0bfcb59a5b76)

## After

### Light mode (default)

![Light mode is lighter and on brand](https://github.com/OctopusDeploy/docs/assets/99181436/efb327e5-e91b-4b6d-9183-6b5bb68e4d8b)

### Dark mode

Not yet actively used, but in the pipeline. Hence the page itself is still in light mode.

![Dark mode is available](https://github.com/OctopusDeploy/docs/assets/99181436/25febdb5-7a53-4ee4-b0be-588d8fccfbd8)


