### PR TITLE
Update deployment-process-as-code.md

### DIFF
--- a/src/pages/docs/deployments/patterns/deployment-process-as-code.md
+++ b/src/pages/docs/deployments/patterns/deployment-process-as-code.md
@@ -9,7 +9,7 @@ navOrder: 70
 
 :::div{.hint}
 **Looking for Configuration as Code?**
-This section looks at storing your deployment process as code **without** using the [Configuration as Code (Early Access)](/docs/projects/version-control) feature.
+This section looks at storing your deployment process as code **without** using the [Configuration as Code](/docs/projects/version-control) feature.
 :::
 
 With Octopus you can manage your deployment process as code. This means you can define your deployment process, scripts, and variables in source code. You can store this configuration in the same source control repository as your application source code, or somewhere else.


### PR DESCRIPTION
Removing mention of 'early access' in relation to CaC as suggested by [Chris Fraser here](https://octopusdeploy.slack.com/archives/C03UDS16R6G/p1719587891413759)