### PR TITLE
Add redirect to fix broken link from overview page

### DIFF
--- a/src/pages/docs/kubernetes/tutorials/first-kubernetes-deployment.md
+++ b/src/pages/docs/kubernetes/tutorials/first-kubernetes-deployment.md
@@ -1,0 +1,9 @@
+---
+layout: src/layouts/Redirect.astro
+title: Redirect
+redirect: /docs/kubernetes/tutorials
+pubDate:  2024-08-06
+navSearch: false
+navSitemap: false
+navMenu: false
+---


### PR DESCRIPTION
Some of the new sections under `/Kubernetes` don't have overview pages; but the section heading needs an `index.md` page for the title + position metadata. So we ended up making the first page in the section the index page.

But, that changes the page URL to be that of the section, not the page:

`/Kubernetes/tutorials/first-kubernetes-deployment.md` -> `/Kubernetes/tutorials/index.md`
URL is now `/docs/kubernetes/tutorials`

But, we want to keep using the _correct_ link in our emails and other places, so they still work if we later decide to implement an overview page. 