### PR TITLE
Add Cloud uptime track record; update SLO; update references.

### DIFF
--- a/src/pages/docs/octopus-cloud/frequently-asked-questions.md
+++ b/src/pages/docs/octopus-cloud/frequently-asked-questions.md
@@ -185,11 +185,16 @@ We publish our [release updates](https://octopus.com/whatsnew) and provide a [re
 
 ### What is Octopus Cloud’s uptime SLO?
 
-Octopus Cloud's monthly [uptime SLO](/docs/octopus-cloud/uptime-slo) is 99.5%, measured for the 95th percentile of Cloud instances. This target includes all downtime, including scheduled maintenance.
+Octopus Cloud's monthly [uptime SLO](/docs/octopus-cloud/uptime-slo) is 99.99%, measured for the 95th percentile of paid Cloud instances. We calculate uptime as 100% of the month, less all unplanned downtime. 
 
 ### How is uptime monitored?
 
 Our Cloud Platform team observes uptime and planned downtime durations as part of frequent health checks. We use a third-party vendor to assess availability every minute of the day.
+
+### Where can I see Octopus Cloud uptime data?
+
+We publish Octopus Cloud’s [uptime track record](/docs/octopus-cloud/uptime-slo) monthly.
+
 
 ### How can we check Octopus Cloud's status?
 

--- a/src/pages/docs/octopus-cloud/maintenance-window.md
+++ b/src/pages/docs/octopus-cloud/maintenance-window.md
@@ -13,10 +13,11 @@ Most of these won't affect your instance's availability, but occasionally, we mi
 
 :::div{.hint}
 We don’t need to perform actions on your instance daily, and most of our maintenance actions won’t take your instance offline. At most, you might notice a performance impact. The steps that require an outage typically only take a short time to complete.
+
+In the 4 months up to and including October 2024, Octopus Cloud instances: 
+ * had an average downtime of fewer than 8 minutes per week
+ * experienced any downtime on average fewer than 2 days a week
 :::
-
-At the time of publishing this (April 2024), our maintenance tasks require an average of 15 minutes downtime per week.
-
 
 
 ## You’re in control of the schedule

--- a/src/pages/docs/octopus-cloud/maintenance-window.md
+++ b/src/pages/docs/octopus-cloud/maintenance-window.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-09-23
+modDate: 2024-11-27
 title: Octopus Cloud Maintenance Window
 navOrder: 55
 description: Details about the Octopus Cloud maintenance window
@@ -15,17 +15,18 @@ Most of these won't affect your instance's availability, but occasionally, we mi
 We don’t need to perform actions on your instance daily, and most of our maintenance actions won’t take your instance offline. At most, you might notice a performance impact. The steps that require an outage typically only take a short time to complete.
 
 In the 4 months up to and including October 2024, Octopus Cloud instances: 
- * had an average downtime of fewer than 8 minutes per week
- * experienced any downtime on average fewer than 2 days a week
+- Had an average downtime of fewer than 8 minutes per week
+- Experienced any downtime on average fewer than 2 days a week
 :::
 
 
 ## You’re in control of the schedule
+
 You get to choose a two-hour time slot for maintenance activities. Pick a time outside your regular business hours to minimize potential impact.
 You can adjust your maintenance window anytime, but make sure to do it before your current window begins to avoid interrupting ongoing maintenance tasks. 
 
-
 ## View or change your maintenance window
+
 Setting up your maintenance window to suit your business needs is easy. Just follow these steps:
 
 1. Log in to [Octopus.com](https://octopus.com).
@@ -34,13 +35,12 @@ Setting up your maintenance window to suit your business needs is easy. Just fol
 4. Scroll down to the **Maintenance window** section.
 5. Select the time in UTC, providing a window of at least two hours and click **Submit**.
 
-
-
 ## During a Maintenance Window
 
 At the start of each window, an evaluation is performed to determine which maintenance operations need to be performed on each Octopus Cloud instance. There may be several operations that need to be performed in sequence on your instance during a single maintenance window.
 
 Those tasks include (but are not limited to) the following:
+
 - Database maintenance. This involves reindexing and compacting your Octopus Cloud instance database so that it can perform at its best. 
 - Performing any Octopus Server software upgrades.
 - Moving your instance to new infrastructure. These operations don't happen as often, but are required when we roll out improvements to the underlying infrastructure. 
@@ -57,6 +57,7 @@ Upgrading an instance is the primary cause of outages. The most noticeable impac
 :::
 
 ## Taking your instance offline
+
 If we need to take your instance offline to perform any maintenance:
 - Your instance will be given a few minutes to shut down cleanly. This will allow any in-progress tasks to complete. Any tasks still running at the end of the timeout will be abandoned.
 - A maintenance page will be displayed to users and any requests to the API will return a 503 Service Unavailable status code.
@@ -66,5 +67,6 @@ If we need to take your instance offline to perform any maintenance:
 
 
 ## How we communicate maintenance windows
+
 - **Routine maintenance:** During a regular maintenance window, a maintenance page will be displayed to users, and any requests to the API will return a 503 Service Unavailable status code
 - **Other maintenance:** There may be rare occasions outside of your normal maintenance window where we need to perform maintenance on your instance. Our Support team will contact you in these scenarios to coordinate the work.

--- a/src/pages/docs/octopus-cloud/uptime-slo.md
+++ b/src/pages/docs/octopus-cloud/uptime-slo.md
@@ -1,21 +1,53 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-04-05
+modDate: 2024-11-21
 title: Octopus Cloud Uptime SLO
 navOrder: 50
 description: The uptime SLO for Octopus Cloud instances
 ---
 
-Each Octopus Cloud customer has their own instance of the Octopus Server and can use [dynamic workers](/docs/infrastructure/workers/dynamic-worker-pools). As the name implies, these workers are assigned to a cloud instance dynamically and are spun up and down as required by the Deployment or Runbook executed. The following uptime SLO (service level objective), therefore, refers to the customer's Cloud instance.
+Each Octopus Cloud customer has their own Octopus Server delivered as a highly available, scalable, secure SaaS application hosted for you. Octopus Deploy manages maintenance and resource provisioning for these hosted servers, letting our customers focus on happy deployments. 
 
-Each customer's instance may experience its own series of maintenance operations and reprovisioning for operational and upgrade reasons. Therefore the 95th percentile of monthly uptime is used as the basis for the Octopus Cloud uptime SLO. Operational downtime is, other than in exceptional circumstances, scheduled in the customer's [maintenance window](/docs/octopus-cloud/maintenance-window). All downtime (unplanned and planned) is used in the determination of the uptime SLO.
+Octopus Cloud's monthly uptime SLO is 99.99%. 
 
-## Uptime SLO
-Monthly uptime SLO: 99.5%
+We calculate uptime as 100% of the month, less all unplanned downtime. 
 
-**“Monthly uptime of an instance”** means 100% minus the percentage of downtime (planned and unplanned) minutes out of the total minutes in a calendar month.
+Planned maintenance is a key benefit of Octopus Cloud and is scheduled in advance, so we exclude it from our uptime SLO calculation. Other than in exceptional circumstances, planned maintenance occurs during the customer’s [maintenance window](/docs/octopus-cloud/maintenance-window). In the 4 months ending October 2024, planned maintenance averaged fewer than 8 minutes of downtime per week. 
 
-**“Downtime of an instance”** means a period of time where the customer instance is unavailable according to Octopus Deploy's internal and external monitoring systems.
+## Uptime Track Record
 
-**Basis:** 95th percentile of the monthly average of paid subscriptions (95% of customers would be above 99.5%). Included in the downtime is any planned downtime during the customer's maintenance window.
+This table lists Octopus Cloud's monthly uptime statistics for the last 12 months. 
+
+We list our achieved uptime percentage and the average amount of unplanned downtime for each month. We also show these data points including planned maintenance.
+
+| Month  | Uptime % | Average weekly unplanned downtime | Uptime % incl. planned maintenance | Average weekly downtime incl. planned maintenance |
+| :----- | ------: | ------: |------: | ------: |
+| October 2024 | 99.9973% | 5 s | 99.917% | 309 s |
+| September 2024 | 99.9977% | 4s | 99.9165% | 313s |
+| August 2024 | 99.9955% | 8s | 99.8978% | 447s |
+| July 2024 | 99.9978% | 6s | 99.8602% | 616s |
+| June 2024 | 99.9931% | 9s | 99.9196% | * 279s |
+| May 2024 | 99.9976% | 11s |- | - |
+| April 2024 | 99.9687% | 17s |- | - |
+| March 2024 | 99.9914% | 10s |- | - |
+| February 2024 | 100% | 2s |- | - |
+| January 2024 | 99.9976% | 3s |- | - |
+| December 2023 | 99.998% | 5s |- | - |
+| November 2023 | 99.9957% | 4s |- | - |
+
+\* We began capturing planned downtime metrics on June 10, 2024.
+
+### How we calculate uptime
+
+We calculate uptime as 100% minus the percentage of unplanned downtime seconds out of the total seconds in a calendar month. We measure uptime performance at the 95th percentile of all paid subscriptions (95% of customers would meet or exceed the listed uptime %).
+
+We exclude downtime that arises from planned or customer-requested maintenance from our uptime SLO calculation, but we measure and report it for transparency. 
+Some Octopus Cloud customers use [dynamic workers](/docs/infrastructure/workers/dynamic-worker-pools). As the name implies, these workers are dynamically assigned to a cloud instance and are spun up and down as required by the Deployment or Runbook executed. We exclude Dynamic Workers from our calculation of uptime.
+
+**“Downtime”** means a period where the customer instance is unavailable, according to Octopus Deploy's internal and external monitoring systems.
+
+**"Average weekly unplanned downtime"** is measured in seconds per week, as an arithmetic mean across all paid customers. It excludes planned maintenance and customer-requested maintenance.
+
+**"Average weekly downtime incl. planned maintenance"** is measured in seconds per week, as an arithmetic mean across all paid customers. It includes planned maintenance and customer-requested maintenance.
+


### PR DESCRIPTION
Improves, defines and clarifies content about Octopus Cloud uptime SLO. 

Adds a table of track record data.

Add recent & accurate data points to maintenance windows page.

Link FAQ to uptime track record.