### PR TITLE
Adding more information about the behaviour of manual interventions

### DIFF
--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -80,10 +80,14 @@ When a manual step is completed, details of the interruption are saved as variab
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.EmailAddress` | The email address of the user who submitted the interruption form | *jamie.jones@example.com* |
 
 ## Evaluating manual intervention output in following steps
-If you want to control subsequent steps based on the outcome of the manual intervention step, you can use "Variable: only run when the variable expression is true". Use the following to evaluate the outcome of the manual intervention step":
+If you want to control subsequent steps based on the outcome of the manual intervention step, you can use "Variable: only run when the variable expression is true", and use the `Octopus.Deployment.Error` variable as the conditional. For example:
 
 ```
-#{unless Octopus.Deployment.Error}true#{/unless}
+#{unless Octopus.Deployment.Error}RESULT IF MANUAL INTERVENTION PROCEEDED{/unless}
+```
+or
+```
+#{if Octopus.Deployment.Error}RESULT IF MANUAL INTERVENTION WAS ABORTED{/if}
 ```
 
 ## Learn more

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -17,6 +17,12 @@ While fully automated deployment is a great goal, there are times when a human n
 
 The **Manual intervention step** is a step that can be added to deployment processes to pause the deployment to wait for a member of a specified team to either allow the deployment to proceed or to be aborted.
 
+:::div{.hint}
+Manual interventions result in either a success or failure outcome based on the user’s input. Subsequent steps evaluate this outcome according to their run conditions. By default, the run condition is set to "Success: only run when previous steps succeed." This means manual interventions can prevent these steps from executing, causing the deployment to fail.
+
+However, if "Always Run" is selected for subsequent steps, they will proceed regardless of the manual intervention outcome. For steps with the condition "Variable: only run when the variable expression is true," the manual intervention's outcome must be included in the variable expression to determine whether the step should run.
+:::
+
 [Getting Started - Manual Intervention](https://www.youtube.com/watch?v=ePQjCClGfZQ)
 
 ## Add a manual intervention step
@@ -72,6 +78,13 @@ When a manual step is completed, details of the interruption are saved as variab
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.Username` | The username of the user who submitted the interruption form | *j_jones* |
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.DisplayName` | The display name of the user who submitted the interruption form | *Jamie Jones* |
 | `Octopus.Action[Step Name].Output.Manual.ResponsibleUser.EmailAddress` | The email address of the user who submitted the interruption form | *jamie.jones@example.com* |
+
+## Evaluating manual intervention output in following steps
+If you want to control subsequent steps based on the outcome of the manual intervention step, you can use "Variable: only run when the variable expression is true". Use the following to evaluate the outcome of the manual intervention step":
+
+```
+#{unless Octopus.Deployment.Error}true#{/unless}
+```
 
 ## Learn more
 


### PR DESCRIPTION
# Background
[It was observed](https://octopusdeploy.slack.com/archives/C04GAH78491/p1733096479465069) that our docs do not make it clear what should happen when a manual intervention is aborted.

What Octopus Deploy does, is that it treats that like any other failure, and then proceeds to evaluate the run conditions of subsequent steps. So if a step is setup to run on a previous step failing, then it will run.

This PR aims to help specify this behaviour so it is more clear to our customers on how manual interventions should behave.

## Example
We added a sample to the docs on the Octostache variable that you could use to control steps with variable conditions.

This sample was tested, and here are the results:

The configured variable:
![image](https://github.com/user-attachments/assets/a3a72bf6-7627-42a0-a5ea-3e47b9a5188e)

A deployment where we aborted the manual intervention:
![image](https://github.com/user-attachments/assets/f660f343-2d43-4ddb-acad-f7ca166e8c3c)

A deployment where we proceeded with the manual intervention:
![image](https://github.com/user-attachments/assets/f3b3e4f5-8748-4fca-a5e1-406220531233)
