### PR TITLE
Fix Kubernetes agent cluster versions

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -74,9 +74,9 @@ The Kubernetes agent follows [semantic versioning](https://semver.org/), so a ma
 | Kubernetes agent | Octopus Server           | Kubernetes cluster   |
 | ---------------- | ------------------------ | -------------------- |
 | 1.0.0 - 1.16.1   | **2024.2.6580** or newer | **1.26** to **1.29** |
-| 1.17.0 - 1.\*.\* | **2024.2.6580** or newer | **1.28** to **1.31** |
+| 1.17.0 - 1.\*.\* | **2024.2.6580** or newer | **1.27** to **1.30** |
 | 2.0.0 - 2.2.1    | **2024.2.9396** or newer | **1.26** to **1.29** |
-| 2.3.0 - 2.\*.\*  | **2024.2.9396** or newer | **1.28** to **1.31** |
+| 2.3.0 - 2.\*.\*  | **2024.2.9396** or newer | **1.27** to **1.30** |
 
 Additionally, the Kubernetes agent only supports **Linux AMD64** and **Linux ARM64** Kubernetes nodes.
 


### PR DESCRIPTION
Tentacle is currently using `v14` of the Kubernetes C# SDK, which targets `1.30`