### PR TITLE
Fix the formatting in the Kubernetes Agent version requirements table

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -74,7 +74,6 @@ The Kubernetes agent follows [semantic versioning](https://semver.org/), so a ma
 | Kubernetes agent | Octopus Server           | Kubernetes cluster   |
 | ---------------- | ------------------------ | -------------------- |
 | 1.\*.\*          | **2024.2.6580** or newer | **1.26** to **1.29** |
-| ---------------- | ------------------------ | -------------------- |
 | 2.\*.\*          | **2024.2.9396** or newer | **1.26** to **1.29** |
 
 Additionally, the Kubernetes agent only supports **Linux AMD64** and **Linux ARM64** Kubernetes nodes.

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/sha1-certificate-incompatibility.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/sha1-certificate-incompatibility.md
@@ -8,7 +8,7 @@ navOrder: 71
 ---
 
 ## Background
-[Since 2017](../../../../security/cve/shattered-and-octopus-deploy#detecting-sha1-certificates-with-powershell), Octopus Server no longer supports SHA1 certificates due to their inherent security vulnerabilities. SHA1 is an outdated cryptographic hash algorithm that has been replaced by the more secure SHA256 standard, in line with industry best practices.
+[Since 2017](../../../../security/cve/shattered-and-octopus-deploy), Octopus Server no longer supports SHA1 certificates due to their inherent security vulnerabilities. SHA1 is an outdated cryptographic hash algorithm that has been replaced by the more secure SHA256 standard, in line with industry best practices.
 
 
 ## Compatibility Issue: SHA1 on Windows Server 2012 R2


### PR DESCRIPTION
- Fixed the markdown code for rendering the table
- PR also includes an unrelated small hyperlink adjustment

## Before
<img width="657" alt="Screenshot 2024-09-18 at 2 45 51 pm" src="https://github.com/user-attachments/assets/db59bb88-fc21-4eaf-905d-bffb6d4a4644">

## After
<img width="648" alt="Screenshot 2024-09-18 at 2 48 48 pm" src="https://github.com/user-attachments/assets/cbf13ccb-17ae-408a-a942-dacbfa888b82">
