### PR TITLE
added version warning for bento migrations

### DIFF
--- a/src/pages/docs/projects/export-import/index.mdx
+++ b/src/pages/docs/projects/export-import/index.mdx
@@ -16,6 +16,10 @@ The Export/Import Projects feature was added in Octopus Deploy **2021.1**
 **Version-controlled projects are not currently supported**
 :::
 
+:::div{.warning}
+Migrations can only be performed from an earlier or equal version of Octopus Server. It cannot be used to migrate resources to an older version.
+:::
+
 The `Export/Import Projects` feature can export one or more projects into a zip file, which can then be imported into other spaces.  The target space may be in a different Octopus Server instance, and projects can be exported and imported between self-hosted and Octopus Cloud instances (see below for some [specific considerations when moving a project to Octopus Cloud](#octopus-cloud)). 
 
 Export/Import features are found in the overflow menu on the **Projects** page. 
@@ -39,7 +43,7 @@ The export runs as a task. Once the task is complete, the export zip file is att
 ## Scenarios
 
 The current implementation of the Export/Import feature was designed for moving a project between spaces, specifically:
-- Moving from a self-hosted instance to an Octopus Cloud instance (or vice-versa)
+- Moving from a self-hosted instance to an Octopus Cloud instance
 - Splitting a space containing many projects into multiple spaces
 
 Scenarios this feature was _not_ designed for include:


### PR DESCRIPTION
Added warning around version support for bento migrations.
Due to the nature of GA being 1 version behind Cloud, migration from cloud to self hosted is not practically supported.