### PR TITLE
Update RHEL supported version

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/linux/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/index.md
@@ -38,7 +38,7 @@ The following platforms are explicitly supported (we run automated tests against
 
 - Ubuntu 18.04 LTS
 - Ubuntu 16.04 LTS
-- Redhat (RHEL) 7.2
+- Redhat (RHEL) 7.9
 - Centos 7.7
 - Amazon Linux 2
 - Debian 9.12


### PR DESCRIPTION
As noted in [internal slack thread](https://octopusdeploy.slack.com/archives/C033W4273/p1708385768287979) we have