### PR TITLE
Update OIDC Other Issuers doc

### DIFF
--- a/src/pages/docs/octopus-rest-api/openid-connect/other-issuers.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/other-issuers.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-09-27
-modDate: 2023-09-27
+modDate: 2024-09-16
 title: Using OpenID Connect in Octopus with other issuers
 description: How to use OpenID Connect to interact with Octopus using other issuers
 navOrder: 30
@@ -27,10 +27,6 @@ The first step is to create an OIDC identity for your issuer to access the Octop
    2. The URL should be the base where the OIDC Discovery endpoint (`/.well-known/openid-configuration`) endpoint can be found. For example if the discovery endpoint is `https://my-oidc-issuer.com/.well-known/openid-configuration` then the issuer should be set to `https://my-oidc-issuer.com`.
 6. Enter the subject of the identity. This must match the subject that is provided in the OIDC token and is _case-sensitive_, wildcards for matching multiple characters `*` and single characters `?` can be used. The format of the subject will differ by issuer, please consult your OIDC issuers documentation.
 7. Click Save.
-
-:::div{.hint}
-Support for wildcards when matching a subject is available from Octopus 2024.1. To match multiple characters in a subject use `*`, and to match a single character use `?`.
-:::
 
 :::div{.hint}
 Multiple OIDC identities can be added for a service account.
@@ -113,3 +109,7 @@ To use the access token as authentication for a request to the Octopus API, it m
 ```
 Authorization: Bearer {the-access-token-obtained-from-octopus}
 ```
+
+## Older Versions
+
+- Support for wildcards when matching a subject was added in Octopus 2024.1.


### PR DESCRIPTION
### Following the new docs guidelines we have:
- Moved version information to the bottom of the page
- Updated an image linked to by this doc in [a previous PR](https://github.com/OctopusDeploy/docs/pull/2488)

### What's it look like?
<img width="695" alt="image" src="https://github.com/user-attachments/assets/c580aa34-e30a-417c-939b-a4de6dc1bb8e">
<img width="728" alt="image" src="https://github.com/user-attachments/assets/d91faf3c-6fa0-4d82-95ad-922480737580">
