### PR TITLE
Add icon to moving version control page

### DIFF
--- a/src/pages/docs/projects/version-control/moving-version-control.md
+++ b/src/pages/docs/projects/version-control/moving-version-control.md
@@ -3,7 +3,8 @@ layout: src/layouts/Default.astro
 pubDate: 2023-01-01
 modDate: 2023-01-01
 title: Moving version control
-description: Changing the location of your configuration repository. 
+description: Changing the location of your configuration repository.
+icon: fa-brands fa-git-alt 
 navOrder: 60
 ---
 


### PR DESCRIPTION
This PR adds an icon to the Moving Version Control page

![image](https://github.com/user-attachments/assets/28a02e8e-ecff-4a42-9638-ab72b52a7193)
