### PR TITLE
Adding 'Deprecated' tag to title of Octo CLI

### DIFF
--- a/src/pages/docs/octopus-rest-api/octopus-cli/index.mdx
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/index.mdx
@@ -2,7 +2,7 @@
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
 modDate: 2023-02-23
-title: Octo Command Line (CLI)
+title: Octo Command Line (CLI) (Deprecated)
 description: The Octo CLI is the Octopus command line tool that builds on top of the Octopus REST API.
 navOrder: 100
 hideInThisSection: true

--- a/src/pages/docs/octopus-rest-api/octopus-cli/index.mdx
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-02-23
+modDate: 2024-03-05
 title: Octo Command Line (CLI) (Deprecated)
 description: The Octo CLI is the Octopus command line tool that builds on top of the Octopus REST API.
 navOrder: 100


### PR DESCRIPTION
Adding deprecation notice to appear in page title and side navigation.