### PR TITLE
Update Calamari.Legacy links

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/windows/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/windows/index.mdx
@@ -89,7 +89,7 @@ From Octopus Server release `2025.1` there will be [limited support](https://oct
 
 
 To allow this:
-1. Download the [most recent version of Calamari](https://download.octopusdeploy.com/calamari/Calamari.Legacy.27.4.2.zip) (currently `27.4.2`). This is version of Calamari is unlikely to be updated unless there are significant vulnerabilities discovered so it may be missing new capabilities that are released later than `2025.1`.
+1. Download the [most recent version of Calamari](https://download.octopusdeploy.com/calamari/Calamari.Legacy.zip) (verify with [sha256](https://download.octopusdeploy.com/calamari/Calamari.Legacy.sha256) or [md5](https://download.octopusdeploy.com/calamari/Calamari.Legacy.md5) checksum). This is version of Calamari is unlikely to be updated unless there are significant vulnerabilities discovered so it may be missing new capabilities that are released later than `2025.1`.
 
 2. Extract the zip contents to a location on the Tentacle. 
 3. Set an environment variable `CalamariDirectoryPath` with a value of the extracted location. This variable should be provided in a context that will be available to the Tentacle process.


### PR DESCRIPTION
The downloadable link has been updated to remove the version as well as include checksum files