### PR TITLE
Change cli link to github releases page.

### DIFF
--- a/src/pages/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/install-octopus-cli-capability.md
+++ b/src/pages/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/install-octopus-cli-capability.md
@@ -95,7 +95,7 @@ Self-hosted agents are available for Linux, macOS, or Windows. They may also be 
 - [Windows agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-windows) (x64, x86)
 - [Docker agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker)
 
-A self-hosted agent must be configured to include the Octopus CLI before using it in a pipeline. Binaries and/or packages for the Octopus CLI can be downloaded from the [Octopus CLI downloads](https://octopus.com/downloads/octopuscli) page.
+A self-hosted agent must be configured to include the Octopus CLI before using it in a pipeline. Binaries and/or packages for the Octopus CLI can be downloaded from the [Octopus CLI downloads](https://github.com/OctopusDeploy/OctopusCLI/releases) page.
 
 :::div{.warning}
 **Breaking Change in Version 5**

--- a/src/pages/docs/packaging-applications/create-packages/octopus-cli.md
+++ b/src/pages/docs/packaging-applications/create-packages/octopus-cli.md
@@ -11,7 +11,7 @@ The Octopus CLI (`octo`) is a command line tool that interacts with the [Octopus
 
 ## Installation
 
-The [Octopus CLI downloads page](https://octopus.com/downloads/octopuscli) provides installation options for various platforms.
+The [Octopus CLI downloads page](https://github.com/OctopusDeploy/OctopusCLI/releases) provides installation options for various platforms.
 
 After installation, you can run the following to verify the version of the Octopus CLI that was installed (if you're using Windows, remember to open a new command prompt):
 

--- a/src/pages/docs/packaging-applications/create-packages/octopus-cli.md
+++ b/src/pages/docs/packaging-applications/create-packages/octopus-cli.md
@@ -6,7 +6,7 @@ title: Create packages with the Octopus CLI
 description: Using the Octopus CLI (octo) command line tool to create packages for deployment.
 navOrder: 30
 ---
-
+# spell-checker:ignore Myatt's, PKWARE, Packagingyourapplicationfromafolder
 The Octopus CLI (`octo`) is a command line tool that interacts with the [Octopus Deploy REST API](/docs/octopus-rest-api/) and includes a [pack](/docs/octopus-rest-api/octopus-cli/pack) command to create packages either as [Zip](#create-zip-packages) or [NuGet](#create-nuget-packages) packages for deployment with Octopus.
 
 ## Installation


### PR DESCRIPTION
There are old links to the downloads page on octopus.com which is an out of date page and a source of confusion for customers.

Fix these links to direct users to the github releases page for that same cli tool (the deprecated one).