### PR TITLE
Add icon to GitHub Actions page

### DIFF
--- a/src/pages/docs/packaging-applications/build-servers/github-actions.md
+++ b/src/pages/docs/packaging-applications/build-servers/github-actions.md
@@ -4,6 +4,7 @@ pubDate: 2023-01-01
 modDate: 2024-06-13
 title: GitHub Actions
 description: GitHub Actions can leverage the Octopus CLI to pack, build, push, and create releases for Octopus Deploy.
+icon: fa-brands fa-github
 navOrder: 55
 ---
 


### PR DESCRIPTION
This PR adds the GitHub icon to the GitHub Actions page.

![image](https://github.com/user-attachments/assets/dbca0c4d-4759-4967-b357-dbc9cc9ebf39)
