### PR TITLE
Removing import instruction

### DIFF
--- a/src/pages/docs/releases/creating-a-release.md
+++ b/src/pages/docs/releases/creating-a-release.md
@@ -6,8 +6,6 @@ title: Creating a release
 description: Learn how to create a release in Octopus Deploy  
 navOrder: 2
 ---
-import CreateRelease from 'src/shared-content/releases/create-release.include.md';
-
 ## How to create a release in Octopus Deploy
 
 1. With your deployment process defined, you can create a release on the project's Overview page, by clicking **CREATE RELEASE**.


### PR DESCRIPTION
See screenshot - code snippet is displaying on prod. The content from the imported segment has already been added to the page directly so it is no longer needed anyway.

![image](https://github.com/OctopusDeploy/docs/assets/109653283/3c068f8e-f763-4110-aaea-6dd3a9077278)
