### PR TITLE
Change link and reword as ".NET" rather than ".NET Core".

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -20,7 +20,7 @@ Before you can configure a Linux Tentacle, the Linux server must meet the [requi
 
 - Octopus Server **2019.8.3** or newer
 
-Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that there are [.NET Core prerequisites](https://github.com/dotnet/core/blob/main/Documentation/linux-prereqs.md) that may need to be installed.
+Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that [you will need to install .NET](https://learn.microsoft.com/en-us/dotnet/core/install/linux).
 
 ## Known limitations
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-11-07
+modDate: 2024-03-11
 title: Linux Tentacle
 description: How to install and configure Octopus Tentacles on Linux Servers in either listening or polling mode.
 navOrder: 20


### PR DESCRIPTION
Fixes a broken external link to Microsoft documentation and brings it up to date with ".NET" now being the name for "the thing that runs on Windows and Linux".