### PR TITLE
Fix pipes not being escaped and simplify intro text

### DIFF
--- a/src/pages/docs/projects/variables/tenant-variables.mdx
+++ b/src/pages/docs/projects/variables/tenant-variables.mdx
@@ -12,7 +12,7 @@ Tenant variables allow you to configure [variables](/docs/projects/variables/) t
 
 ![](/docs/projects/variables/images/tenant-variables.png "width=500")
 
-Tenant variables are provided using variable templates which map a single variable name to different values for each tenant based on what you choose to set. Each variable template can define the data type, name, label, help text, and default value.
+Tenant variables are provided using variable templates which map a single variable name to different values for each tenant. Each variable template can define the data type, name, label, help text, and default value.
 
 There are two types of variable templates:
 
@@ -43,7 +43,7 @@ To add a project template:
 | **Help text**     | The descriptive help text that will be displayed to provide the user with enough information to accurately provide the value. | A shortened, URL friendly, version of the tenant's name. |
 | **Control type** | You can select one of several different data types. This controls the user interface provided to collect the variable value, and determines how the variable value is interpreted. Note the variable values will be stored and interpreted as text. | Single-line text box, multi-line text box, drop down, checkbox, sensitive/password box, Azure account |
 | **Default value** | The value that will be given to the variable if an actual value is not provided. The default value can contain [variable binding expressions](/docs/projects/variables/variable-substitutions). | `https://#{Tenant.Alias}.myapp.com`      |
-| **Options** | (Only applies when control type is drop down). This defines the list of options available for the user to select from the drop down list. Enter each option on a new line. Use `|` to separate values and display text. | `Value1|Display text 1` <br>`Value2|Display text 2`  |
+| **Options** | (Only applies when control type is drop down). This defines the list of options available for the user to select from the drop down list. Enter each option on a new line. Use `\|` to separate values and display text. | `Value1\|Display text 1` <br />`Value2\|Display text 2`  |
 
 Values for your newly created templates will be displayed for each tenant/environment combination. If you don't see any values, make sure you've [connected tenants](/docs/projects/tenants/bulk-connection) to the project. You can filter the displayed values to a specific template by selecting it from the list on the side, or to specific tenants and environments using the provided filter options.
 


### PR DESCRIPTION
The pipes weren't escaped which led to incorrect table content.

## After
![image](https://github.com/OctopusDeploy/docs/assets/11970672/54e9aa23-5980-4e4d-a1db-f58cf5aead8c)
