### PR TITLE
fixed k8s worker pool warning

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-api/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-api/index.md
@@ -178,7 +178,7 @@ To make use of the Kubernetes steps, the Octopus Server or workers that will run
 11. Click **SAVE**.
 
 :::div{.warning}
-Setting the Worker Pool directly on the Deployment Target will override the Worker Pool defined in a Deployment Process.  
+Setting the Worker Pool in a Deployment Process will override the Worker Pool defined directly on the Deployment Target.  
 :::
 
 ## Create service accounts


### PR DESCRIPTION
the warning was backwards.. the Deployment Process Worker Pool will override the Deployment Target Worker Pool not the other way around.

Testing:
Deployment Target Worker Pool - Local Ubuntu
<img width="454" alt="Screenshot 2024-05-13 at 12 08 32" src="https://github.com/OctopusDeploy/docs/assets/78527975/c54278a2-475a-4b23-b250-c5fa32bf7e31">

Deployment Process Worker Pool - Hosted Ubuntu 
<img width="543" alt="Screenshot 2024-05-13 at 12 09 45" src="https://github.com/OctopusDeploy/docs/assets/78527975/5212385f-c2d0-413d-8aca-e991cc7593db">


Task Logs indicate Deployment Process Worker Pool - Hosted Ubuntu  was used:
<img width="713" alt="Screenshot 2024-05-13 at 12 11 00" src="https://github.com/OctopusDeploy/docs/assets/78527975/d1efdeac-5fec-4467-a84a-94b96b912899">
