### PR TITLE
Updating ownership of database deployments to MD

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -253,7 +253,7 @@
 
 # updates to the deployments databases section are reviewed by team-backend-foundations
 
-/docs/deployments/databases/ @OctopusDeploy/team-backend-foundations
+/docs/deployments/databases/ @OctopusDeploy/team-modern-deployments
 
 # updates to the deployments docker section are reviewed by team-modern-deployments
 


### PR DESCRIPTION
Discussed with RobE and NickJ, moving CODEOWNERSHIP of database deployments for docs to Modern Deployments (MD).

https://octopusdeploy.slack.com/archives/C04F5HY8JPJ/p1726800624405499?thread_ts=1726788822.771049&cid=C04F5HY8JPJ

