### PR TITLE
Just warn for PNPM mismatch

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # Expose Astro dependencies for `pnpm` users
 shamefully-hoist=true
+package-manager-strict=false


### PR DESCRIPTION
Instead of faulting out, just warn users when their PNPM version is incorrect. This is especially useful if you're ahead of the specified version.