### PR TITLE
Explicitly list the steps that support Server-Side Apply

### DIFF
--- a/src/pages/docs/deployments/kubernetes/server-side-apply/index.md
+++ b/src/pages/docs/deployments/kubernetes/server-side-apply/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2024-04-15
-modDate: 2024-04-15
+modDate: 2024-04-24
 title: Server-Side Apply
 description: Deploy Raw YAML to a Kubernetes cluster.
 navOrder: 80

--- a/src/pages/docs/deployments/kubernetes/server-side-apply/index.md
+++ b/src/pages/docs/deployments/kubernetes/server-side-apply/index.md
@@ -10,7 +10,15 @@ navOrder: 80
 [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/) is an opt-in Kubernetes mechanism that improves the configuration management of the `kubectl apply` command by tracking field ownership directly on the Kubernetes server.
 SSA allows multiple appliers to manage the fields of a single Kubernetes object without accidentally overwriting each other’s intentions.
 
-Octopus supports Server-Side Apply for all of our Kubernetes steps. 
+Octopus supports Server-Side Apply for the following steps:
+- Deploy Kubernetes YAML
+- Deploy with Kustomize
+- Configure and apply Kubernetes resources
+- Configure and apply a Kubernetes ConfigMap
+- Configure and apply a Kubernetes Service
+- Configure and apply a Kubernetes Ingress
+- Configure and apply a Kubernetes Secret
+
 You can find the settings under the **Additional Configuration Options** section of the step in the process editor.
 
 :::figure


### PR DESCRIPTION
We want to be more specific than just saying "Octopus supports Server-Side Apply for all of our Kubernetes steps" because some people might expect to see it in the Helm step or kubectl script step which don't have it.

<img width="770" alt="Screenshot 2024-04-24 at 4 31 53 pm" src="https://github.com/OctopusDeploy/docs/assets/151479559/95a4d23d-f85e-4e64-b7be-f37bb9d0ad22">

