### PR TITLE
Add AzureRM to deprecations

### DIFF
--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -38,7 +38,7 @@ Further notes about this pending change are mentioned in the [2024.1 deprecation
 The AzureRM Powershell modules were Microsoft’s way of integrating Powershell with Azure resources however this has since been 
 deprecated by Microsoft in favor of the Azure CLI or the Az Powershell modules.
 
-These modules were [deprecated by Microsoft](https://learn.microsoft.com/en-us/powershell/azure/azurerm-retirement-overview) (as of 29-February-2024
+These modules were [deprecated by Microsoft](https://learn.microsoft.com/en-us/powershell/azure/azurerm-retirement-overview) (as of 29-February-2024).
 
 AzureRm will remain available until July 2024 (albeit with an in-app warning), but users will be required to move to either `az cli` or the `az module for powershell` 
 for Azure authentication thereafter.

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-11-20
+modDate: 2024-04-17
 title: Deprecations
 description: Upcoming and past deprecations by version for Octopus Server
 navOrder: 300

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -40,8 +40,8 @@ deprecated by Microsoft in favor of the Azure CLI or the Az Powershell modules.
 
 These modules were [deprecated by Microsoft](https://learn.microsoft.com/en-us/powershell/azure/azurerm-retirement-overview) (as of 29-February-2024
 
-AzureRm will remain available until July 2024 (albeit with an in-app warning), but will be required to move  to either `az cli` or the `az module for powershell` 
-for authentication thereafter.
+AzureRm will remain available until July 2024 (albeit with an in-app warning), but users will be required to move to either `az cli` or the `az module for powershell` 
+for Azure authentication thereafter.
 
 ## Deprecations for 2024.1
 

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -32,6 +32,17 @@ To provide ample time to act, from Octopus Server `2024.1`, workloads that run o
 
 Further notes about this pending change are mentioned in the [2024.1 deprecation blog post](https://octopus.com/blog/2024-deprecated-features#windows-server-2008)
 
+## Deprecations for 2024.3
+
+### Azure Resource Manager Powershell Module
+The AzureRM Powershell modules were Microsoft’s way of integrating Powershell with Azure resources however this has since been 
+deprecated by Microsoft in favor of the Azure CLI or the Az Powershell modules.
+
+These modules were [deprecated by Microsoft](https://learn.microsoft.com/en-us/powershell/azure/azurerm-retirement-overview) (as of 29-February-2024
+
+AzureRm will remain available until July 2024 (albeit with an in-app warning), but will be required to move  to either `az cli` or the `az module for powershell` 
+for authentication thereafter.
+
 ## Deprecations for 2024.1
 
 ### Helm V2


### PR DESCRIPTION
The Azure Resource Manager powershell module was deprecated by microsoft in 2021 - however it is still being used/available for use in OctopusDeploy.

If users are using the module, we will show them a warning asap - use of the module will be (soft) disabled in 2024.3, and fully removed for 2024.4.

Section appears:
![image](https://github.com/OctopusDeploy/docs/assets/37158202/69ff36a2-8659-4d24-995a-d3ac7cd89fa3)

