### PR TITLE
Add icons for Open ID Connect pages

### DIFF
--- a/src/pages/docs/octopus-rest-api/openid-connect/github-actions.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/github-actions.md
@@ -4,6 +4,7 @@ pubDate: 2023-09-27
 modDate: 2024-09-16
 title: Using OpenID Connect with Octopus and GitHub Actions
 description: How to use OpenID Connect to interact with Octopus in GitHub Actions
+icon: fa-brands fa-openid
 navOrder: 30
 hideInThisSection: true
 ---

--- a/src/pages/docs/octopus-rest-api/openid-connect/index.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/index.md
@@ -4,6 +4,7 @@ pubDate: 2023-09-27
 modDate: 2024-09-16
 title: Using OpenID Connect with the Octopus API
 description: External systems can use OpenID Connect with service accounts to access the Octopus API without needing to provision API keys
+icon: fa-brands fa-openid
 navOrder: 30
 hideInThisSection: true
 ---

--- a/src/pages/docs/octopus-rest-api/openid-connect/other-issuers.md
+++ b/src/pages/docs/octopus-rest-api/openid-connect/other-issuers.md
@@ -4,6 +4,7 @@ pubDate: 2023-09-27
 modDate: 2024-09-16
 title: Using OpenID Connect in Octopus with other issuers
 description: How to use OpenID Connect to interact with Octopus using other issuers
+icon: fa-brands fa-openid
 navOrder: 30
 hideInThisSection: true
 ---


### PR DESCRIPTION
This PR adds the `openid` icon to the Open ID Connect pages.

![image](https://github.com/user-attachments/assets/6577ebc2-14f4-4f05-b383-bb7cbd4d4ac5)
