### PR TITLE
Makes skip links visible on focus

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -376,7 +376,7 @@ table th {
 /* Skip Links */
 nav.skip-links {
   position: fixed;
-  z-index: 2;
+  z-index: 12;
 }
 
 nav.skip-links a {
@@ -390,7 +390,6 @@ nav.skip-links a {
   z-index: 15;
   text-align: center;
   display: inline-block;
-  height: 1px;
   margin: -1px;
   width: 1px;
 }


### PR DESCRIPTION
When you use a keyboard, the skiplinks should be visible on focus.

1. Navigate to the page
2. Hit tab
3. The skip to... should appear

![Skip links](https://github.com/OctopusDeploy/docs/assets/99181436/cc928c69-6345-46aa-9ec9-5afef7a58c80)
