### PR TITLE
Remove section on exporting data from Octopus Cloud

### DIFF
--- a/src/pages/docs/octopus-cloud/disaster-recovery.md
+++ b/src/pages/docs/octopus-cloud/disaster-recovery.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-10-04
+modDate: 2024-04-23
 title: Disaster recovery
 navOrder: 40
 description: How to work with your data and disaster recovery in an Octopus Cloud instance.

--- a/src/pages/docs/octopus-cloud/disaster-recovery.md
+++ b/src/pages/docs/octopus-cloud/disaster-recovery.md
@@ -66,7 +66,3 @@ In the case of an Azure region wide disaster the time to restore services will v
 ### Importing data
 
 Due to some key differences between the self-hosted and cloud configurations, it **is not possible** to use the existing [Migration API](/docs/octopus-rest-api/migration-api/) to import data. If you are migrating from an existing self-hosted instance please see [migrating from self-hosted to Octopus Cloud](/docs/octopus-cloud/migrations).
-
-### Exporting your data
-
-If you need to export your data, this can be done with the [Migration API](/docs/octopus-rest-api/migration-api), alternatively, we can provide you with a full database backup if required. Please visit the [support page](https://octopus.com/support) if you need this.


### PR DESCRIPTION
We don't currently have a good way to comprehensively export data from a Cloud instance.

For Octonauts, this is being discussed internally [here](https://octopusdeploy.slack.com/archives/C01EG659GHK/p1713855979631789).

[sc-76512]