### PR TITLE
Code font is too small for readability

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -119,7 +119,6 @@ pre {
 
 pre code {
   background-color: unset;
-  font-size: var(--font-size-small);
 }
 
 .dark pre {


### PR DESCRIPTION
Fixes the follow up issue on #2129

# Before

![image](https://github.com/user-attachments/assets/8d92472a-d855-40f2-8836-63d78ebfc150)

# After

![image](https://github.com/user-attachments/assets/f39efd6f-d42c-42bb-a9ff-2818f9814836)

