### PR TITLE
Update troubleshooting-tentacles.md

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -386,6 +386,7 @@ websockets
 WEBSVR
 WFLYUT
 Wildfly
+Wireshark
 WIXUI
 workerpool
 workerpools

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting-tentacles.md
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting-tentacles.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-07-19
+modDate: 2024-07-29
 title: Troubleshooting Tentacles
 description: How to troubleshoot problems with Octopus Tentacles.
 navOrder: 60

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting-tentacles.md
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting-tentacles.md
@@ -262,3 +262,7 @@ Server-side:`System.IO.IOException: Unable to read data from the transport conne
 **Halibut.Transport.Protocol.ConnectionInitializationFailedException: Unable to process remote identity; unknown identity 'HTTP/1.0'**
 
 If a Tentacle health-check fails with an error message containing this error message, then there is network infrastructure inserting a web page into the communication.  The most common components to do this are firewalls and proxy servers so it's recommend to check your network setup to verify connectivity between the two servers using the information above and then update your infrastructure appropriately.
+
+**Halibut.HalibutClientException: An error occurred when sending a request to 'https://my-tentacle:10933', before the request could begin: Attempted to read past the end of the stream.**
+
+If your Octopus server certificate was [generated with SHA1](/docs/security/cve/shattered-and-octopus-deploy) then you might get this error when connecting to modern Linux distributions, as the default security configuration now rejects communication using SHA1. To regenerate your Octopus server certificate, follow the documentation [How to regenerate certificates with Octopus Server and Tentacle](/docs/security/octopus-tentacle-communication/regenerate-certificates-with-octopus-server-and-tentacle).


### PR DESCRIPTION
Added note in 'Other error messages' section about SHA1 Octopus server certificates causing communication issues with modern Linux distros.