### PR TITLE
Deploy-release.md: revert accidental change to CLI output

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -417,6 +417,7 @@ tfvar
 tfvars
 TFVC
 thepassword
+timespan
 tlsv1
 tmpfs
 Toolsets

--- a/src/pages/docs/octopus-rest-api/octopus-cli/create-release.md
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/create-release.md
@@ -16,181 +16,174 @@ Creates (and, optionally, deploys) a release.
 
 Usage: octo create-release [<options>]
 
-Where [<options>] is any of:
+Where [<options>] is any of: 
 
-Release creation:
+Release creation: 
 
       --project=VALUE        Name or ID of the project.
       --defaultPackageVersion, --packageVersion=VALUE
-                             Default version number of all packages to use
+                             Default version number of all packages to use 
                              for this release. Override per-package using --
                              package.
-      --gitCommit=VALUE      [Optional] Git commit to use when creating the
-                             release. Use in conjunction with the --gitRef
+      --gitCommit=VALUE      [Optional] Git commit to use when creating the 
+                             release. Use in conjunction with the --gitRef 
                              parameter to select any previous commit.
-      --ref, --gitRef=VALUE  [Optional] Git reference to use when creating
+      --ref, --gitRef=VALUE  [Optional] Git reference to use when creating 
                              the release.
       --version, --releaseNumber=VALUE
-                             [Optional] Release number to use for the new
+                             [Optional] Release number to use for the new 
                              release.
-      --channel=VALUE        [Optional] Name or ID of the channel to use for
-                             the new release. Omit this argument to
+      --channel=VALUE        [Optional] Name or ID of the channel to use for 
+                             the new release. Omit this argument to 
                              automatically select the best channel.
-      --package=VALUE        [Optional] Version number to use for a package
-                             in the release. Format: StepName:Version or
-                             PackageID:Version or
-                             StepName:PackageName:Version. StepName,
-                             PackageID, and PackageName can be replaced with
-                             an asterisk. An asterisk will be assumed for
-                             StepName, PackageID, or PackageName if they are
+      --package=VALUE        [Optional] Version number to use for a package 
+                             in the release. Format: StepName:Version or 
+                             PackageID:Version or 
+                             StepName:PackageName:Version. StepName, 
+                             PackageID, and PackageName can be replaced with 
+                             an asterisk. An asterisk will be assumed for 
+                             StepName, PackageID, or PackageName if they are 
                              omitted.
-                             Can be specified multiple times.
-      --git-resource=VALUE   [Optional] Git reference to use for a Git resource 
-                             in the release. Format: StepName:GitRef or 
-                             StepName:GitResourceName:GitRef. GitRef can be 
-                             replaced with an asterisk. An asterisk means 
-                             use the step-defined default branch.
-                             Can be specified multiple times.
-      --packagesFolder=VALUE [Optional] A folder containing NuGet packages
+      --packagesFolder=VALUE [Optional] A folder containing NuGet packages 
                              from which we should get versions.
-      --releaseNotes=VALUE   [Optional] Release Notes for the new release.
+      --releaseNotes=VALUE   [Optional] Release Notes for the new release. 
                              Styling with Markdown is supported.
       --releaseNoteFile, --releaseNotesFile=VALUE
-                             [Optional] Path to a file that contains Release
-                             Notes for the new release. Supports Markdown
+                             [Optional] Path to a file that contains Release 
+                             Notes for the new release. Supports Markdown 
                              files.
-      --ignoreExisting       [Optional, Flag] Don't create this release if
-                             there is already one with the same version
+      --ignoreExisting       [Optional, Flag] Don't create this release if 
+                             there is already one with the same version 
                              number.
-      --ignoreChannelRules   [Optional, Flag] Create the release ignoring any
+      --ignoreChannelRules   [Optional, Flag] Create the release ignoring any 
                              version rules specified by the channel.
       --packagePrerelease=VALUE
-                             [Optional] Pre-release for latest version of all
-                             packages to use for this release. This argument
+                             [Optional] Pre-release for latest version of all 
+                             packages to use for this release. This argument 
                              supports regex patterns.
-      --whatIf               [Optional, Flag] Perform a dry run but don't
+      --whatIf               [Optional, Flag] Perform a dry run but don't 
                              actually create/deploy release.
 
-Deployment:
+Deployment: 
 
       --progress             [Optional] Show progress of the deployment.
-      --forcePackageDownload [Optional] Whether to force downloading of
+      --forcePackageDownload [Optional] Whether to force downloading of 
                              already installed packages (flag, default false).
-      --waitForDeployment    [Optional] Whether to wait synchronously for
+      --waitForDeployment    [Optional] Whether to wait synchronously for 
                              deployment to finish.
       --deploymentTimeout=VALUE
-                             [Optional] Specifies maximum time (time span
-                             format) that the console session will wait for
-                             the deployment to finish(default 00:10:00). This
+                             [Optional] Specifies maximum time (timespan 
+                             format) that the console session will wait for 
+                             the deployment to finish(default 00:10:00). This 
                              will not stop the deployment. Requires --
                              waitForDeployment parameter set.
-      --cancelOnTimeout      [Optional] Whether to cancel the deployment if
-                             the deployment timeout is reached (flag, default
+      --cancelOnTimeout      [Optional] Whether to cancel the deployment if 
+                             the deployment timeout is reached (flag, default 
                              false).
       --deploymentCheckSleepCycle=VALUE
-                             [Optional] Specifies how much time (time span
-                             format) should elapse between deployment status
+                             [Optional] Specifies how much time (timespan 
+                             format) should elapse between deployment status 
                              checks (default 00:00:10).
-      --guidedFailure=VALUE  [Optional] Whether to use guided failure mode.
-                             (True or False. If not specified, will use
+      --guidedFailure=VALUE  [Optional] Whether to use guided failure mode. 
+                             (True or False. If not specified, will use 
                              default setting from environment).
       --specificMachines=VALUE
-                             [Optional] A comma-separated list of machine
-                             names to target in the deployed environment. If
-                             not specified all machines in the environment
+                             [Optional] A comma-separated list of machine 
+                             names to target in the deployed environment. If 
+                             not specified all machines in the environment 
                              will be considered.
       --excludeMachines=VALUE
-                             [Optional] A comma-separated list of machine
-                             names to exclude in the deployed environment. If
-                             not specified all machines in the environment
+                             [Optional] A comma-separated list of machine 
+                             names to exclude in the deployed environment. If 
+                             not specified all machines in the environment 
                              will be considered.
-      --force                [Optional] If a project is configured to skip
-                             packages with already-installed versions,
-                             override this setting to force re-deployment
+      --force                [Optional] If a project is configured to skip 
+                             packages with already-installed versions, 
+                             override this setting to force re-deployment 
                              (flag, default false).
       --skip=VALUE           [Optional] Skip a step by name.
-      --noRawLog             [Optional] Don't print the raw log of failed
+      --noRawLog             [Optional] Don't print the raw log of failed 
                              tasks.
-      --rawLogFile=VALUE     [Optional] Redirect the raw log of failed tasks
+      --rawLogFile=VALUE     [Optional] Redirect the raw log of failed tasks 
                              to a file.
-  -v, --variable=VALUE       [Optional] Specifies the value for a prompted
-                             variable in the format Label:Value. For JSON
-                             values, embedded quotation marks should be
+  -v, --variable=VALUE       [Optional] Specifies the value for a prompted 
+                             variable in the format Label:Value. For JSON 
+                             values, embedded quotation marks should be 
                              escaped with a backslash.
-      --deployAt=VALUE       [Optional] Time at which deployment should start
-                             (scheduled deployment), specified as any valid
-                             DateTimeOffset format, and assuming the time
+      --deployAt=VALUE       [Optional] Time at which deployment should start 
+                             (scheduled deployment), specified as any valid 
+                             DateTimeOffset format, and assuming the time 
                              zone is the current local time zone.
-      --noDeployAfter=VALUE  [Optional] Time at which scheduled deployment
-                             should expire, specified as any valid
-                             DateTimeOffset format, and assuming the time
+      --noDeployAfter=VALUE  [Optional] Time at which scheduled deployment 
+                             should expire, specified as any valid 
+                             DateTimeOffset format, and assuming the time 
                              zone is the current local time zone.
-      --tenant=VALUE         [Optional] Create a deployment for the tenant
-                             with this name or ID; specify this argument
-                             multiple times to add multiple tenants or use
-                             `*` wildcard to deploy to all tenants who are
+      --tenant=VALUE         [Optional] Create a deployment for the tenant 
+                             with this name or ID; specify this argument 
+                             multiple times to add multiple tenants or use 
+                             `*` wildcard to deploy to all tenants who are 
                              ready for this release (according to lifecycle).
-      --tenantTag=VALUE      [Optional] Create a deployment for tenants
-                             matching this tag; specify this argument
-                             multiple times to build a query/filter with
-                             multiple tags, just like you can in the user
+      --tenantTag=VALUE      [Optional] Create a deployment for tenants 
+                             matching this tag; specify this argument 
+                             multiple times to build a query/filter with 
+                             multiple tags, just like you can in the user 
                              interface.
-      --deployTo=VALUE       [Optional] Name or ID of the environment to
-                             automatically deploy to, e.g., 'Production' or
-                             'Environments-1'; specify this argument multiple
+      --deployTo=VALUE       [Optional] Name or ID of the environment to 
+                             automatically deploy to, e.g., 'Production' or 
+                             'Environments-1'; specify this argument multiple 
                              times to deploy to multiple environments.
 
-Common options:
+Common options: 
 
       --help                 [Optional] Print help for a command.
       --helpOutputFormat=VALUE
-                             [Optional] Output format for help, valid options
+                             [Optional] Output format for help, valid options 
                              are Default or Json
-      --outputFormat=VALUE   [Optional] Output format, valid options are
+      --outputFormat=VALUE   [Optional] Output format, valid options are 
                              Default or Json
-      --server=VALUE         [Optional] The base URL for your Octopus Server,
-                             e.g., 'https://octopus.example.com/'. This URL
-                             can also be set in the OCTOPUS_CLI_SERVER
+      --server=VALUE         [Optional] The base URL for your Octopus Server, 
+                             e.g., 'https://octopus.example.com/'. This URL 
+                             can also be set in the OCTOPUS_CLI_SERVER 
                              environment variable.
-      --apiKey=VALUE         [Optional] Your API key. Get this from the user
-                             profile page. You must provide an apiKey or
-                             username and password. If the guest account is
-                             enabled, a key of API-GUEST can be used. This
-                             key can also be set in the OCTOPUS_CLI_API_KEY
+      --apiKey=VALUE         [Optional] Your API key. Get this from the user 
+                             profile page. You must provide an apiKey or 
+                             username and password. If the guest account is 
+                             enabled, a key of API-GUEST can be used. This 
+                             key can also be set in the OCTOPUS_CLI_API_KEY 
                              environment variable.
-      --user=VALUE           [Optional] Username to use when authenticating
-                             with the server. You must provide an apiKey or
-                             username and password. This Username can also be
-                             set in the OCTOPUS_CLI_USERNAME environment
+      --user=VALUE           [Optional] Username to use when authenticating 
+                             with the server. You must provide an apiKey or 
+                             username and password. This Username can also be 
+                             set in the OCTOPUS_CLI_USERNAME environment 
                              variable.
-      --pass=VALUE           [Optional] Password to use when authenticating
-                             with the server. This Password can also be set
+      --pass=VALUE           [Optional] Password to use when authenticating 
+                             with the server. This Password can also be set 
                              in the OCTOPUS_CLI_PASSWORD environment variable.
-      --configFile=VALUE     [Optional] Text file of default values, with one
+      --configFile=VALUE     [Optional] Text file of default values, with one 
                              'key = value' per line.
       --debug                [Optional] Enable debug logging.
-      --ignoreSslErrors      [Optional] Set this flag if your Octopus Server
-                             uses HTTPS but the certificate is not trusted on
-                             this machine. Any certificate errors will be
-                             ignored. WARNING: this option may create a
+      --ignoreSslErrors      [Optional] Set this flag if your Octopus Server 
+                             uses HTTPS but the certificate is not trusted on 
+                             this machine. Any certificate errors will be 
+                             ignored. WARNING: this option may create a 
                              security vulnerability.
       --enableServiceMessages
-                             [Optional] Enable TeamCity or Team Foundation
+                             [Optional] Enable TeamCity or Team Foundation 
                              Build service messages when logging.
-      --timeout=VALUE        [Optional] Timeout in seconds for network
+      --timeout=VALUE        [Optional] Timeout in seconds for network 
                              operations. Default is 600.
-      --proxy=VALUE          [Optional] The URL of the proxy to use, e.g.,
+      --proxy=VALUE          [Optional] The URL of the proxy to use, e.g., 
                              'https://proxy.example.com'.
       --proxyUser=VALUE      [Optional] The username for the proxy.
-      --proxyPass=VALUE      [Optional] The password for the proxy. If both
-                             the username and password are omitted and
-                             proxyAddress is specified, the default
+      --proxyPass=VALUE      [Optional] The password for the proxy. If both 
+                             the username and password are omitted and 
+                             proxyAddress is specified, the default 
                              credentials are used.
-      --space=VALUE          [Optional] The name or ID of a space within
-                             which this command will be executed. The default
+      --space=VALUE          [Optional] The name or ID of a space within 
+                             which this command will be executed. The default 
                              space will be used if it is omitted.
-      --logLevel=VALUE       [Optional] The log level. Valid options are
-                             verbose, debug, information, warning, error and
+      --logLevel=VALUE       [Optional] The log level. Valid options are 
+                             verbose, debug, information, warning, error and 
                              fatal. Defaults to 'debug'.
 ```
 

--- a/src/pages/docs/octopus-rest-api/octopus-cli/create-release.md
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/create-release.md
@@ -16,174 +16,181 @@ Creates (and, optionally, deploys) a release.
 
 Usage: octo create-release [<options>]
 
-Where [<options>] is any of: 
+Where [<options>] is any of:
 
-Release creation: 
+Release creation:
 
       --project=VALUE        Name or ID of the project.
       --defaultPackageVersion, --packageVersion=VALUE
-                             Default version number of all packages to use 
+                             Default version number of all packages to use
                              for this release. Override per-package using --
                              package.
-      --gitCommit=VALUE      [Optional] Git commit to use when creating the 
-                             release. Use in conjunction with the --gitRef 
+      --gitCommit=VALUE      [Optional] Git commit to use when creating the
+                             release. Use in conjunction with the --gitRef
                              parameter to select any previous commit.
-      --ref, --gitRef=VALUE  [Optional] Git reference to use when creating 
+      --ref, --gitRef=VALUE  [Optional] Git reference to use when creating
                              the release.
       --version, --releaseNumber=VALUE
-                             [Optional] Release number to use for the new 
+                             [Optional] Release number to use for the new
                              release.
-      --channel=VALUE        [Optional] Name or ID of the channel to use for 
-                             the new release. Omit this argument to 
+      --channel=VALUE        [Optional] Name or ID of the channel to use for
+                             the new release. Omit this argument to
                              automatically select the best channel.
-      --package=VALUE        [Optional] Version number to use for a package 
-                             in the release. Format: StepName:Version or 
-                             PackageID:Version or 
-                             StepName:PackageName:Version. StepName, 
-                             PackageID, and PackageName can be replaced with 
-                             an asterisk. An asterisk will be assumed for 
-                             StepName, PackageID, or PackageName if they are 
+      --package=VALUE        [Optional] Version number to use for a package
+                             in the release. Format: StepName:Version or
+                             PackageID:Version or
+                             StepName:PackageName:Version. StepName,
+                             PackageID, and PackageName can be replaced with
+                             an asterisk. An asterisk will be assumed for
+                             StepName, PackageID, or PackageName if they are
                              omitted.
-      --packagesFolder=VALUE [Optional] A folder containing NuGet packages 
+                             Can be specified multiple times.
+      --git-resource=VALUE   [Optional] Git reference to use for a Git resource 
+                             in the release. Format: StepName:GitRef or 
+                             StepName:GitResourceName:GitRef. GitRef can be 
+                             replaced with an asterisk. An asterisk means 
+                             use the step-defined default branch.
+                             Can be specified multiple times.
+      --packagesFolder=VALUE [Optional] A folder containing NuGet packages
                              from which we should get versions.
-      --releaseNotes=VALUE   [Optional] Release Notes for the new release. 
+      --releaseNotes=VALUE   [Optional] Release Notes for the new release.
                              Styling with Markdown is supported.
       --releaseNoteFile, --releaseNotesFile=VALUE
-                             [Optional] Path to a file that contains Release 
-                             Notes for the new release. Supports Markdown 
+                             [Optional] Path to a file that contains Release
+                             Notes for the new release. Supports Markdown
                              files.
-      --ignoreExisting       [Optional, Flag] Don't create this release if 
-                             there is already one with the same version 
+      --ignoreExisting       [Optional, Flag] Don't create this release if
+                             there is already one with the same version
                              number.
-      --ignoreChannelRules   [Optional, Flag] Create the release ignoring any 
+      --ignoreChannelRules   [Optional, Flag] Create the release ignoring any
                              version rules specified by the channel.
       --packagePrerelease=VALUE
-                             [Optional] Pre-release for latest version of all 
-                             packages to use for this release. This argument 
+                             [Optional] Pre-release for latest version of all
+                             packages to use for this release. This argument
                              supports regex patterns.
-      --whatIf               [Optional, Flag] Perform a dry run but don't 
+      --whatIf               [Optional, Flag] Perform a dry run but don't
                              actually create/deploy release.
 
-Deployment: 
+Deployment:
 
       --progress             [Optional] Show progress of the deployment.
-      --forcePackageDownload [Optional] Whether to force downloading of 
+      --forcePackageDownload [Optional] Whether to force downloading of
                              already installed packages (flag, default false).
-      --waitForDeployment    [Optional] Whether to wait synchronously for 
+      --waitForDeployment    [Optional] Whether to wait synchronously for
                              deployment to finish.
       --deploymentTimeout=VALUE
-                             [Optional] Specifies maximum time (timespan 
-                             format) that the console session will wait for 
-                             the deployment to finish(default 00:10:00). This 
+                             [Optional] Specifies maximum time (time span
+                             format) that the console session will wait for
+                             the deployment to finish(default 00:10:00). This
                              will not stop the deployment. Requires --
                              waitForDeployment parameter set.
-      --cancelOnTimeout      [Optional] Whether to cancel the deployment if 
-                             the deployment timeout is reached (flag, default 
+      --cancelOnTimeout      [Optional] Whether to cancel the deployment if
+                             the deployment timeout is reached (flag, default
                              false).
       --deploymentCheckSleepCycle=VALUE
-                             [Optional] Specifies how much time (timespan 
-                             format) should elapse between deployment status 
+                             [Optional] Specifies how much time (time span
+                             format) should elapse between deployment status
                              checks (default 00:00:10).
-      --guidedFailure=VALUE  [Optional] Whether to use guided failure mode. 
-                             (True or False. If not specified, will use 
+      --guidedFailure=VALUE  [Optional] Whether to use guided failure mode.
+                             (True or False. If not specified, will use
                              default setting from environment).
       --specificMachines=VALUE
-                             [Optional] A comma-separated list of machine 
-                             names to target in the deployed environment. If 
-                             not specified all machines in the environment 
+                             [Optional] A comma-separated list of machine
+                             names to target in the deployed environment. If
+                             not specified all machines in the environment
                              will be considered.
       --excludeMachines=VALUE
-                             [Optional] A comma-separated list of machine 
-                             names to exclude in the deployed environment. If 
-                             not specified all machines in the environment 
+                             [Optional] A comma-separated list of machine
+                             names to exclude in the deployed environment. If
+                             not specified all machines in the environment
                              will be considered.
-      --force                [Optional] If a project is configured to skip 
-                             packages with already-installed versions, 
-                             override this setting to force re-deployment 
+      --force                [Optional] If a project is configured to skip
+                             packages with already-installed versions,
+                             override this setting to force re-deployment
                              (flag, default false).
       --skip=VALUE           [Optional] Skip a step by name.
-      --noRawLog             [Optional] Don't print the raw log of failed 
+      --noRawLog             [Optional] Don't print the raw log of failed
                              tasks.
-      --rawLogFile=VALUE     [Optional] Redirect the raw log of failed tasks 
+      --rawLogFile=VALUE     [Optional] Redirect the raw log of failed tasks
                              to a file.
-  -v, --variable=VALUE       [Optional] Specifies the value for a prompted 
-                             variable in the format Label:Value. For JSON 
-                             values, embedded quotation marks should be 
+  -v, --variable=VALUE       [Optional] Specifies the value for a prompted
+                             variable in the format Label:Value. For JSON
+                             values, embedded quotation marks should be
                              escaped with a backslash.
-      --deployAt=VALUE       [Optional] Time at which deployment should start 
-                             (scheduled deployment), specified as any valid 
-                             DateTimeOffset format, and assuming the time 
+      --deployAt=VALUE       [Optional] Time at which deployment should start
+                             (scheduled deployment), specified as any valid
+                             DateTimeOffset format, and assuming the time
                              zone is the current local time zone.
-      --noDeployAfter=VALUE  [Optional] Time at which scheduled deployment 
-                             should expire, specified as any valid 
-                             DateTimeOffset format, and assuming the time 
+      --noDeployAfter=VALUE  [Optional] Time at which scheduled deployment
+                             should expire, specified as any valid
+                             DateTimeOffset format, and assuming the time
                              zone is the current local time zone.
-      --tenant=VALUE         [Optional] Create a deployment for the tenant 
-                             with this name or ID; specify this argument 
-                             multiple times to add multiple tenants or use 
-                             `*` wildcard to deploy to all tenants who are 
+      --tenant=VALUE         [Optional] Create a deployment for the tenant
+                             with this name or ID; specify this argument
+                             multiple times to add multiple tenants or use
+                             `*` wildcard to deploy to all tenants who are
                              ready for this release (according to lifecycle).
-      --tenantTag=VALUE      [Optional] Create a deployment for tenants 
-                             matching this tag; specify this argument 
-                             multiple times to build a query/filter with 
-                             multiple tags, just like you can in the user 
+      --tenantTag=VALUE      [Optional] Create a deployment for tenants
+                             matching this tag; specify this argument
+                             multiple times to build a query/filter with
+                             multiple tags, just like you can in the user
                              interface.
-      --deployTo=VALUE       [Optional] Name or ID of the environment to 
-                             automatically deploy to, e.g., 'Production' or 
-                             'Environments-1'; specify this argument multiple 
+      --deployTo=VALUE       [Optional] Name or ID of the environment to
+                             automatically deploy to, e.g., 'Production' or
+                             'Environments-1'; specify this argument multiple
                              times to deploy to multiple environments.
 
-Common options: 
+Common options:
 
       --help                 [Optional] Print help for a command.
       --helpOutputFormat=VALUE
-                             [Optional] Output format for help, valid options 
+                             [Optional] Output format for help, valid options
                              are Default or Json
-      --outputFormat=VALUE   [Optional] Output format, valid options are 
+      --outputFormat=VALUE   [Optional] Output format, valid options are
                              Default or Json
-      --server=VALUE         [Optional] The base URL for your Octopus Server, 
-                             e.g., 'https://octopus.example.com/'. This URL 
-                             can also be set in the OCTOPUS_CLI_SERVER 
+      --server=VALUE         [Optional] The base URL for your Octopus Server,
+                             e.g., 'https://octopus.example.com/'. This URL
+                             can also be set in the OCTOPUS_CLI_SERVER
                              environment variable.
-      --apiKey=VALUE         [Optional] Your API key. Get this from the user 
-                             profile page. You must provide an apiKey or 
-                             username and password. If the guest account is 
-                             enabled, a key of API-GUEST can be used. This 
-                             key can also be set in the OCTOPUS_CLI_API_KEY 
+      --apiKey=VALUE         [Optional] Your API key. Get this from the user
+                             profile page. You must provide an apiKey or
+                             username and password. If the guest account is
+                             enabled, a key of API-GUEST can be used. This
+                             key can also be set in the OCTOPUS_CLI_API_KEY
                              environment variable.
-      --user=VALUE           [Optional] Username to use when authenticating 
-                             with the server. You must provide an apiKey or 
-                             username and password. This Username can also be 
-                             set in the OCTOPUS_CLI_USERNAME environment 
+      --user=VALUE           [Optional] Username to use when authenticating
+                             with the server. You must provide an apiKey or
+                             username and password. This Username can also be
+                             set in the OCTOPUS_CLI_USERNAME environment
                              variable.
-      --pass=VALUE           [Optional] Password to use when authenticating 
-                             with the server. This Password can also be set 
+      --pass=VALUE           [Optional] Password to use when authenticating
+                             with the server. This Password can also be set
                              in the OCTOPUS_CLI_PASSWORD environment variable.
-      --configFile=VALUE     [Optional] Text file of default values, with one 
+      --configFile=VALUE     [Optional] Text file of default values, with one
                              'key = value' per line.
       --debug                [Optional] Enable debug logging.
-      --ignoreSslErrors      [Optional] Set this flag if your Octopus Server 
-                             uses HTTPS but the certificate is not trusted on 
-                             this machine. Any certificate errors will be 
-                             ignored. WARNING: this option may create a 
+      --ignoreSslErrors      [Optional] Set this flag if your Octopus Server
+                             uses HTTPS but the certificate is not trusted on
+                             this machine. Any certificate errors will be
+                             ignored. WARNING: this option may create a
                              security vulnerability.
       --enableServiceMessages
-                             [Optional] Enable TeamCity or Team Foundation 
+                             [Optional] Enable TeamCity or Team Foundation
                              Build service messages when logging.
-      --timeout=VALUE        [Optional] Timeout in seconds for network 
+      --timeout=VALUE        [Optional] Timeout in seconds for network
                              operations. Default is 600.
-      --proxy=VALUE          [Optional] The URL of the proxy to use, e.g., 
+      --proxy=VALUE          [Optional] The URL of the proxy to use, e.g.,
                              'https://proxy.example.com'.
       --proxyUser=VALUE      [Optional] The username for the proxy.
-      --proxyPass=VALUE      [Optional] The password for the proxy. If both 
-                             the username and password are omitted and 
-                             proxyAddress is specified, the default 
+      --proxyPass=VALUE      [Optional] The password for the proxy. If both
+                             the username and password are omitted and
+                             proxyAddress is specified, the default
                              credentials are used.
-      --space=VALUE          [Optional] The name or ID of a space within 
-                             which this command will be executed. The default 
+      --space=VALUE          [Optional] The name or ID of a space within
+                             which this command will be executed. The default
                              space will be used if it is omitted.
-      --logLevel=VALUE       [Optional] The log level. Valid options are 
-                             verbose, debug, information, warning, error and 
+      --logLevel=VALUE       [Optional] The log level. Valid options are
+                             verbose, debug, information, warning, error and
                              fatal. Defaults to 'debug'.
 ```
 

--- a/src/pages/docs/octopus-rest-api/octopus-cli/deploy-release.md
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/deploy-release.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-06-25
+modDate: 2024-12-16
 title: Deploy release
 description: Using the Octopus CLI to deploy releases.
 navOrder: 100

--- a/src/pages/docs/octopus-rest-api/octopus-cli/deploy-release.md
+++ b/src/pages/docs/octopus-rest-api/octopus-cli/deploy-release.md
@@ -24,7 +24,7 @@ Deployment:
       --waitForDeployment    [Optional] Whether to wait synchronously for
                              deployment to finish.
       --deploymentTimeout=VALUE
-                             [Optional] Specifies maximum time (time span
+                             [Optional] Specifies maximum time (timespan
                              format) that the console session will wait for
                              the deployment to finish(default 00:10:00). This
                              will not stop the deployment. Requires --
@@ -33,7 +33,7 @@ Deployment:
                              the deployment timeout is reached (flag, default
                              false).
       --deploymentCheckSleepCycle=VALUE
-                             [Optional] Specifies how much time (time span
+                             [Optional] Specifies how much time (timespan
                              format) should elapse between deployment status
                              checks (default 00:00:10).
       --guidedFailure=VALUE  [Optional] Whether to use guided failure mode.


### PR DESCRIPTION
https://github.com/OctopusDeploy/docs/commit/84533e1c25d86cfe9d305c9e24b25051e91b60ba#diff-3ff5010e27082aad4cc3916a5118a1a06022f9f70d5334e22fcc05c70ff5b5d0R27 changed the word `timespan` to `time span` in the CLI output.

CLI output:
![CleanShot 2024-12-16 at 13 03 52@2x](https://github.com/user-attachments/assets/42e8215a-537d-4eaa-9434-cdacb4abdff7)
