### PR TITLE
Update code blocks to switch on the new data-theme.

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -119,7 +119,7 @@ pre code {
 
 html[data-theme='dark'] {
   pre {
-    filter: invert(98%) hue-rotate(180deg) brightness(1.5);
+    filter: invert(98%) hue-rotate(180deg) brightness(1.1);
   }
 }
 

--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -117,9 +117,9 @@ pre code {
   filter: invert(98%) hue-rotate(180deg);
 }
 
-@media (prefers-color-scheme: dark) {
+html[data-theme='dark'] {
   pre {
-    filter: invert(98%) hue-rotate(180deg);
+    filter: invert(98%) hue-rotate(180deg) brightness(1.5);
   }
 }
 

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -255,6 +255,7 @@ html[data-theme='dark'] {
   --theme-switcher-border: var(--navy-700);
   --color-hint: var(--color-text);
   --bg-color-hint: rgba(13, 128, 216, 0.1);
+  --color-info: var(--color-text);
   --bg-color-info: var(--blue-grey-light);
   --hamburger-lines-color: var(--white);
   --footer-link-color: var(--color-menu-link);


### PR DESCRIPTION
Example: https://octopus.com/docs/packaging-applications/create-packages/octopack/troubleshooting-octopack

## Before

![Dark mode page, code blocks are light mode](https://github.com/OctopusDeploy/docs/assets/99181436/b5a64d51-7abf-4b40-ba63-e055453039f8)

## After

![Dark mode page, code blocks are dark mode](https://github.com/OctopusDeploy/docs/assets/99181436/1e587804-f5b5-43bc-9c78-6b21a208f554)

