### PR TITLE
Change #{Project} to #{Octopus} for environment ID

### DIFF
--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-08-21
-modDate: 2023-08-21
+modDate: 2024-04-19
 title: Setting the Concurrency Tag
 description: How to set the Task's Concurrency Tag to improve deployment efficiency
 navOrder: 60

--- a/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag.md
+++ b/src/pages/docs/tenants/guides/tenants-sharing-machine-targets/setting-the-concurrency-tag.md
@@ -10,9 +10,9 @@ hideInThisSectionHeader: true
 
 The `Octopus.Task.ConcurrencyTag` system variable gives us finer control over how tasks run concurrently in Octopus. Like the variable that allows you to bypass the deployment mutex, this variable should be handled with care.
 
-Octopus uses this variable to determine which tasks can run concurrently. For non-tenanted deployments, it has the value `#{Octopus.Project.Id}/#{Project.Environment.Id}`. Tenanted deployments use the value `#{Octopus.Deployment.Tenant.Id}/#{Octopus.Project.Id}/#{Octopus.Environment.Id}`.
+Octopus uses this variable to determine which tasks can run concurrently. For non-tenanted deployments, it has the value `#{Octopus.Project.Id}/#{Octopus.Environment.Id}`. Tenanted deployments use the value `#{Octopus.Deployment.Tenant.Id}/#{Octopus.Project.Id}/#{Octopus.Environment.Id}`.
 
-If we change the value for a tenanted deployment to `#{Octopus.Project.Id}/#{Project.Environment.Id}`, the tenanted deployment tasks will run sequentially instead of concurrently.
+If we change the value for a tenanted deployment to `#{Octopus.Project.Id}/#{Octopus.Environment.Id}`, the tenanted deployment tasks will run sequentially instead of concurrently.
 
 In this scenario, we want to run one task per hosting group concurrently. We can do that by scoping different values to the Hosting Group tenant tags.
 


### PR DESCRIPTION
Currently set to `#{Project.Environment.Id}`, changing to `#{Octopus.Environment.Id}`