### PR TITLE
Give the branch validation and deployment pipeline steps clear names

### DIFF
--- a/.github/workflows/branch-validation.yml
+++ b/.github/workflows/branch-validation.yml
@@ -9,7 +9,7 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  branch_tests:
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/build-astro.yml
+++ b/.github/workflows/build-astro.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  build_and_deploy:
     runs-on: ubuntu-latest
 
     env:

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
         "pnpm-lock.yaml",
         "docs/credits.md",
         ".octopus/**",
+        ".github/**",
         "src/pages/report/**",
         "public/docs/js/**",
         "node_modules/**",


### PR DESCRIPTION
This is a pre-requisite for the branch protection rule fix.