### PR TITLE
Add permissions page for Kubernetes Agent

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -164,6 +164,7 @@ petshop
 PKCE
 pkcs
 podannotation
+preproduction
 prerender
 prerenderingchange
 printfn

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
@@ -36,9 +36,12 @@ The service account for script pods can be customized in a few ways:
 | `scriptPods.serviceAccount.name`              | The name of the scriptPods service account                       | `<agent-name>-tentacle`                                                                                                                                                                                                                    |
 | `scriptPods.serviceAccount.annotations`       | Annotations given to the service account                         | `[]`                                                                                                                                                                                                                                       |
 
-Example for `script.serviceAccount.targetNamespaces`:
+### Examples
+<details data-group="script-pod-value-examples">
+<summary>Target Namespaces</summary>
 
-**script:**
+`scriptPods.serviceAccount.targetNamespaces`
+
 ```Bash
 helm upgrade --install --atomic \
 --set scriptPods.serviceAccount.targetNamespaces="{development,preproduction}" \
@@ -55,8 +58,12 @@ helm upgrade --install --atomic \
 my-agent\
 oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
 ```
+</details>
 
-Example for `scriptPods.serviceAccount.clusterRole.rules`:
+<details data-group="script-pod-value-examples">
+<summary>Cluster Role Rules</summary>
+
+`scriptPods.serviceAccount.clusterRole.rules`
 
 **values.yaml:**
 ```yaml
@@ -89,7 +96,7 @@ agent:
     - 'k8s-cluster-tag'
   bearerToken: 'XXXX'
 ```
-**script:**
+**command:**
 ```Bash
 helm upgrade --install --atomic \
 --values values.yaml \
@@ -98,6 +105,7 @@ helm upgrade --install --atomic \
 my-agent \
 oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
 ```
+</details>
 
 
 # NFS Server Pod Permissions

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
@@ -42,6 +42,9 @@ The service account for script pods can be customized in a few ways:
 
 `scriptPods.serviceAccount.targetNamespaces`
 
+<br/>
+
+**command:**
 ```Bash
 helm upgrade --install --atomic \
 --set scriptPods.serviceAccount.targetNamespaces="{development,preproduction}" \
@@ -64,6 +67,8 @@ oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
 <summary>Cluster Role Rules</summary>
 
 `scriptPods.serviceAccount.clusterRole.rules`
+
+<br/>
 
 **values.yaml:**
 ```yaml
@@ -96,6 +101,8 @@ agent:
     - 'k8s-cluster-tag'
   bearerToken: 'XXXX'
 ```
+<br/>
+
 **command:**
 ```Bash
 helm upgrade --install --atomic \

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
@@ -1,0 +1,105 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2024-04-29
+modDate: 2024-04-29
+title: Permissions
+description: Information about what permissions are required and how to adjust them
+navOrder: 10
+---
+
+The Kubernetes agent uses service accounts to manage access to cluster objects.
+
+There are 3 main components that run with different permissions in the Kubernetes agent:
+- **Agent Pod** - This is the main component and is responsible for receiving work from Octopus Server and scheduling it in the cluster.
+- **Script Pods** - These are run to execute work on the cluster. When Octopus issues work to the agent, the Tentacle will schedule a pod to run the script to execute the required work. These are short-lived, single-use pods which are removed by Tentacle when they are complete.
+- **NFS Server Pod** - This optional component is used if no Storage Class is specified during installation.
+
+# Agent Pod Permissions
+
+The agent pod uses a service account which only allows the agent to create, view and modify pods, pod logs, config maps, and secrets in the agent namespace. Adjusting these permissions is not supported.
+
+| Variable Name                      | Description                              | Default Value            |
+|:-----------------------------------|:-----------------------------------------|:-------------------------|
+| `agent.serviceAccount.name`        | The name of the agent service account    | `<agent-name>-tentacle`  |
+| `agent.serviceAccount.annotations` | Annotations given to the service account | `[]`                     |
+
+# Script Pod Permissions
+
+By default, the script pods (the pods which run your deployment steps) are given cluster wide admin access to deploy any and all cluster objects in any namespaces as configured in your deployment processes.
+
+The service account for script pods can be customized in a few ways:
+
+| Variable Name                                 | Description                                                      | Default Value                                                                                                                                                                                                                              |
+|:----------------------------------------------|:-----------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `scriptPods.serviceAccount.targetNamespaces`  | Limit the namespaces that the service account can interact with. | `[]`<br/>(When empty, all namespaces are allowed.)                                                                                                                                                                                         |
+| `scriptPods.serviceAccount.clusterRole.rules` | Give the service account custom rules                            | <pre>- apiGroups:<br/>&nbsp;&nbsp;- '\*'<br/>&nbsp;&nbsp;resources:<br/>&nbsp;&nbsp;- '\*'<br/>&nbsp;&nbsp;verbs:<br/>&nbsp;&nbsp;- '\*'<br/>- nonResourceURLs:<br/>&nbsp;&nbsp;- '\*'<br/>&nbsp;&nbsp;verbs:<br/>&nbsp;&nbsp;- '\*'</pre> |
+| `scriptPods.serviceAccount.name`              | The name of the scriptPods service account                       | `<agent-name>-tentacle`                                                                                                                                                                                                                    |
+| `scriptPods.serviceAccount.annotations`       | Annotations given to the service account                         | `[]`                                                                                                                                                                                                                                       |
+
+Example for `script.serviceAccount.targetNamespaces`:
+
+**script:**
+```Bash
+helm upgrade --install --atomic \
+--set scriptPods.serviceAccount.targetNamespaces="{development,preproduction}" \
+--set tentacle.ACCEPT_EULA="Y" \
+--set tentacle.targetName="Nonproduction Agent" \
+--set tentacle.serverUrl="http://localhost:5000/" \
+--set tentacle.serverCommsAddress="http://localhost:10943/" \
+--set tentacle.space="Default" \
+--set tentacle.targetEnvironments="{Development,Preproduction}" \
+--set tentacle.targetRoles="{k8s-cluster-tag}" \
+--set tentacle.bearerToken="XXXX" \
+--version "1.*.*" \
+--create-namespace --namespace octopus-agent-my-cluster \
+my-cluster \
+oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
+```
+
+Example for `scriptPods.serviceAccount.clusterRole.rules`:
+
+**values.yaml:**
+```yaml
+scriptPods:
+  serviceAccount:
+    clusterRole:
+      rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - 'configmaps'
+          - 'deployments'
+          - 'services'
+          verbs:
+          - '*'
+        - nonResourceURLs:
+          - '*'
+          verbs:
+          - '*'
+
+tentacle:
+  ACCEPT_EULA: 'Y'
+  targetName: 'No Secret Access Production Agent'
+  serverUrl: 'http://localhost:5000/'
+  serverCommsAddress: 'http://localhost:10943/'
+  space: 'Default'
+  targetEnvironments:
+    - 'Production'
+  targetRoles:
+    - 'k8s-cluster-tag'
+  bearerToken: 'XXXX'
+```
+**script:**
+```Bash
+helm upgrade --install --atomic \
+--values values.yaml \
+--version "1.*.*" \
+--create-namespace --namespace octopus-agent-my-cluster \
+my-cluster \
+oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
+```
+
+
+# NFS Server Pod Permissions
+
+If you have not provided a storageClassName for persistence, an NFS pod will be used. This NFS Server pod requires `privileged` access. For more information see [Kubernetes agent Storage](/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage#nfs-storage).

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/permissions/index.md
@@ -12,7 +12,7 @@ The Kubernetes agent uses service accounts to manage access to cluster objects.
 There are 3 main components that run with different permissions in the Kubernetes agent:
 - **Agent Pod** - This is the main component and is responsible for receiving work from Octopus Server and scheduling it in the cluster.
 - **Script Pods** - These are run to execute work on the cluster. When Octopus issues work to the agent, the Tentacle will schedule a pod to run the script to execute the required work. These are short-lived, single-use pods which are removed by Tentacle when they are complete.
-- **NFS Server Pod** - This optional component is used if no Storage Class is specified during installation.
+- **NFS Server Pod** - This optional component is used if no StorageClass is specified during installation.
 
 # Agent Pod Permissions
 
@@ -42,17 +42,17 @@ Example for `script.serviceAccount.targetNamespaces`:
 ```Bash
 helm upgrade --install --atomic \
 --set scriptPods.serviceAccount.targetNamespaces="{development,preproduction}" \
---set tentacle.ACCEPT_EULA="Y" \
---set tentacle.targetName="Nonproduction Agent" \
---set tentacle.serverUrl="http://localhost:5000/" \
---set tentacle.serverCommsAddress="http://localhost:10943/" \
---set tentacle.space="Default" \
---set tentacle.targetEnvironments="{Development,Preproduction}" \
---set tentacle.targetRoles="{k8s-cluster-tag}" \
---set tentacle.bearerToken="XXXX" \
+--set agent.acceptEula="Y" \
+--set agent.targetName="Nonproduction Agent" \
+--set agent.serverUrl="http://localhost:5000/" \
+--set agent.serverCommsAddress="http://localhost:10943/" \
+--set agent.space="Default" \
+--set agent.targetEnvironments="{Development,Preproduction}" \
+--set agent.targetRoles="{k8s-cluster-tag}" \
+--set agent.bearerToken="XXXX" \
 --version "1.*.*" \
---create-namespace --namespace octopus-agent-my-cluster \
-my-cluster \
+--create-namespace --namespace octopus-agent-my-agent \
+my-agent\
 oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
 ```
 
@@ -77,8 +77,8 @@ scriptPods:
           verbs:
           - '*'
 
-tentacle:
-  ACCEPT_EULA: 'Y'
+agent:
+  acceptEula: 'Y'
   targetName: 'No Secret Access Production Agent'
   serverUrl: 'http://localhost:5000/'
   serverCommsAddress: 'http://localhost:10943/'
@@ -94,12 +94,12 @@ tentacle:
 helm upgrade --install --atomic \
 --values values.yaml \
 --version "1.*.*" \
---create-namespace --namespace octopus-agent-my-cluster \
-my-cluster \
+--create-namespace --namespace octopus-agent-my-agent\
+my-agent \
 oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
 ```
 
 
 # NFS Server Pod Permissions
 
-If you have not provided a storageClassName for persistence, an NFS pod will be used. This NFS Server pod requires `privileged` access. For more information see [Kubernetes agent Storage](/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage#nfs-storage).
+If you have not provided a predefined storageClassName for persistence, an NFS pod will be used. This NFS Server pod requires `privileged` access. For more information see [Kubernetes agent Storage](/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage#nfs-storage).


### PR DESCRIPTION
[[sc-76944]](https://app.shortcut.com/octopusdeploy/story/76944/documentation-permissions)

# Target Namespaces Screen Shot
![localhost_3000_docs_infrastructure_deployment-targets_kubernetes_kubernetes-agent_permissions (5)](https://github.com/OctopusDeploy/docs/assets/97430840/6f51a348-bf9a-4da0-9667-9072ffb95d77)


# Cluster Role Rules Screen Shot
![localhost_3000_docs_infrastructure_deployment-targets_kubernetes_kubernetes-agent_permissions (6)](https://github.com/OctopusDeploy/docs/assets/97430840/82455fa4-880c-4538-9463-7e863e9858d9)

