### PR TITLE
Image typo fix

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -180,7 +180,7 @@ img {
 /* Image component */
 .image {
   border-radius: 0.9375rem;
-  border: 0.0625 solid var(--navy-200);
+  border: 0.0625rem solid var(--navy-200);
   background: #F4F6F8;
   display: flex;
   flex-direction: column;
@@ -214,7 +214,7 @@ img {
 /* TODO: Once all images are used with Image component these styles should be removed */
 figure > p > img {
   border-radius: 0.9375rem;
-  border: 0.0625 solid var(--navy-200);
+  border: 0.0625rem solid var(--navy-200);
   background: #F4F6F8;
   padding: 2rem;
   width: calc(100% - 4rem);


### PR DESCRIPTION
Border was without unit `rem` I missed that somehow so that's a quick fix to that.