### PR TITLE
Add icon to OCL syntax page

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -91,6 +91,7 @@ dpkg
 dryrun
 Dspring
 DWORD
+EBNF
 echoerror
 elbv2
 elif

--- a/src/pages/docs/projects/version-control/ocl-file-format.md
+++ b/src/pages/docs/projects/version-control/ocl-file-format.md
@@ -4,6 +4,7 @@ pubDate: 2023-01-01
 modDate: 2023-01-01
 title: OCL Syntax for Config as Code
 description: A description of Octopus Deploy's OCL file format.
+icon: fa-solid fa-code
 navOrder: 70
 ---
 


### PR DESCRIPTION
This PR adds a code icon to the OCL syntax, no other changes are needed in terms of updated screenshots.

![image](https://github.com/user-attachments/assets/038537b1-ebae-4e52-a40c-9db2755d7757)
