### PR TITLE
Add a 2024.2 section for HA Cluster support

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/ha-cluster-support.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/ha-cluster-support.md
@@ -27,20 +27,20 @@ Once these values are provided the generated helm upgrade command will configure
 
 ### Octopus Deploy 2024.2
 
-To install the Agent with Octopus Deploy 2024.2 you need to adjust the helm command produced by the wizard before running it.
+To install the agent with Octopus Deploy 2024.2 you need to adjust the Helm command produced by the wizard before running it.
 
-1. Use the wizard to produce the helm command to install the agent.
+1. Use the wizard to produce the Helm command to install the agent.
    1. You may need to provide a ServerCommsAddress: you can just provide any valid URL to progress the wizard.
 2. Replace the `--set agent.serverCommsAddress="..."` property with
 ```
---set agent.serverCommsAddresses="{https://<url>:<port>/,https://<url>:<port>/,https://<url>:<port>/}"
+--set agent.serverCommsAddresses="{https://<url1>:<port1>/,https://<url2>:<port2>/,https://<url3>:<port3>/}"
 ```
 where each `<url>:<port>` is a unique address for an individual node.
 
-3. Run the command as normal.
+3. Execute the Helm command in a terminal connected to the target cluster.
 
 :::div{.warning}
-Note: The new property name is `agent.serverCommsAddresses` ("Addresses" is plural!).
+The new property name is `agent.serverCommsAddresses`. Note that "Addresses" is plural.
 :::
 
 ## Upgrading the Agent after Adding/Removing Cluster nodes

--- a/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/ha-cluster-support.md
+++ b/src/pages/docs/infrastructure/deployment-targets/kubernetes/kubernetes-agent/ha-cluster-support.md
@@ -15,6 +15,8 @@ To read more about selecting the right URL for your nodes, see [Polling Tentacle
 
 ## Agent Installation on an HA Cluster
 
+### Octopus Deploy 2024.3+
+
 To make things easier, Octopus will detect when it's running HA and show an extra configuration page in the Kubernetes agent creation wizard which asks you to give a unique URL for each cluster node.
 
 :::figure
@@ -22,6 +24,24 @@ To make things easier, Octopus will detect when it's running HA and show an extr
 :::
 
 Once these values are provided the generated helm upgrade command will configure your new agent to receive commands from all nodes.
+
+### Octopus Deploy 2024.2
+
+To install the Agent with Octopus Deploy 2024.2 you need to adjust the helm command produced by the wizard before running it.
+
+1. Use the wizard to produce the helm command to install the agent.
+   1. You may need to provide a ServerCommsAddress: you can just provide any valid URL to progress the wizard.
+2. Replace the `--set agent.serverCommsAddress="..."` property with
+```
+--set agent.serverCommsAddresses="{https://<url>:<port>/,https://<url>:<port>/,https://<url>:<port>/}"
+```
+where each `<url>:<port>` is a unique address for an individual node.
+
+3. Run the command as normal.
+
+:::div{.warning}
+Note: The new property name is `agent.serverCommsAddresses` ("Addresses" is plural!).
+:::
 
 ## Upgrading the Agent after Adding/Removing Cluster nodes
 


### PR DESCRIPTION
I realised that we don't have a section for 2024.2 users as we only talk about the UI option for installation. I've added the 2024.2 section to show how users would update the helm command to add HA support to their agent.

<img width="864" alt="Screenshot 2024-06-18 at 08 33 49" src="https://github.com/OctopusDeploy/docs/assets/97430840/cd3f2fc7-4fe0-4314-beb4-dd479beac6ed">
