### PR TITLE
Adding blog post reference in storage class section for the agent.

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/storage.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/storage.md
@@ -56,6 +56,10 @@ Many managed Kubernetes offerings will provide storage that require little effor
 |[Elastic Kubernetes Service (EKS)](https://docs.aws.amazon.com/eks/latest/userguide/storage.html)  |`efs.csi.aws.com`                  |`efs-sc`                            |
 |[Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/docs/concepts/storage-overview)    |`filestore.csi.storage.gke.io`     |`standard-rwx`                      |
 
+:::div{.info}
+See this [blog post](https://octopus.com/blog/efs-eks) for a tutorial on connecing EFS to and EKS cluster.
+:::
+
 If you manage your own cluster and don’t have offerings from cloud providers available, there are some in-cluster options you could explore:
 - [Longhorn](https://longhorn.io/)
 - [Rook (CephFS)](https://rook.io/)


### PR DESCRIPTION
While AWS documentation is great if you know what you're looking for, it can be a bit tedious to work with when you need to connect multiple services together.  The blog post was written to help others by consolidating the information needed to connect EFS to EKS in a single location rather than having to scour the Internet.  Blogs are great when they're published, but tend to slip into obscurity over time.  This update links the post to the storage class section for the agent for those who encounter difficulties setting it up.