### PR TITLE
fix: update upload artifact to deployment script to use byte stream

### DIFF
--- a/src/shared-content/scripts/upload-artifact-to-deployment-scripts.include.md
+++ b/src/shared-content/scripts/upload-artifact-to-deployment-scripts.include.md
@@ -68,19 +68,8 @@ $httpClientHandler = New-Object System.Net.Http.HttpClientHandler
 $httpClient = New-Object System.Net.Http.HttpClient $httpClientHandler
 $httpClient.DefaultRequestHeaders.Add("X-Octopus-ApiKey", $ApiKey)
 
-$packageFileStream = New-Object System.IO.FileStream @($filePathToUpload, [System.IO.FileMode]::Open)
-
-$contentDispositionHeaderValue = New-Object System.Net.Http.Headers.ContentDispositionHeaderValue "form-data"
-$contentDispositionHeaderValue.Name = "fileData"
-$contentDispositionHeaderValue.FileName = [System.IO.Path]::GetFileName($filePathToUpload)
-
-$streamContent = New-Object System.Net.Http.StreamContent $packageFileStream
-$streamContent.Headers.ContentDisposition = $contentDispositionHeaderValue
-$ContentType = "multipart/form-data"
-$streamContent.Headers.ContentType = New-Object System.Net.Http.Headers.MediaTypeHeaderValue $ContentType
-
-$content = New-Object System.Net.Http.MultipartFormDataContent
-$content.Add($streamContent)
+$bytes = Get-Content $filePathToUpload -AsByteStream
+$content = New-Object System.Net.Http.ByteArrayContent -ArgumentList @(,$bytes)
 
 $uploadUrl = "$OctopusUrl/api/$spaceId/artifacts/$artifactId/content"
 Write-Host "Uploading file $filePathToUpload to $uploadUrl"


### PR DESCRIPTION
The script to upload an artifact to an existing deployment prepends extra headers in the file content when uploading to Octopus.

This PR updates the script to use a byte stream instead of streaming as multipart form data. This ensures that the header content is not added to the artifact.

Fixes https://github.com/OctopusDeploy/docs/issues/2399

Tested using [artifact.csv](https://github.com/user-attachments/files/17427805/artifact.csv)

### Before

Running the original script and downloading the artifact from Octopus:

<img width="604" alt="Screenshot 2024-10-18 at 2 05 59 PM" src="https://github.com/user-attachments/assets/ed73d5f6-774e-403d-ac85-0cd1e4d8a4c3">


### After

Running the new script and downloading the artifact from Octopus:

<img width="219" alt="Screenshot 2024-10-18 at 2 06 29 PM" src="https://github.com/user-attachments/assets/3499638f-c32c-4457-adeb-84b60ee6fb05">

