### PR TITLE
Remove dated TF version references

### DIFF
--- a/src/pages/docs/deployments/terraform/index.md
+++ b/src/pages/docs/deployments/terraform/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2024-12-23
 title: Terraform
 description: Terraform deployments
 navOrder: 100
@@ -16,7 +16,7 @@ Octopus Deploy provides first-class support for deploying Terraform templates.
 
 The `Plan to apply a Terraform template` will generate a plan for the result of running `apply` on a template, while `Plan a Terraform destroy` will generate a plan for the result of running `destroy` on the template.
 
-Similarly, the `Apply a Terraform template` step can be used to create or update a resources from a Terraform template, while the `Destroy Terraform resources` step can be used to destroy existing Terraform resources.
+Similarly, the `Apply a Terraform template` step can be used to create or update resources from a Terraform template, while the `Destroy Terraform resources` step can be used to destroy existing Terraform resources.
 
 The built-in Octopus Terraform steps are created to help you follow a pipeline using the following process:
 
@@ -31,12 +31,12 @@ The built-in Octopus Terraform steps are created to help you follow a pipeline u
 All Terraform steps execute on a worker. By default, that will be the built-in worker in the Octopus Server. Learn about [workers](/docs/infrastructure/workers) and the different configuration options.
 
 :::div{.warning}
-If the Terraform tool is updated above version `0.11`, you are using an Octopus version prior to **2020.5.0**, and you are using the **Source Code** option within a Terraform step, you will receive syntax warnings within Octopus. You can update the Terraform tool to a version higher than `0.11` without issue in an Octopus version prior to **2020.5.0** only if you use the **File inside a package** option within the terraform step.
+If the Terraform tool is updated above version `0.11`, you are using an Octopus version prior to **2020.5.0**, and you are using the **Source Code** option within a Terraform step, you will receive syntax warnings within Octopus. You can update the Terraform tool to a version higher than `0.11` without issue in an Octopus version prior to **2020.5.0** only if you use the **File inside a package** option within the Terraform step.
 :::
 
 ## Special variables
 
-Setting the variable `Octopus.Action.Terraform.CustomTerraformExecutable` to the absolute path of a custom Terraform executable will result in the step using that executable instead of the one shipped with Octopus. You can use this variable to force the Terraform steps to use a specific version of Terraform, or to use the x64 version if you wish.
+Setting the variable `Octopus.Action.Terraform.CustomTerraformExecutable` to the absolute path of a custom Terraform executable will result in the step using that executable instead of the one shipped with Octopus. You can use this variable to force the Terraform steps to use a specific version of Terraform or to use the x64 version if you wish.
 
 For example, setting `Octopus.Action.Terraform.CustomTerraformExecutable` to `C:\Apps\terraform.exe` will cause the steps to execute `C:\Apps\terraform.exe` rather than the built in copy of Terraform.
 
@@ -48,7 +48,7 @@ The Terraform steps have some unique messages that may be displayed in the outpu
 
 ### Terraform-Configuration-UntestedTerraformCLIVersion
 
-The Terraform steps in Octopus Deploy are tested against a range of versions of the Terraform CLI from 0.11.15 to 1.0.0. As new versions of Terraform are released, testing will be expanded to include these versions to ensure that they are compatible with the Terraform steps in Octopus. In the meantime, if the Terraform CLI version used in a step is outside the tested range a message will be displayed in the output indicating this. The Terraform step will likely continue to run successfully even if the CLI version being used has not been tested in Octopus. If the step succeeds, then the message will be informational only, and there is no action that needs to be taken. If the step resulted in an error, then the message will be a warning; however, the error may not be related to the version of Terraform being used.
+The Terraform steps in Octopus Deploy are tested against a range of versions of the Terraform CLI. If the Terraform CLI version used in a step is outside the tested range, a message will be displayed in the output indicating this. The Terraform step will likely continue to run successfully even if the CLI version being used has not been tested in Octopus. If the step succeeds, then the message will be informational only, and there is no action that needs to be taken. If the step resulted in an error, then the message will be a warning; however, the error may not be related to the version of Terraform being used.
 
 ## Learn more
 


### PR DESCRIPTION
Removed stale tested versions and reworded to remove the need to explicitly define this every time the testing range changes.