### PR TITLE
Kubernetes agent supported versions policy

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -80,6 +80,8 @@ The Kubernetes agent follows [semantic versioning](https://semver.org/), so a ma
 
 Additionally, the Kubernetes agent only supports **Linux AMD64** and **Linux ARM64** Kubernetes nodes.
 
+See our [support policy](/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy) for more information.
+
 ## Installing the Kubernetes agent
 
 The Kubernetes agent is installed using [Helm](https://helm.sh) via the [octopusdeploy/kubernetes-agent](https://hub.docker.com/r/octopusdeploy/kubernetes-agent) chart.

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy.md
@@ -2,7 +2,7 @@
 layout: src/layouts/Default.astro
 pubDate: 2024-12-11
 modDate: 2024-12-11
-title: Supported Versions of Kubernetes Policy
+title: Support Policy for Kubernetes Versions
 navTitle: Supported Versions Policy
 navSection: Kubernetes agent
 description: Policy for which versions of Kubernetes are supported by the Kubernetes agent

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy.md
@@ -1,0 +1,20 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2024-12-11
+modDate: 2024-12-11
+title: Supported Versions of Kubernetes Policy
+navTitle: Supported Versions Policy
+navSection: Kubernetes agent
+description: Policy for which versions of Kubernetes are supported by the Kubernetes agent
+navOrder: 100
+---
+
+[The Kubernetes project](https://kubernetes.io/releases/version-skew-policy/#supported-versions) maintains release branches for the most recent three minor releases of Kubernetes.
+
+Octopus aims to follow this support policy as closely as makes sense.
+
+## Kubernetes Agent
+
+The Kubernetes agent uses the [Kubernetes C# client](https://github.com/kubernetes-client/csharp) to interact with the Kubernetes API, so we are bound to their release cadence. The Kubernetes agent will receive an update within **3 months** of a new major release of the Kubernetes C# client being released.
+
+If your use case requires the latest and greatest version of Kubernetes before we have released a new version, please [contact support](https://octopus.com/company/contact) to discuss options.

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/supported-versions-policy.md
@@ -18,3 +18,9 @@ Octopus aims to follow this support policy as closely as makes sense.
 The Kubernetes agent uses the [Kubernetes C# client](https://github.com/kubernetes-client/csharp) to interact with the Kubernetes API, so we are bound to their release cadence. The Kubernetes agent will receive an update within **3 months** of a new major release of the Kubernetes C# client being released.
 
 If your use case requires the latest and greatest version of Kubernetes before we have released a new version, please [contact support](https://octopus.com/company/contact) to discuss options.
+
+### Support for older versions
+
+Each time the Kubernetes agent is updated to support a new version of Kubernetes, support for older versions will be dropped in line with the Kubernetes project's supported versions. Historically, the APIs in use have been stable and the Kubernetes agent has remained compatible with older version of Kubernetes, however we can make no guarantees of this in the future.
+
+We strongly recommend leaving automatic Kubernetes agent updates enabled and keeping your Kubernetes cluster up to date in line with the latest support version. If you must maintain support for older versions, you can configure how the Kubernetes agent is automatically updated with [machine policies](/docs/infrastructure/deployment-targets/machine-policies#configure-machine-updates).


### PR DESCRIPTION
Adds a short explainer to describe when we make updates to the supported versions of Kubernetes.

Unsure if we want to direct people to talk to support for something that we'll get to eventually - but I think it's a nice touch.

![image](https://github.com/user-attachments/assets/de43ad2e-e5d8-4fa8-85ad-97f1de25ad7a)

