### PR TITLE
Fix typo in redirect

### DIFF
--- a/src/pages/docs/deployment-patterns/rolling-deployments/index.md
+++ b/src/pages/docs/deployment-patterns/rolling-deployments/index.md
@@ -1,7 +1,7 @@
 ﻿---
 layout: src/layouts/Redirect.astro
 title: Redirect
-redirect: hhttps://octopus.com/devops/software-deployments/rolling-deployment/
+redirect: https://octopus.com/devops/software-deployments/rolling-deployment/
 pubDate:  2023-01-01
 modDate: 2024-08-13
 navSearch: false


### PR DESCRIPTION
Double-h in `https` is causing an error.