### PR TITLE
Add subject wildcard and CLI usage to OIDC docs

### DIFF
--- a/src/pages/docs/octopus-rest-api/openid-connect/github-actions.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/github-actions.md
@@ -57,7 +57,7 @@ When configuring an OIDC identity for GitHub Actions you need to choose a filter
 - Tag: Workflow runs for the specific tag will be allowed to connect using the OIDC identity. The prefix for the git ref does not need to be supplied e.g. Use `v1` instead of `refs/tags/v1`.
 
 :::div{.hint}
-The subject in an OIDC identity is case-sensitive and must match exactly, wildcards are currently not supported.
+Support for wildcards when matching a subject is available from Octopus 2024.1. To match multiple characters in a subject use `*`, and to match a single character use `?`.
 :::
 
 ### Customized subject claims

--- a/src/pages/docs/octopus-rest-api/openid-connect/index.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/index.md
@@ -156,6 +156,24 @@ A Service Account Id will be shown, this will be a GUID which must be supplied a
 
 The access token obtained from the token exchange must be supplied in the `Authorization` header of API requests, using the `Bearer` scheme, for example `Authorization: Bearer {the-access-token}`.
 
+## Using the Octopus CLI with OIDC
+
+From version `2.1.0`, the [Octopus CLI](https://github.com/OctopusDeploy/cli) supports a new command `octopus login` which can be used to authenticate using OIDC, providing the Octopus Server URL, the id of the service account and the ID token from your OIDC provider. This can be used as part of your CI server workflows where you are using the CLI but currently provisioning an API key.
+
+After authenticating using OIDC, the `login` command will configure the CLI environment to be used.
+
+Usage:
+
+```
+octopus login --server {OctopusServerUrl} --service-account-id {ServiceAccountId} --id-token {IdTokenFromProvider}
+```
+
+For example:
+
+```
+octopus login --server https://my.octopus.app --service-account-id 834a7275-b5b8-42a1-8b36-14f11c8eb55e --id-token eyJhbGciOiJQUzI1NiIs...
+```
+
 ## Validation of OIDC identity tokens
 
 When an OIDC identity token from an external system is received as part of a token exchange request, Octopus will validate this token before issuing an access token. It does this by:

--- a/src/pages/docs/octopus-rest-api/openid-connect/other-issuers.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/other-issuers.md
@@ -25,11 +25,11 @@ The first step is to create an OIDC identity for your issuer to access the Octop
 5. Enter the URL of the identity. Octopus uses OpenID Configuration Discovery to validate the OIDC token provided by the issuer.
    1. The issuer URL must be HTTPS.
    2. The URL should be the base where the OIDC Discovery endpoint (`/.well-known/openid-configuration`) endpoint can be found. For example if the discovery endpoint is `https://my-oidc-issuer.com/.well-known/openid-configuration` then the issuer should be set to `https://my-oidc-issuer.com`.
-6. Enter the subject of the identity. This must match exactly the subject that is provided in the OIDC token and is _case-sensitive_. The format of the subject will differ by issuer, please consult your OIDC issuers documentation.
+6. Enter the subject of the identity. This must match the subject that is provided in the OIDC token and is _case-sensitive_, wildcards for matching multiple characters `*` and single characters `?` can be used. The format of the subject will differ by issuer, please consult your OIDC issuers documentation.
 7. Click Save.
 
 :::div{.hint}
-Currently there is no support for wildcards when configuring the subject of an identity, support for this may be available in a future version of Octopus.
+Support for wildcards when matching a subject is available from Octopus 2024.1. To match multiple characters in a subject use `*`, and to match a single character use `?`.
 :::
 
 :::div{.hint}


### PR DESCRIPTION
This PR updates the OIDC docs to include the following:
- Support for using wildcard characters which was released in `2024.1`
- A section on how to use the Octopus CLI with OIDC