### PR TITLE
Fix invalid project casing in "Octopus Server Container with Docker Compose" guide

### DIFF
--- a/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
+++ b/src/pages/docs/installation/octopus-server-linux-container/docker-compose-linux.md
@@ -131,7 +131,7 @@ It is also highly recommended that you create a new master key with the command 
 Start both containers by running:
 
 ```
-docker-compose --project-name Octopus up -d
+docker-compose --project-name octopus up -d
 ```
 
 When both containers are healthy, you can browse directly to `http://localhost:8080` from your host machine.


### PR DESCRIPTION
The example project name in the guide is `Octopus` (used as `docker compose --project-name Octopus up -d`), except docker throws an error, because, quoting the Docker docs, "Project names must contain only lowercase letters, decimal digits, dashes, and underscores, and must begin with a lowercase letter or decimal digit."

See docs here: https://docs.docker.com/compose/project-name/#set-a-project-name 

Before:
<img width="1256" alt="image" src="https://github.com/OctopusDeploy/docs/assets/46470837/713b52a1-853f-4e88-ae9b-f403e741101e">

After:
<img src="https://media3.giphy.com/media/o2AGVG7s6iWnOuAiEI/giphy.gif"/>