### PR TITLE
Add Kubernetes Agent OpenShift storage warning

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage.md
@@ -32,7 +32,7 @@ This default implementation is made to let you try the Kubernetes agent without 
 The NFS server requires `privileged` access when running as a container, which may not be permitted depending on the cluster configuration. Access to the NFS pod should be kept to a minimum since it enables access to the host. 
 
 :::div{.warning}
-Red Hat OpenShift does not enable `privileged` access by default. When enabled, we have also encountered inconsistent file access issues using the NFS server. We highly recommend the use of a [custom storage class](#custom-storage-class).
+Red Hat OpenShift does not enable `privileged` access by default. When enabled, we have also encountered inconsistent file access issues using the NFS storage. We highly recommend the use of a [custom storage class](#custom-storage-class) when using Red Hat OpenShift.
 :::
 
 ### Reliability

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/storage.md
@@ -31,12 +31,16 @@ This default implementation is made to let you try the Kubernetes agent without 
 ### Privileges
 The NFS server requires `privileged` access when running as a container, which may not be permitted depending on the cluster configuration. Access to the NFS pod should be kept to a minimum since it enables access to the host. 
 
+:::div{.warning}
+Red Hat OpenShift does not enable `privileged` access by default. When enabled, we have also encountered inconsistent file access issues using the NFS server. We highly recommend the use of a [custom storage class](#custom-storage-class).
+:::
+
 ### Reliability
 Since the NFS server runs inside your Kubernetes cluster, upgrades and other cluster operations can cause the NFS server to restart. Due to how NFS stores and allows access to shared data, script pods will not be able to recover cleanly from an NFS server restart. This causes running deployments to fail when the NFS server is restarted.
 
 If you have a use case that can’t tolerate occasional deployment failures, it’s recommended to provide your own `StorageClass` instead of using the default NFS implementation.
 
-## Custom StorageClass
+## Custom StorageClass \{#custom-storage-class}
 
 If you need a more reliable storage solution, then you can specify your own `StorageClass`. This `StorageClass` must be capable of `ReadWriteMany` (also known as `RWX`) access mode. 
 


### PR DESCRIPTION
OpenShift does not support privileged containers by default and when enabled, there are issues with file access. Adding a warning to the storage page indicating people should use a custom storage class.

Shortcut story: [sc-77491]

![image](https://github.com/OctopusDeploy/docs/assets/332730/c3a53f77-3ea3-4948-aa9f-c64724590a77)
