### PR TITLE
Tweak ssh-deployments to reference all external feeds, not just nuget

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -107,6 +107,7 @@ emptytitle
 entra
 environmentids
 eprintfn
+esac
 expressjs
 externalgroups
 externalusers

--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-deployments.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-deployments.md
@@ -76,7 +76,7 @@ By making all paths relative to the user's home directory, you can then theoreti
 
 ## Package acquisition
 
-Leveraging Calamari means that the deployment can obtain the package via the same methods as a target running the Tentacle agent; either pushed from the server or directly from a NuGet repository. There is therefore no bottleneck in acquisition if there are multiple SSH endpoints all trying to retrieve the same package independently.
+Leveraging Calamari means that the deployment can obtain the package via the same methods as a target running the Tentacle agent; either pushed from the server or directly from a supported [external repository](/docs/packaging-applications/package-repositories). There is therefore no bottleneck in acquisition if there are multiple SSH endpoints all trying to retrieve the same package independently.
 
 ## Calamari
 

--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-deployments.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-deployments.md
@@ -29,6 +29,7 @@ If you are writing a cross-platform script, be aware of the differences between 
 :::div{.hint}
 **Bash (and other shell) variables**
 Octopus Deploy will log into the SSH target via a non-interactive shell. Because of this, startup files like `.bashrc` are not fully evaluated. If you are referencing bash variables `export`ed in these files, you should move them before the following common code block at the top of the file:
+<!--- cspell:disable -->
 ```
 # If not running interactively, don't do anything
 case $- in
@@ -36,6 +37,7 @@ case $- in
       *) return;;
 esac
 ```
+<!--- cspell:enable -->
 This will ensure that they are evaluated on non-interactive logins.
 :::
 
@@ -55,11 +57,11 @@ You can also set an [output variable](/docs/projects/variables/output-variables)
 ### Example: Collecting an artifact
 
 Your script can tell Octopus to collect a file and store it as a [deployment artifact](/docs/projects/deployment-process/artifacts):
-
+<!--- cspell:disable -->
 > ```
 > new_octopusartifact "./subdir/anotherdir/myfile"
 > ```
-
+<!--- cspell:enable -->
 which results in the server retrieving that file, at the end of that step. Keep in mind that this means the file must be accessible over SFTP using the same credentials as that used during execution.
 
 ## Transport
@@ -80,7 +82,7 @@ Leveraging Calamari means that the deployment can obtain the package via the sam
 
 ## Calamari
 
-Calamari is the tool Octopus uses to execute deployments on a remote computer. Before any processing is begun we do an initial check to ensure the available Calamari executable on the endpoint is up to date with the server. If not, we push up the latest Calamari package and then recommence the task. The Calamari package is sent as a `.tar.gz` so it can be extracted with minimal dependencies. This means the server needs to be able to un-tar that package, however, this should be available by default in most distros.
+Calamari is the tool Octopus uses to execute deployments on a remote computer. Before any processing is begun we do an initial check to ensure the available Calamari executable on the endpoint is up to date with the server. If not, we push up the latest Calamari package and then recommence the task. The Calamari package is sent as a `.tar.gz` so it can be extracted with minimal dependencies. This means the server needs to be able to un-tar that package, however, this should be available by default in most distributions.
 
 ## Learn more
 

--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-deployments.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-deployments.md
@@ -29,18 +29,17 @@ If you are writing a cross-platform script, be aware of the differences between 
 :::div{.hint}
 **Bash (and other shell) variables**
 Octopus Deploy will log into the SSH target via a non-interactive shell. Because of this, startup files like `.bashrc` are not fully evaluated. If you are referencing bash variables `export`ed in these files, you should move them before the following common code block at the top of the file:
-<!--- cspell:disable -->
-```
+
+```bash
 # If not running interactively, don't do anything
 case $- in
     *i*) ;;
       *) return;;
 esac
 ```
-<!--- cspell:enable -->
+
 This will ensure that they are evaluated on non-interactive logins.
 :::
-
 
 ### Example: Using variables in Bash
 
@@ -50,18 +49,18 @@ Your script can use a [variable value](/docs/projects/variables) by invoking the
 
 You can also set an [output variable](/docs/projects/variables/output-variables):
 
-> ```
-> set_octopusvariable RandomNumber 3
-> ```
+```bash
+set_octopusvariable RandomNumber 3
+```
 
 ### Example: Collecting an artifact
 
 Your script can tell Octopus to collect a file and store it as a [deployment artifact](/docs/projects/deployment-process/artifacts):
-<!--- cspell:disable -->
-> ```
-> new_octopusartifact "./subdir/anotherdir/myfile"
-> ```
-<!--- cspell:enable -->
+
+```bash
+new_octopusartifact "./subdir/another_dir/my_file"
+```
+
 which results in the server retrieving that file, at the end of that step. Keep in mind that this means the file must be accessible over SFTP using the same credentials as that used during execution.
 
 ## Transport


### PR DESCRIPTION
The ssh-deployments file states that calamari is used such that packages can be acquired - either from server or from nuget.

This has been updated to reference (and link to) all possible external repos.