### PR TITLE
Add storage options for Kubernetes agent

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -15,10 +15,12 @@ auths
 autodeployoverride
 awsaccount
 azureaccount
+azurefile
 Bento
 bootstrap
 bootstrapped
 bootstrapper
+Ceph
 changeit
 childelement
 choco
@@ -65,12 +67,14 @@ feedcred
 Feedz.io
 fieldset
 figcaption
+filestore
 FIPS
 frontmatter
 gcloud
 getenv
 gifs
 globbing
+Gluster
 googleaccount
 groff
 Groupsand

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
@@ -28,7 +28,7 @@ This default implementation is made to let you try the Kubernetes agent without 
 Since the NFS server runs inside your Kubernetes cluster, upgrades and other cluster operations will interrupt the server. Due to how NFS stores and allows access to the shared data, clients will not be able to recover from a restart cleanly. This results in deployment failure if one happens to be running while the NFS server is restarted.
 
 ### Privileges
-The NFS server requires `privileged` access when running as a container. This can be disallowed in some clusters, and access to the NFS pod should be kept to a minimum. 
+The NFS server requires `privileged` access when running as a container, which may not be permitted depending on the cluster configuration. Access to the NFS pod should be kept to a minimum since it enables access to the host. 
 
 If you have a use case that can’t tolerate occasional deployment failures, it’s recommended to provide your own `StorageClass` instead of using the default NFS implementation.
 
@@ -41,11 +41,11 @@ Many managed Kubernetes offerings will have offerings that require little effort
 
 |**Offering**                      |**Provisioner**                    |**Default StorageClass name**       |
 |----------------------------------|-----------------------------------|------------------------------------|
-|Azure Kubernetes Service (AKS)    |`file.csi.azure.com`               |`azurefile`                        |
-|Elastic Kubernetes Service (EKS)  |`efs.csi.aws.com`                  |`efs-sc`                            |
-|Google Kubernetes Engine (GKE)    |`filestore.csi.storage.gke.io`     |`standard-rwx`                      |
+|[Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/concepts-storage)    |`file.csi.azure.com`               |`azurefile`                        |
+|[Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/latest/userguide/storage.html)  |`efs.csi.aws.com`                  |`efs-sc`                            |
+|[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/concepts/storage-overview)    |`filestore.csi.storage.gke.io`     |`standard-rwx`                      |
 
 If you manage your own cluster and don’t have offerings from cloud providers available, there are some in-cluster options you could explore:
-- Longhorn
-- Rook (CephFS)
-- GlusterFS
+- [Longhorn](https://longhorn.io/)
+- [Rook (CephFS)](https://rook.io/)
+- [GlusterFS](https://www.gluster.org/)

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
@@ -13,7 +13,11 @@ On a Kubernetes agent, scripts are executed in separate Kubernetes pods (script 
 
 Since the Kubernetes agent is built on the Tentacle codebase,  it is necessary to configure shared storage so that the Tentacle Pod can write the files in a place that the Script Pods can read from.
 
-We offer two options for configuring the shared storage - you can use either the default NFS storage or specify a Storage Class name.
+We offer two options for configuring the shared storage - you can use either the default NFS storage or specify a Storage Class name during setup:
+
+:::figure
+![Kubernetes Agent Wizard Config Page](/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/kubernetes-agent-wizard-config.png)
+:::
 
 
 ## NFS storage

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
@@ -24,14 +24,13 @@ This NFS server is referenced in the `StorageClass` that the Kubernetes agent an
 
 This default implementation is made to let you try the Kubernetes agent without worrying about installing a `ReadWriteMany` compatible `StorageClass` yourself. There are  some drawbacks to this approach:
 
-### Reliability
-Since the NFS server runs inside your Kubernetes cluster, upgrades and other cluster operations will interrupt the server. Due to how NFS stores and allows access to the shared data, clients will not be able to recover from a restart cleanly. This results in deployment failure if one happens to be running while the NFS server is restarted.
-
 ### Privileges
 The NFS server requires `privileged` access when running as a container, which may not be permitted depending on the cluster configuration. Access to the NFS pod should be kept to a minimum since it enables access to the host. 
 
-If you have a use case that can’t tolerate occasional deployment failures, it’s recommended to provide your own `StorageClass` instead of using the default NFS implementation.
+### Reliability
+Since the NFS server runs inside your Kubernetes cluster, upgrades and other cluster operations can cause the NFS server to restart. Due to how NFS stores and allows access to shared data, script pods will not be able to recover cleanly from an NFS server restart. This causes running deployments to fail when the NFS server is restarted.
 
+If you have a use case that can’t tolerate occasional deployment failures, it’s recommended to provide your own `StorageClass` instead of using the default NFS implementation.
 
 ## Custom StorageClass
 

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage/index.md
@@ -1,0 +1,51 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2024-04-29
+modDate: 2024-04-29
+title: Storage
+description: How to configure storage for a Kubernetes agent
+navOrder: 10
+---
+
+During a deployment, Octopus Server first sends any required scripts and packages to [Tentacle](https://octopus.com/docs/infrastructure/deployment-targets/tentacle) which writes them to the file system. The actual script execution then takes place in a different process called [Calamari](https://github.com/OctopusDeploy/Calamari), which retrieves the scripts and packages directly from the file system. 
+
+On a Kubernetes agent, scripts are executed in separate Kubernetes pods (script pod) as opposed to in a local shell (Bash/Powershell). This means the Tentacle pod and script pods don’t automatically share a common file system.
+
+Since the Kubernetes agent is built on the Tentacle codebase,  it is necessary to configure shared storage so that the Tentacle Pod can write the files in a place that the Script Pods can read from.
+
+We offer two options for configuring the shared storage - you can use either the default NFS storage or specify a Storage Class name.
+
+
+## NFS storage
+
+By default, the Kubernetes agent Helm chart will set up an NFS server suitable for use by the agent inside your cluster. The server runs as a `StatefulSet` in the same namespace as the Kubernetes agent, and uses `EmptyDir` storage, as the working files of the agent are not required to be long-lived. 
+
+This NFS server is referenced in the `StorageClass` that the Kubernetes agent and the script pod use. This `StorageClass` will then instruct the `NFS CSI Driver` to mount the server as directed.
+
+This default implementation is made to let you try the Kubernetes agent without worrying about installing a `ReadWriteMany` compatible `StorageClass` yourself. There are  some drawbacks to this approach:
+
+### Reliability
+Since the NFS server runs inside your Kubernetes cluster, upgrades and other cluster operations will interrupt the server. Due to how NFS stores and allows access to the shared data, clients will not be able to recover from a restart cleanly. This results in deployment failure if one happens to be running while the NFS server is restarted.
+
+### Privileges
+The NFS server requires `privileged` access when running as a container. This can be disallowed in some clusters, and access to the NFS pod should be kept to a minimum. 
+
+If you have a use case that can’t tolerate occasional deployment failures, it’s recommended to provide your own `StorageClass` instead of using the default NFS implementation.
+
+
+## Custom StorageClass
+
+If you need a more reliable storage solution, then you can specify your own `StorageClass`. This `StorageClass` must be capable of `ReadWriteMany` (also known as `RWX`) access mode. 
+
+Many managed Kubernetes offerings will have offerings that require little effort to use. These will be a “provisioner” (named as such as they “provision” storage for a storage class), which you can then tie to a storage class. Some examples are listed below:
+
+|**Offering**                      |**Provisioner**                    |**Default StorageClass name**       |
+|----------------------------------|-----------------------------------|------------------------------------|
+|Azure Kubernetes Service (AKS)    |`file.csi.azure.com`               |`azurefile`                        |
+|Elastic Kubernetes Service (EKS)  |`efs.csi.aws.com`                  |`efs-sc`                            |
+|Google Kubernetes Engine (GKE)    |`filestore.csi.storage.gke.io`     |`standard-rwx`                      |
+
+If you manage your own cluster and don’t have offerings from cloud providers available, there are some in-cluster options you could explore:
+- Longhorn
+- Rook (CephFS)
+- GlusterFS


### PR DESCRIPTION
[sc-76947]

We need to get this page in before release since the installation dialog references it.
![CleanShot 2024-04-29 at 14 14 20@2x](https://github.com/OctopusDeploy/docs/assets/2888279/cedaca99-97ec-4c78-abca-0ab6905a0170)

Local render - are too many words formatted as code?
![CleanShot 2024-04-29 at 15 14 05@2x](https://github.com/OctopusDeploy/docs/assets/2888279/185c333b-0faf-4156-ad5c-b4b04079e184)

