### PR TITLE
Cater for multi-line link labels in right sidenav

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -861,7 +861,7 @@ nav.skip-links a:focus {
   flex-direction: column;
   justify-content: center;
   list-style: none;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
 .article-nav__item {
@@ -872,7 +872,7 @@ nav.skip-links a:focus {
   display: flex;
   color: var(--color-subtitle);
   font-size: var(--font-size-medium);
-  line-height: 2.6rem;
+  line-height: 1.5rem;
   font-weight: 400;
   text-decoration: none;
   transition-property: font-weight, color, transform;


### PR DESCRIPTION
# Before
<img width="573" alt="Screenshot 2025-01-22 at 4 32 51 pm" src="https://github.com/user-attachments/assets/11aeb346-e8f0-4ca7-94b6-cf088ab8bf9c" />

# After 
<img width="569" alt="Screenshot 2025-01-22 at 4 27 17 pm" src="https://github.com/user-attachments/assets/6f893eb7-671e-43eb-b6eb-797efa315314" />
