### PR TITLE
Updates references to AES to 256 bit where appropriate

### DIFF
--- a/src/pages/docs/administration/data/backup-and-restore.md
+++ b/src/pages/docs/administration/data/backup-and-restore.md
@@ -18,7 +18,10 @@ A successful disaster recovery plan for Octopus Deploy requires the ability to r
 :::div{.problem}
 
 **Without your Master Key, backups are useless**
-Sensitive information is encrypted using AES-256 with the Master Key as the encryption key. Without this Master Key you will lose your sensitive variables, passwords, and other encrypted data. Make sure you've taken a copy of the key! [Learn more about backing up the Master Key](/docs/security/data-encryption).
+
+Sensitive information is encrypted using AES with the Master Key as the encryption key. Without this Master Key you will lose your sensitive variables, passwords, and other encrypted data. Make sure you've taken a copy of the key! [Learn more about backing up the Master Key](/docs/security/data-encryption).
+
+Octopus Server 2024.4 and newer use AES-256 by default but support AES-128 for compatibility. Previous versions use AES-128.
 
 :::
 

--- a/src/pages/docs/administration/data/backup-and-restore.md
+++ b/src/pages/docs/administration/data/backup-and-restore.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-07-15
+modDate: 2024-11-04
 title: Backup and restore
 description: Information on where Octopus data is stored and how to backup and restore an Octopus instance.
 navOrder: 10

--- a/src/pages/docs/administration/data/backup-and-restore.md
+++ b/src/pages/docs/administration/data/backup-and-restore.md
@@ -18,7 +18,7 @@ A successful disaster recovery plan for Octopus Deploy requires the ability to r
 :::div{.problem}
 
 **Without your Master Key, backups are useless**
-Sensitive information is encrypted using AES128 with the Master Key as the encryption key. Without this Master Key you will lose your sensitive variables, passwords, and other encrypted data. Make sure you've taken a copy of the key! [Learn more about backing up the Master Key](/docs/security/data-encryption).
+Sensitive information is encrypted using AES-256 with the Master Key as the encryption key. Without this Master Key you will lose your sensitive variables, passwords, and other encrypted data. Make sure you've taken a copy of the key! [Learn more about backing up the Master Key](/docs/security/data-encryption).
 
 :::
 
@@ -58,6 +58,6 @@ When connecting to an existing database, you will be prompted for this key durin
 :::div{.problem}
 
 **Without your Master Key, backups are useless**
-Sensitive information is encrypted using AES128 with the Master Key as the encryption key. Without this Master Key you will lose sensitive variables, passwords, and other encrypted data. Make sure you've taken a copy of the key! [Learn more about backing up the Master Key](/docs/security/data-encryption).
+Sensitive information is encrypted using AES-256 with the Master Key as the encryption key. Without this Master Key you will lose sensitive variables, passwords, and other encrypted data. Make sure you've taken a copy of the key! [Learn more about backing up the Master Key](/docs/security/data-encryption).
 
 :::

--- a/src/pages/docs/projects/variables/sensitive-variables.md
+++ b/src/pages/docs/projects/variables/sensitive-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-29
+modDate: 2024-10-04
 title: Sensitive variables
 icon: fa-solid fa-key
 description: Sensitive variables allow you to define secret values used in your applications that can be securely stored in Octopus, or retrieved from a Secret Manager/Key Vault using one of our community step templates.

--- a/src/pages/docs/projects/variables/sensitive-variables.md
+++ b/src/pages/docs/projects/variables/sensitive-variables.md
@@ -13,7 +13,7 @@ As you work with [variables](/docs/projects/variables) in Octopus, there will be
 Sensitive variables can be sourced from either:
 
 - A Secret Manager/Key Vault using one of our Community step templates.
-- Octopus itself, with values stored securely using **AES128 encryption**.
+- Octopus itself, with values stored securely using **AES-256 encryption**.
 
 ## Values from a Secret Manager/Key Vault {#values-from-key-vaults}
 
@@ -70,7 +70,12 @@ For variable type, select **Sensitive**.
 Learn more about [security and encryption](/docs/security/data-encryption) in Octopus Deploy.
 :::
 
-When dealing with sensitive variables, Octopus encrypts these values using **AES128 encryption** any time they are in transmission, or "at rest" like when they are stored in the Octopus database or staged on a deployment target as part of a deployment. You can use these sensitive values in your deployment process just like normal [variables](/docs/projects/variables), with two notable exceptions:
+When dealing with sensitive variables, Octopus encrypts these values using:
+
+- **AES-256** encryption when they are stored in the Octopus database
+- **AES-128 encryption** any time they are in transmission, or when they are stored on a deployment target as part of a deployment. 
+
+You can use these sensitive values in your deployment process just like normal [variables](/docs/projects/variables), with two notable exceptions:
 
 - Once the variable is saved, Octopus will **never allow you to retrieve the value** via the [REST API](/docs/octopus-rest-api) or the Octopus Web Portal; and
 - Whenever possible, Octopus will **mask these sensitive values in logs**.

--- a/src/pages/docs/projects/variables/sensitive-variables.md
+++ b/src/pages/docs/projects/variables/sensitive-variables.md
@@ -72,7 +72,8 @@ Learn more about [security and encryption](/docs/security/data-encryption) in Oc
 
 When dealing with sensitive variables, Octopus encrypts these values using:
 
-- **AES-256** encryption when they are stored in the Octopus database
+- **AES-256** encryption when they are stored in the Octopus database in versions 2024.4 and newer.
+- **AES-128** encryption when they are stored in the Octopus database in versions prior to 2024.4.
 - **AES-128 encryption** any time they are in transmission, or when they are stored on a deployment target as part of a deployment. 
 
 You can use these sensitive values in your deployment process just like normal [variables](/docs/projects/variables), with two notable exceptions:

--- a/src/pages/docs/security/data-encryption.md
+++ b/src/pages/docs/security/data-encryption.md
@@ -11,7 +11,7 @@ This section focuses on securing data in the [Octopus database](/docs/administra
 
 When an Octopus Server is installed, we generate a special key used for encryption, called the **Master Key**. The Master Key is then encrypted asymmetrically, using [Windows Data Protection](https://learn.microsoft.com/en-us/previous-versions/ms995355(v=msdn.10)), and stored in the Octopus configuration file.
 
-The Master Key is then used along with [AES-128](http://en.wikipedia.org/wiki/Advanced_Encryption_Standard) to encrypt certain sensitive data in the Octopus database, including:
+The Master Key is then used along with [AES-256](http://en.wikipedia.org/wiki/Advanced_Encryption_Standard) to encrypt certain sensitive data in the Octopus database, including:
 
 - [Sensitive variables](/docs/projects/variables/sensitive-variables).
 - Private keys used for [Octopus/Tentacle](/docs/security/octopus-tentacle-communication/) communication, and for authenticating with [Azure](/docs/infrastructure/accounts/azure/) and [SSH endpoints](/docs/infrastructure/deployment-targets/linux/ssh-target).
@@ -43,7 +43,6 @@ When Octopus is installed, it generates a random string which will be used as th
 
 Depending on the version of Octopus Server you are using you may need to use a slightly different parsing:
 
-</details>
 <details data-group="data-encryption">
 <summary>Using text</summary>
 

--- a/src/pages/docs/security/data-encryption.md
+++ b/src/pages/docs/security/data-encryption.md
@@ -13,6 +13,12 @@ When an Octopus Server is installed, we generate a special key used for encrypti
 
 The Master Key is then used along with [AES-256](http://en.wikipedia.org/wiki/Advanced_Encryption_Standard) to encrypt certain sensitive data in the Octopus database, including:
 
+:::div{.hint}
+
+Octopus Server 2024.4 and newer use AES-256 by default but support AES-128 for compatibility. Previous versions use AES-128.
+
+:::
+
 - [Sensitive variables](/docs/projects/variables/sensitive-variables).
 - Private keys used for [Octopus/Tentacle](/docs/security/octopus-tentacle-communication/) communication, and for authenticating with [Azure](/docs/infrastructure/accounts/azure/) and [SSH endpoints](/docs/infrastructure/deployment-targets/linux/ssh-target).
 - Credentials used to authenticate with [SSH](/docs/infrastructure/accounts/ssh-key-pair/) (for username/password auth) and [external NuGet feeds](/docs/packaging-applications/package-repositories).

--- a/src/pages/docs/security/data-encryption.md
+++ b/src/pages/docs/security/data-encryption.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-07-15
+modDate: 2024-10-04
 title: Data encryption
 description: This section describes how Octopus Deploy encrypts sensitive data at rest.
 navOrder: 50


### PR DESCRIPTION
Documentation changes to accompany https://github.com/OctopusDeploy/OctopusDeploy/pull/28689, which changed our default master key length to 256 bits.