### PR TITLE
Add new page listing Kubernetes agent container images

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/images.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/images.md
@@ -1,19 +1,104 @@
 ---
 layout: src/layouts/Default.astro
-pubDate: 2024-04-22
-modDate: 2024-08-08
-title: Octopus Kubernetes agent
-navTitle: Overview
-description: How to configure a Kubernetes agent as a deployment target in Octopus
+pubDate: 2024-09-24
+modDate: 2024-09-24
+title: Octopus Kubernetes agent default images
+navTitle: Default images
+description: Details the default container images used by the Kubernetes agent
 navOrder: 80
 ---
 
 The following is a list of the default container images used as part of the Kubernetes agent & worker.
 
-| Image                                                                                                          | Source                                                                   | Helm values path                     | Purpose                                                                                                                                                                                         |
-| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [octopusdeploy/kubernetes-agent-tentacle](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-tentacle)         | [GitHub](https://github.com/OctopusDeploy/OctopusTentacle)               | `.agent.image`                       | The main application container. Provides registration and communication with Octopus Server and manages the script pods.                                                                        |
-| [octopusdeploy/nfs-server](https://hub.docker.com/r/octopusdeploy/nfs-server)                                       | [GitHub](https://github.com/OctopusDeploy/nfs-server-alpine)             | `.persistence.nfs.image`             | A small Alpine-based NFS server. Runs in a separate pod when a custom storage class is not provided.                                                                                            |
-| [octopusdeploy/kubernetes-agent-nfs-watchdog](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-nfs-watchdog) | [GitHub](https://github.com/OctopusDeploy/kubernetes-agent-nfs-watchdog) | `.persistence.nfs.watchdog.image`    | A small application that monitors the health of the NFS mount. Terminates the Tentacle or running script pod if the NFS mount is deemed to be unhealthy. Only runs when the NFS pod is running. |
-| [octopusdeploy/kubernetes-agent-tools-base](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-tools-base)     | [GitHub](https://github.com/OctopusDeploy/kubernetes-agent-tools-base)   | `.scriptPods.deploymentTarget.image` | The default image used for deployments when running as a deployment target. If no values are specified, uses the tag that matches the cluster version.                                          |
-| [octopusdeploy/worker-tools](https://hub.docker.com/r/octopusdeploy/worker-tools)                                   | [GitHub](https://github.com/OctopusDeploy/WorkerTools)                   | `.scriptPods.worker.image`           | The default image used for workloads when running as a worker.                                                                                                                                  |
+**Note**  
+The Helm values paths are based on the `v2` version of the Helm chart.
+
+## octopusdeploy/kubernetes-agent-tentacle
+
+**Default registry**
+
+[Docker Hub](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-tentacle)
+
+**Source code**
+
+[GitHub](https://github.com/OctopusDeploy/OctopusTentacle)
+
+**Helm values path**
+
+`.agent.image`
+
+**Purpose**
+
+The main application container. Provides registration and communication with Octopus Server and manages the script pods.
+
+## octopusdeploy/nfs-server
+
+**Default registry**
+
+[Docker Hub](https://hub.docker.com/r/octopusdeploy/nfs-server)
+
+**Source code**
+
+[GitHub](https://github.com/OctopusDeploy/nfs-server-alpine)
+
+**Helm values path**
+
+`.persistence.nfs.image` 
+
+**Purpose**
+
+A small Alpine-based NFS server. Runs in a separate pod when a custom storage class is not provided.
+
+## octopusdeploy/kubernetes-agent-nfs-watchdog
+
+**Default registry**
+
+[Docker Hub](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-nfs-watchdog)
+
+**Source code**
+
+[GitHub](https://github.com/OctopusDeploy/kubernetes-agent-nfs-watchdog)
+
+**Helm values path**
+
+`.persistence.nfs.watchdog.image`
+
+**Purpose**
+
+A small application that monitors the health of the NFS mount. Terminates the Tentacle or running script pod if the NFS mount is deemed to be unhealthy. Only runs when the NFS pod is running.
+
+## octopusdeploy/kubernetes-agent-tools-base
+
+**Default registry**
+
+[Docker Hub](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-tools-base)
+
+**Source code**
+
+[GitHub](https://github.com/OctopusDeploy/kubernetes-agent-tools-base)
+
+**Helm values path**
+
+`.scriptPods.deploymentTarget.image`
+
+**Purpose**
+
+The default image used for deployments when running as a deployment target. If no values are specified, uses the tag that matches the cluster version.  
+
+## octopusdeploy/worker-tools
+
+**Default registry**
+
+[Docker Hub](https://hub.docker.com/r/octopusdeploy/worker-tools)
+
+**Source code**
+
+[GitHub](https://github.com/OctopusDeploy/WorkerTools)
+
+**Helm values path**
+
+`.scriptPods.worker.image`  
+
+**Purpose**
+
+The default image used for workloads when running as a worker.

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/images.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/images.md
@@ -1,0 +1,19 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2024-04-22
+modDate: 2024-08-08
+title: Octopus Kubernetes agent
+navTitle: Overview
+description: How to configure a Kubernetes agent as a deployment target in Octopus
+navOrder: 80
+---
+
+The following is a list of the default container images used as part of the Kubernetes agent & worker.
+
+| Image                                                                                                          | Source                                                                   | Helm values path                     | Purpose                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [octopusdeploy/kubernetes-agent-tentacle](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-tentacle)         | [GitHub](https://github.com/OctopusDeploy/OctopusTentacle)               | `.agent.image`                       | The main application container. Provides registration and communication with Octopus Server and manages the script pods.                                                                        |
+| [octopusdeploy/nfs-server](https://hub.docker.com/r/octopusdeploy/nfs-server)                                       | [GitHub](https://github.com/OctopusDeploy/nfs-server-alpine)             | `.persistence.nfs.image`             | A small Alpine-based NFS server. Runs in a separate pod when a custom storage class is not provided.                                                                                            |
+| [octopusdeploy/kubernetes-agent-nfs-watchdog](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-nfs-watchdog) | [GitHub](https://github.com/OctopusDeploy/kubernetes-agent-nfs-watchdog) | `.persistence.nfs.watchdog.image`    | A small application that monitors the health of the NFS mount. Terminates the Tentacle or running script pod if the NFS mount is deemed to be unhealthy. Only runs when the NFS pod is running. |
+| [octopusdeploy/kubernetes-agent-tools-base](https://hub.docker.com/r/octopusdeploy/kubernetes-agent-tools-base)     | [GitHub](https://github.com/OctopusDeploy/kubernetes-agent-tools-base)   | `.scriptPods.deploymentTarget.image` | The default image used for deployments when running as a deployment target. If no values are specified, uses the tag that matches the cluster version.                                          |
+| [octopusdeploy/worker-tools](https://hub.docker.com/r/octopusdeploy/worker-tools)                                   | [GitHub](https://github.com/OctopusDeploy/WorkerTools)                   | `.scriptPods.worker.image`           | The default image used for workloads when running as a worker.                                                                                                                                  |


### PR DESCRIPTION
Adds a new page under the Kubernetes agent that lists all the default images, where they and the source code are hosted and also details their purpose.

<img width="259" alt="{868D93DC-BB26-4EFC-8C8C-3F2529826A2F}" src="https://github.com/user-attachments/assets/469118b8-aad9-4b4c-8ff7-2dfe42bdb213">

![image](https://github.com/user-attachments/assets/88631268-1f91-418b-bdb6-379ff163f778)

