### PR TITLE
Update the supported Kubernetes server versions for the Kubernetes agent

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/index.md
@@ -74,9 +74,11 @@ The Kubernetes agent follows [semantic versioning](https://semver.org/), so a ma
 | Kubernetes agent | Octopus Server           | Kubernetes cluster   |
 | ---------------- | ------------------------ | -------------------- |
 | 1.0.0 - 1.16.1   | **2024.2.6580** or newer | **1.26** to **1.29** |
-| 1.17.0 - 1.\*.\* | **2024.2.6580** or newer | **1.27** to **1.30** |
+| 1.17.0 - 1.19.2  | **2024.2.6580** or newer | **1.27** to **1.30** |
+| 1.20.0 - 1.\*.\* | **2024.2.6580** or newer | **1.28** to **1.31** |
 | 2.0.0 - 2.2.1    | **2024.2.9396** or newer | **1.26** to **1.29** |
-| 2.3.0 - 2.\*.\*  | **2024.2.9396** or newer | **1.27** to **1.30** |
+| 2.3.0 - 2.8.2    | **2024.2.9396** or newer | **1.27** to **1.30** |
+| 2.9.0 - 2.\*.\*  | **2024.2.9396** or newer | **1.28** to **1.31** |
 
 Additionally, the Kubernetes agent only supports **Linux AMD64** and **Linux ARM64** Kubernetes nodes.
 


### PR DESCRIPTION
The supported Kubernetes server versions have been updated due to an upgrade of the Kubernetes client library in the agent.

<img width="708" alt="Screenshot 2024-12-20 at 10 32 48 am" src="https://github.com/user-attachments/assets/abb584a5-0b26-4129-9fb8-ec6b6b47b268" />

[sc-99802]
