### PR TITLE
Add warning for Kubernetes agent naming

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -108,6 +108,12 @@ kubectl config view
 4. Optionally, add the name of an existing [Storage Class](https://kubernetes.io/docs/concepts/storage/storage-classes/) for the agent to use. The storage class must support the ReadWriteMany [access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).  
 If no storage class name is added, the default Network File System (NFS) storage will be used.
 
+:::div{.warning}
+As the display name is used for the Helm release name, this name must be unique for a given cluster. This means that if you have a Kubernetes agent and Kubernetes worker with the same name (e.g. `production`), then they will clash during installation.
+
+If you do want a Kubernetes agent and Kubernetes worker to have the same name, Then prepend the type to the name (e.g. `worker production` and `agent production`) during installation. This will install them with unique Helm release names, avoiding the clash. After installation, the worker & target names can then be changed in the Octopus Server UI to the desired name to remove the prefix.
+:::
+
 #### Advanced options
 
 :::figure

--- a/src/shared-content/tentacle/configure-k8s-worker.include.md
+++ b/src/shared-content/tentacle/configure-k8s-worker.include.md
@@ -24,3 +24,8 @@ kubectl config view
 6. A green 'success' bar will appear when the Helm Chart has completed installation, and the worker has registered with the Octopus Server.
 7. Click the **View Worker** button to display the settings of the created worker, or  **Cancel** to return to the **Add Worker** page
 
+:::div{.warning}
+As the display name is used for the Helm release name, this name must be unique for a given cluster. This means that if you have a Kubernetes agent and Kubernetes worker with the same name (e.g. `production`), then they will clash during installation.
+
+If you do want a Kubernetes agent and Kubernetes worker to have the same name, Then prepend the type to the name (e.g. `worker production` and `agent production`) during installation. This will install them with unique Helm release names, avoiding the clash. After installation, the worker & target names can then be changed in the Octopus Server UI to the desired name to remove the prefix.
+:::


### PR DESCRIPTION
Adding warning callout explaining how to avoid Kubernetes agent & Kubernetes worker naming clashes.

<img width="609" alt="{9D5E8737-5F64-464A-B24E-E37135B75297}" src="https://github.com/user-attachments/assets/a929de79-9a70-4398-b573-f8a2a9300a43">
