### PR TITLE
Minor language cleanup for custom Octopus Server certificates with K8s Agent

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -215,7 +215,7 @@ Certificate subject name: CN=octopus.corp.domain
 Certificate thumbprint:   42983C1D517D597B74CDF23F054BBC106F4BB32F
 ```
 
-To resolve this, you need to provide the Kubernetes agent with a base64-encoded string of the public key of the certificate in either `.pem` or `.crt` format. When viewed as text, this will look similar to this:
+To resolve this, you need to provide the Kubernetes agent with a base64-encoded string of the public key of the either the self-signed certificate or root organization CA certificate in either `.pem` or `.crt` format. When viewed as text, this will look similar to this:
 
 ```
 -----BEGIN CERTIFICATE-----

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -215,7 +215,7 @@ Certificate subject name: CN=octopus.corp.domain
 Certificate thumbprint:   42983C1D517D597B74CDF23F054BBC106F4BB32F
 ```
 
-To resolve this, you need to provide the Kubernetes agent with a base64-encoded string of the public key of the either the self-signed certificate or root organization CA certificate in either `.pem` or `.crt` format. When viewed as text, this will look similar to this:
+To resolve this, you need to provide the Kubernetes agent with a base64-encoded string of the public key of either the self-signed certificate or root organization CA certificate in either `.pem` or `.crt` format. When viewed as text, this will look similar to this:
 
 ```
 -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Make it clearer that it's the public key of the root organization CA certificate