### PR TITLE
Update actually supported Kubernetes versions for the agent

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -73,8 +73,10 @@ The Kubernetes agent follows [semantic versioning](https://semver.org/), so a ma
 
 | Kubernetes agent | Octopus Server           | Kubernetes cluster   |
 | ---------------- | ------------------------ | -------------------- |
-| 1.\*.\*          | **2024.2.6580** or newer | **1.26** to **1.29** |
-| 2.\*.\*          | **2024.2.9396** or newer | **1.26** to **1.29** |
+| 1.0.0 - 1.16.1   | **2024.2.6580** or newer | **1.26** to **1.29** |
+| 1.17.0 - 1.\*.\* | **2024.2.6580** or newer | **1.28** to **1.31** |
+| 2.0.0 - 2.2.1    | **2024.2.9396** or newer | **1.26** to **1.29** |
+| 2.3.0 - 2.\*.\*  | **2024.2.9396** or newer | **1.28** to **1.31** |
 
 Additionally, the Kubernetes agent only supports **Linux AMD64** and **Linux ARM64** Kubernetes nodes.
 


### PR DESCRIPTION
It turns out we had upgraded the SDK used by the agent a few versions ago (by @OctopusDeploy/team-server-at-scale as part of the .NET 8 work).

As a result, the supported versions of the agent change to 1.28 -> 1.31