### PR TITLE
Update Octopus extension for GitHub Copilot docs with Github naming conventions

### DIFF
--- a/src/pages/docs/administration/copilot/index.md
+++ b/src/pages/docs/administration/copilot/index.md
@@ -2,7 +2,7 @@
 layout: src/layouts/Default.astro
 pubDate: 2024-05-08
 modDate: 2023-10-04
-title: Octopus Copilot integration
+title: Octopus extension for GitHub Copilot
 description: How to use the Octopus extension for GitHub Copilot
 navOrder: 100
 hideInThisSection: true
@@ -22,7 +22,7 @@ The goal of the Octopus extension is to provide a middle ground between the web 
 
 ## Getting started
 
-Octopus Copilot has 3 prerequisites:
+The Octopus extension has 3 prerequisites:
 
 * An Octopus Cloud instance
 * An API key

--- a/src/pages/docs/administration/copilot/index.md
+++ b/src/pages/docs/administration/copilot/index.md
@@ -3,7 +3,7 @@ layout: src/layouts/Default.astro
 pubDate: 2024-05-08
 modDate: 2023-10-04
 title: Octopus Copilot integration
-description: How to use the Octopus Copilot integration
+description: How to use the Octopus extension for GitHub Copilot
 navOrder: 100
 hideInThisSection: true
 navSearch: false
@@ -12,13 +12,13 @@ navMenu: false
 robots: noindex, follow
 ---
 
-The Octopus Copilot integration allows read only queries of cloud Octopus instances via GitHub Copilot.
+The Octopus extension for GitHub Copilot allows read only queries of cloud Octopus instances via GitHub Copilot.
 
 :::div{.warning}
-Octopus Copilot is an experiment. It is not covered by service level agreements.
+The Octopus extension is an experiment. It is not covered by service level agreements.
 :::
 
-The goal of Octopus Copilot is to provide a middle ground between the web based UI and the REST API. Prior to Octopus Copilot, tasks that can not be performed via the web UI could only be achieved through custom scripts that interacted with the REST API. Working with the REST API requires a good understanding of the Octopus domain model and the ability to write custom code. Octopus Copilot provides the ability to query the configuration and state of an Octopus instance via natural language prompts.
+The goal of the Octopus extension is to provide a middle ground between the web based UI and the REST API. Prior to the Octopus extension, tasks that can not be performed via the web UI could only be achieved through custom scripts that interacted with the REST API. Working with the REST API requires a good understanding of the Octopus domain model and the ability to write custom code. The Octopus extension provides the ability to query the configuration and state of an Octopus instance via natural language prompts.
 
 ## Getting started
 
@@ -29,12 +29,12 @@ Octopus Copilot has 3 prerequisites:
 * A GitHub Copilot account
 
 ### Creating an Octopus cloud instance
-Octopus Copilot is available for cloud Octopus instances. Click [here](https://octopus.com/start) to sign up for a trial cloud Octopus instance.
+The Octopus extension is available for cloud Octopus instances. Click [here](https://octopus.com/start) to sign up for a trial cloud Octopus instance.
 
 ### Creating the Octopus API key
-Octopus Copilot requires an [API key](/docs/octopus-rest-api/how-to-create-an-api-key) to interact with the Octopus server.
+The Octopus extension requires an [API key](/docs/octopus-rest-api/how-to-create-an-api-key) to interact with the Octopus server.
 
-Octopus Copilot only requires read access to the Octopus instance. It is recommended that you create a [service account](/docs/security/users-and-teams/service-accounts) that belongs to a team with read-only permissions. The documentation [here](https://github.com/OctopusSolutionsEngineering/OctopusCopilot?tab=readme-ov-file#creating-a-service-account) provides a sample Terraform module to create a read-only role, a team referencing the role, and a service account belonging to the team.
+The Octopus extension only requires read access to the Octopus instance. It is recommended that you create a [service account](/docs/security/users-and-teams/service-accounts) that belongs to a team with read-only permissions. The documentation [here](https://github.com/OctopusSolutionsEngineering/OctopusCopilot?tab=readme-ov-file#creating-a-service-account) provides a sample Terraform module to create a read-only role, a team referencing the role, and a service account belonging to the team.
 
 ### Creating a GitHub Copilot account
 
@@ -44,21 +44,21 @@ You can also use the web based interface without GitHub Copilot. See the section
 
 ## Querying Octopus with Copilot
 
-Queries directed to `@octopus-ai-app` in the GitHub Copilot chat window are answered by Octopus Copilot. For example, the following query displays the dashboard of the `Default` space:
+Queries directed to `@octopus-ai-app` in the GitHub Copilot chat window are answered by the Octopus extension. For example, the following query displays the dashboard of the `Default` space:
 
 ```
 @octopus-ai-app Show the dashboard for the "Default" space
 ```
 
-The first request to Octopus Copilot will prompt you to complete a login with the following response:
+The first request to the Octopus extension will prompt you to complete a login with the following response:
 
 ```
 To continue chatting please log in
 ```
 
-Click the `log in` link to open the Octopus Copilot login page. You will first be required to log in via GitHub. You must use the same GitHub credentials as the user logged into the GitHub Copilot chat. You are then prompted to enter the URL and API key of your Octopus instance:
+Click the `log in` link to open the Octopus extension login page. You will first be required to log in via GitHub. You must use the same GitHub credentials as the user logged into the GitHub Copilot chat. You are then prompted to enter the URL and API key of your Octopus instance:
 
-![Octopus Copilot Login Page](/docs/administration/copilot/octopus-copilot-login.png)
+![The Octopus extension login page](/docs/administration/copilot/octopus-copilot-login.png)
 
 Click the `Submit` button to save your Octopus details. You can then return to the Copilot chat.
 
@@ -72,7 +72,7 @@ A [test website](https://aiagent.octopus.com/api/form) allows you to query Octop
 
 Queries entered into the test website do not need to mention `@octopus-ai-app`.
 
-![Octopus Copilot web interface](/docs/administration/copilot/octopus-copilot-web.png)
+![The Octopus extension web interface](/docs/administration/copilot/octopus-copilot-web.png)
 
 ## Saving default values
 
@@ -94,13 +94,13 @@ Default values can be cleared with the prompt `@octopus-ai-app Remove default va
 
 ## Example queries
 
-The following are example queries you can use to test Octopus Copilot:
+The following are example queries you can use to test the Octopus extension:
 
-* `@octopus-ai-app What projects exist in the "Default" space?`
-* `@octopus-ai-app Show the last lines from the latest deployment of "Octopus Copilot Function" to the "Production" environment in the "Default" space in a markdown code block.`
-* `@octopus-ai-app Show the step names from the "Octopus Copilot Function" project in the "Octopus Copilot" space`
+* `@octopus-ai-app What projects exist in the "Target - Kubernetes" space?`
+* `@octopus-ai-app Show the last lines from the latest deployment of "Web App" to the "Production" environment in the "Target - Kubernetes" space in a markdown code block.`
+* `@octopus-ai-app Show the step names from the "Web App" project in the "Target - Kubernetes" space`
 * `@octopus-ai-app How do I use the server side apply feature?`
-* `@octopus-ai-app Find the deployments created after 2024-04-16T00:00:00+10:00 and before 2024-04-17T00:00:00+10:00 for the "Octopus Copilot Function" project in the "Octopus Copilot" space to the "Production" environment. Then find the average deployment duration.`
+* `@octopus-ai-app Find the deployments created after 2024-04-16T00:00:00+10:00 and before 2024-04-17T00:00:00+10:00 for the "Web App" project in the "Target - Kubernetes" space to the "Production" environment. Then find the average deployment duration.`
 
 
 ## Prompt engineering tips
@@ -109,6 +109,6 @@ The following are example queries you can use to test Octopus Copilot:
 
 ## Source code
 
-The Octopus Copilot source code can be found on [GitHub](https://github.com/OctopusSolutionsEngineering/OctopusCopilot).
+The Octopus extension source code can be found on [GitHub](https://github.com/OctopusSolutionsEngineering/OctopusCopilot).
 
-Octopus Copilot generates much of the prompt context using the Octoterra application. The source code for Octoterra is found on [GitHub](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport/actions).
+The Octopus extension generates much of the prompt context using the Octoterra application. The source code for Octoterra is found on [GitHub](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport/actions).

--- a/src/pages/docs/administration/copilot/index.md
+++ b/src/pages/docs/administration/copilot/index.md
@@ -86,9 +86,9 @@ Users will often have a specific project, environment, space, tenant, and channe
 
 With default values set, you can enter a query like `@octopus-ai-app Show me the state of the latest deployment` and the query will return the details of the latest deployment for the project `My Project` to the environment `My Environment` with the channel `My Channel` and tenant `My Tenant` in the space `My Space`. 
 
-This is equivalent to the prompt `octopus-copilot Show me the state of the latest deployment of the project "My Project" to the environment "My Environment" for the channel "My Channel" and tenant "My Tenant" in the space "My Space"`.
+This is equivalent to the prompt `@octopus-ai-app Show me the state of the latest deployment of the project "My Project" to the environment "My Environment" for the channel "My Channel" and tenant "My Tenant" in the space "My Space"`.
 
-Resource names included in a prompt override the defaults. So the query `octopus-copilot Show me the state of the latest deployment of the project "My Web App"` will show the details of the project `My Web App` and ignore the default project name.
+Resource names included in a prompt override the defaults. So the query `@octopus-ai-app Show me the state of the latest deployment of the project "My Web App"` will show the details of the project `My Web App` and ignore the default project name.
 
 Default values can be cleared with the prompt `@octopus-ai-app Remove default values`.
 


### PR DESCRIPTION
GitHub has naming conventions that describe how to refer to the copilot extension. This PR updates the documentation to follow those conventions.