### PR TITLE
Update docs to include Generic Oidc Changes

### DIFF
--- a/src/pages/docs/infrastructure/accounts/google-cloud/index.md
+++ b/src/pages/docs/infrastructure/accounts/google-cloud/index.md
@@ -13,14 +13,14 @@ Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect A
 
 To deploy infrastructure to Google Cloud Platform, you can define a Google cloud or Generic OpenId Connect account in Octopus.
 
-The Generic OpenId Connect Account generates a JWT that can be used for [OpenID Connect](/docs/infrastructure/openid-connect.md) authentication. The Google cloud account uses the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
+The Generic OpenId Connect Account generates a JWT that can be used for [OpenID Connect](/docs/infrastructure/accounts/openid-connect.md) authentication. The Google cloud account uses the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
 
 ## Generic OpenId Connect Account
 Google Cloud steps can use a Generic OpenId Connect Account for authentication.
 
 1. Navigate to **Infrastructure ➜ Accounts**, click the **ADD ACCOUNT** and select **Generic Oidc Account**.
 1. Add a memorable name for the account.
-1. Set the [Deployments and Runbooks](/docs/infrastructure/openid-connect.md) subject generator
+1. Set the [Deployments and Runbooks](/docs/infrastructure/accounts/openid-connect.md) subject generator
 1. set an audience, this should match the audience set on the Workload Identity Federation. By default this is `https://iam.googleapis.com/projects/{project-id}/locations/global/workloadIdentityPools/{pool-id}/providers/{provider-id}`
 1. Click the **SAVE**, to test the account set it as the account on a gcloud script step.
 

--- a/src/pages/docs/infrastructure/accounts/google-cloud/index.md
+++ b/src/pages/docs/infrastructure/accounts/google-cloud/index.md
@@ -8,18 +8,46 @@ navOrder: 30
 ---
 
 :::div{.hint}
-Google Cloud Accounts were added in Octopus **2021.2**.
+Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect Accounts were added in **2025.1**
 :::
 
-To deploy infrastructure to Google Cloud Platform, you can define a Google cloud account in Octopus.
+To deploy infrastructure to Google Cloud Platform, you can define a Google cloud or Generic OpenId Connect account in Octopus.
 
-Octopus manages the GCP credentials used by the Google cloud steps.
+The Generic OpenId Connect Account generates a JWT that can be used for [OpenID Connect](/docs/infrastructure/openid-connect.md) authentication. The Google cloud account uses the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
 
-The Google cloud account is the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
+## Generic OpenId Connect Account
+Google Cloud steps can use a Generic OpenId Connect Account for authentication.
+
+1. Navigate to **Infrastructure ➜ Accounts**, click the **ADD ACCOUNT** and select **Generic Oidc Account**.
+1. Add a memorable name for the account.
+1. Set the [Deployments and Runbooks](/docs/infrastructure/openid-connect.md) subject generator
+1. set an audience, this should match the audience set on the Workload Identity Federation. By default this is `https://iam.googleapis.com/projects/{project-id}/locations/global/workloadIdentityPools/{pool-id}/providers/{provider-id}`
+1. Click the **SAVE**, to test the account set it as the account on a gcloud script step.
+
+See the [Google cloud documentation](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers) for instructions on creating and configuring a Workload Identity Federation.
+
+Behind the scenes Octopus calls the gcloud cli with the following command to authenticate:
+
+```bash
+gcloud iam workload-identity-pools create-cred-config \
+    <audience> \
+    --service-account=<impersonationEmails> \
+    --service-account-token-lifetime-seconds=3600 \
+    --output-file=<jsonAuthFilePath> \
+    --credential-source-file=<jwtFilePath> \
+    --credential-source-type=text \
+    --subject-token-type=urn:ietf:params:oauth:token-type:jwt \
+    --app-id-uri=<serverUri>
+```
+
+
+:::div{.hint}
+The default audience format is `https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID` while `workload-identity-pools create-cred-config` command expects the audience without `https://iam.googleapis.com`. In this scenario Octopus expects the full audience value to be set on the account including `https://iam.googleapis.com` but will trim the `https://iam.googleapis.com` when running the create-cred-config command.  
+:::
 
 ## Create a Google cloud account
 
-Google Cloud steps can use an Octopus managed account for authentication.
+Google Cloud steps can use a Google Cloud Account for authentication.
 
 1. Navigate to **Infrastructure ➜ Accounts**, click the **ADD ACCOUNT** and select **Google Cloud Account**.
 1. Add a memorable name for the account.

--- a/src/pages/docs/infrastructure/accounts/google-cloud/index.md
+++ b/src/pages/docs/infrastructure/accounts/google-cloud/index.md
@@ -13,14 +13,14 @@ Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect A
 
 To deploy infrastructure to Google Cloud Platform, you can define a Google cloud or Generic OpenId Connect account in Octopus.
 
-The Generic OpenId Connect Account generates a JWT that can be used for [OpenID Connect](/docs/infrastructure/accounts/openid-connect.md) authentication. The Google cloud account uses the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
+The Generic OpenId Connect Account generates a JWT that can be used for [OpenID Connect](/docs/infrastructure/accounts/openid-connect) authentication. The Google cloud account uses the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
 
 ## Generic OpenId Connect Account
 Google Cloud steps can use a Generic OpenId Connect Account for authentication.
 
 1. Navigate to **Infrastructure ➜ Accounts**, click the **ADD ACCOUNT** and select **Generic Oidc Account**.
 1. Add a memorable name for the account.
-1. Set the [Deployments and Runbooks](/docs/infrastructure/accounts/openid-connect.md) subject generator
+1. Set the [Deployments and Runbooks](/docs/infrastructure/accounts/openid-connect#subject-key-parts) subject generator
 1. set an audience, this should match the audience set on the Workload Identity Federation. By default this is `https://iam.googleapis.com/projects/{project-id}/locations/global/workloadIdentityPools/{pool-id}/providers/{provider-id}`
 1. Click the **SAVE**, to test the account set it as the account on a gcloud script step.
 


### PR DESCRIPTION
The existing [OpenId Connect](https://octopus.com/docs/infrastructure/accounts/openid-connect#deployments-and-runbooks) page covers most of the relevant details for Oidc accounts. Let me know if you think additional details related to the generic oidc account would fit here let me know. This change includes the CLI commands and call out on the gcloud account that generic OpenId Connect accounts can be used instead.