### PR TITLE
Rename target roles to target tags on the Deployment targets page

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/index.mdx
@@ -32,7 +32,7 @@ Deployment targets are added in different ways, depending on the type of target 
 - [Offline package drop](/docs/infrastructure/deployment-targets/offline-package-drop)
 - [Cloud regions](/docs/infrastructure/deployment-targets/cloud-regions)
 
-## Target tags \{#target-roles}
+## Target tags (formerly target roles) \{#target-roles}
 
 <TargetRoles />
 

--- a/src/pages/docs/infrastructure/deployment-targets/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/index.mdx
@@ -32,23 +32,23 @@ Deployment targets are added in different ways, depending on the type of target 
 - [Offline package drop](/docs/infrastructure/deployment-targets/offline-package-drop)
 - [Cloud regions](/docs/infrastructure/deployment-targets/cloud-regions)
 
-## Target roles \{#target-roles}
+## Target tags \{#target-roles}
 
 <TargetRoles />
 
-### Add target roles \{#create-target-roles}
+### Add target tags \{#create-target-roles}
 
-Roles are created and saved in the database as soon as you assign them to a deployment target.
+Target tags are created and saved in the database as soon as you assign them to a deployment target.
 
-Decide on the naming convention you will use before creating your first target role as it's not possible to change the case after the role has been created, for instance, all lowercase to camel case.
+Decide on the naming convention you will use before creating your first target tag as it's not possible to change the case after the target tag has been created, for instance, all lowercase to camel case.
 
 1. Register a deployment target or click on an already registered deployment target and go to **Settings**.
-2. In the **Target Roles** field, enter the target role you'd like to use (no spaces).
+2. In the **Target Tags** field, enter the target tag you'd like to use (no spaces).
 3. Save the target settings.
 
-The role has been created and assigned to the deployment target and can be added to other deployment targets.
+The target tag has been created and assigned to the deployment target and can be added to other deployment targets.
 
-You can check all the roles assigned to your deployment targets from the **Infrastructure** tab.
+You can check all the target tags assigned to your deployment targets from the **Infrastructure** tab.
 
 ## Dynamic infrastructure
 

--- a/src/shared-content/infrastructure/target-roles.include.md
+++ b/src/shared-content/infrastructure/target-roles.include.md
@@ -1,5 +1,9 @@
 [Getting Started - Machine Roles](https://www.youtube.com/watch?v=AU8TBEOI-0M)
 
+:::div{.info}
+**Target roles** are **target tags** from Octopus Deploy **2024.2** onwards. The functionality remains the same. This is only a name change to make our terminology clearer. No action is needed.
+:::
+
 Before you can deploy software to your deployment targets, you need to associate them with target tags. This ensures you deploy the right software to the right deployment targets. Typical target tags include:
 
 - web-server

--- a/src/shared-content/infrastructure/target-roles.include.md
+++ b/src/shared-content/infrastructure/target-roles.include.md
@@ -1,12 +1,12 @@
 [Getting Started - Machine Roles](https://www.youtube.com/watch?v=AU8TBEOI-0M)
 
-Before you can deploy software to your deployment targets, you need to tag them with target roles. This ensures you deploy the right software to the right deployment targets. Typical target roles include:
+Before you can deploy software to your deployment targets, you need to associate them with target tags. This ensures you deploy the right software to the right deployment targets. Typical target tags include:
 
 - web-server
 - app-server
 - db-server
 
-Using target roles means the infrastructure in each of your environments doesn't need to be identical and the deployment process will know which deployment targets to deploy your software to.
+Using target tags means the infrastructure in each of your environments doesn't need to be identical and the deployment process will know which deployment targets to deploy your software to.
 
-Deployment targets can have more than one role, and more than one deployment target can have the same role, but every deployment target must have at least one role.
+Deployment targets can have more than one target tag, and more than one deployment target can have the same target tag, but every deployment target must have at least one target tag.
 

--- a/src/shared-content/infrastructure/target-roles.include.md
+++ b/src/shared-content/infrastructure/target-roles.include.md
@@ -1,16 +1,17 @@
 [Getting Started - Machine Roles](https://www.youtube.com/watch?v=AU8TBEOI-0M)
 
 :::div{.info}
-**Target roles** are **target tags** from Octopus Deploy **2024.2** onwards. The functionality remains the same. This is only a name change to make our terminology clearer. No action is needed.
+**Target roles** are **target tags** from Octopus Deploy **2024.2** onwards. The functionality remains the same. This is only a name change to make our terminology clearer.
 :::
 
 Before you can deploy software to your deployment targets, you need to associate them with target tags. This ensures you deploy the right software to the right deployment targets. Typical target tags include:
 
+- product-cluster
 - web-server
 - app-server
 - db-server
 
 Using target tags means the infrastructure in each of your environments doesn't need to be identical and the deployment process will know which deployment targets to deploy your software to.
 
-Deployment targets can have more than one target tag, and more than one deployment target can have the same target tag, but every deployment target must have at least one target tag.
+Deployment targets can have more than one target tag, and more than one deployment target can have the same tag, but every deployment target must have at least one tag.
 


### PR DESCRIPTION
# Description 

[sc-75742]

This PR renames target roles to target tags on the Deployment targets page.

# Changes

## Updated page

![localhost_3000_docs_infrastructure_deployment-targets](https://github.com/OctopusDeploy/docs/assets/155603967/597820b7-7627-4cb4-8a50-2f77963cb17c)

## New callout

<img width="1250" alt="Screenshot 2024-04-17 at 3 10 05 pm" src="https://github.com/OctopusDeploy/docs/assets/155603967/48542b24-2c8a-4bed-99c3-9b00595bc8dd">
