### PR TITLE
Header icons fix

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -1508,8 +1508,16 @@ li.has-children .sub-nav ul li:focus > a {
   background: transparent;
 }
 
-.header__icon.fa-octopus:before {
-  padding-inline-end: 0;
+.header__icon {
+  &.fa-octopus,
+  &.fa-twitter,
+  &.fa-linkedin,
+  &.fa-github,
+  &.fa-youtube {
+    &:before {
+      padding-inline-end: 0;
+    }
+  }
 }
 
 .header__text {


### PR DESCRIPTION
There was an issue with Github icon being pushed to the side.

Task: https://octopus-deploy-team.monday.com/boards/7162465638/pulses/7435936809

Fixed:
<img width="112" alt="Screenshot 2024-09-17 at 15 15 54" src="https://github.com/user-attachments/assets/8c686530-5c24-4809-a96e-d150d3077ad3">
