### PR TITLE
Update octopus create release docs

### DIFF
--- a/src/pages/docs/octopus-rest-api/cli/octopus-release-create.mdx
+++ b/src/pages/docs/octopus-rest-api/cli/octopus-release-create.mdx
@@ -26,7 +26,7 @@ Flags:
   -x, --ignore-existing             If a release with the same version exists, do nothing instead of failing.
       --ignore-channel-rules        Allow creation of a release where channel rules would otherwise prevent it.
       --package stringArray         Version specification a specific packages.
-                                    Format as {package}:{version}, {step}:{version} or {package-ref-name}:{packageOrStep}:{version}
+                                    Format as {package}:{version}, {step}:{version} or {packageOrStep}:{package-ref-name}:{version}
                                     You may specify this multiple times
 
 
@@ -46,6 +46,7 @@ Global Flags:
 $ octopus release create --project MyProject --channel Beta --version 1.2.3
 $ octopus release create -p MyProject -c Beta -v 1.2.3
 $ octopus release create -p MyProject -c default --package "utils:1.2.3" --package "utils:InstallOnly:5.6.7"
+$ octopus release create -p MyProject -c default --package "utils:1.2.3" --package "Run a Script:app_package_ref:1.1.1"
 $ octopus release create -p MyProject -c Beta --no-prompt
 
 


### PR DESCRIPTION
When testing creating releases for maven packages I ran into an issue where the default version was being used, not the specified version. It turns out the Step name should be the first section of the `{packageOrStep}:{package-ref-name}:{version}` format, not the package ref name. e.g.

`octopus release create --project "Maven Script" --package "Run a Script:begin_beginai:1.1.1" --space "Another One" --no-prompt verbose`

