### PR TITLE
Mention the "Needs Approval" tab for manual intervention.

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -122,6 +122,7 @@ itemprop
 itemscope
 itemtype
 ITSM
+jjones
 jwks
 keyrings
 keyserver

--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -122,7 +122,6 @@ itemprop
 itemscope
 itemtype
 ITSM
-jjones
 jwks
 keyrings
 keyserver

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -52,6 +52,8 @@ When the interruption has been assigned to you, you can then perform the action 
 
 When aborting a deployment, it's a good idea to write a reason into the **Notes** field, so that the rest of the team can see why the deployment was aborted.
 
+The tasks page, under the "Needs Approval" tab, contains a list of deployments pending manual intervention. In addition to the deployment page, you can also assign, approve, and abort deployments from this page.
+
 ## Output variables
 
 When a manual step is completed, details of the interruption are saved as variables that can be used in other steps including [email](/docs/projects/built-in-step-templates/email-notifications) templates.

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -52,7 +52,7 @@ When the interruption has been assigned to you, you can then perform the action 
 
 When aborting a deployment, it's a good idea to write a reason into the **Notes** field, so that the rest of the team can see why the deployment was aborted.
 
-The tasks page, under the "Needs Approval" tab, contains a list of deployments pending manual intervention. In addition to the deployment page, you can also assign, approve, and abort deployments from this page.
+The tasks page, under the "Needs Approval" tab, contains a list of deployments pending manual intervention. In addition to the deployment page, you can **Assign**, **Proceed**, and **Abort** deployments from this list.
 
 ## Output variables
 

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -65,7 +65,7 @@ When a manual step is completed, details of the interruption are saved as variab
 | `Octopus.Action[Step Name].Output.Manual.Notes` | The contents of the *Notes* field from the interruption form | *Checked with Rick, got the all-clear; Michelle is out at a meeting.* |
 | `Octopus.Action[Step Name].Output.Manual.Approved` | Indicates if the step was approved | *True*
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.Id` | The user ID of the user who submitted the interruption form | *users-237* |
-| `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.Username` | The username of the user who submitted the interruption form | *jjones* |
+| `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.Username` | The username of the user who submitted the interruption form | *j_jones* |
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.DisplayName` | The display name of the user who submitted the interruption form | *Jamie Jones* |
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.EmailAddress` | The email address of the user who submitted the interruption form | *jamie.jones@example.com* |
 

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2024-06-11
 title: Manual intervention and approval step
 description: Manual intervention and approvals allow a human to review, approve, or sign off on deployments.
 navOrder: 20


### PR DESCRIPTION
Included a small paragraph to mention the "Needs Approval" tab on the task page for managing deployment pending manual intervention.

![Screenshot 2024-06-11 at 2 18 01 pm](https://github.com/OctopusDeploy/docs/assets/87625140/ba0c2c97-dbe0-49e6-b690-cadf8dbed2ee)
