### PR TITLE
Update build info docs to callout maven feed groupId & packageId requ…

### DIFF
--- a/src/pages/docs/packaging-applications/build-servers/build-information/index.md
+++ b/src/pages/docs/packaging-applications/build-servers/build-information/index.md
@@ -58,7 +58,7 @@ The build information step requires
 - Octopus URL: URL of your Octopus server
 - API Key: API key to use for uploading
 - (Optional) Space name: Name of the space to upload the build information to
-- Package ID: List of package IDs to associate the Build Information to. For maven packages hosted in external feeds the groupID and packageID are required, for more information see our [maven documentation](/docs/packaging-applications/package-repositories/maven-feeds#troubleshooting-maven-feeds)).
+- Package ID: List of package IDs to associate the build information to. For maven packages hosted in external feeds the groupID and packageID are required, for more information see our [maven documentation](/docs/packaging-applications/package-repositories/maven-feeds#troubleshooting-maven-feeds)).
 - Package version: The version of the packages
 
 :::div{.hint}

--- a/src/pages/docs/packaging-applications/build-servers/build-information/index.md
+++ b/src/pages/docs/packaging-applications/build-servers/build-information/index.md
@@ -58,7 +58,7 @@ The build information step requires
 - Octopus URL: URL of your Octopus server
 - API Key: API key to use for uploading
 - (Optional) Space name: Name of the space to upload the build information to
-- Package ID: List of package IDs to associate the build information to
+- Package ID: List of package IDs to associate the Build Information to. For maven packages hosted in external feeds the groupID and packageID are required, for more information see our [maven documentation](/docs/packaging-applications/package-repositories/maven-feeds#troubleshooting-maven-feeds)).
 - Package version: The version of the packages
 
 :::div{.hint}


### PR DESCRIPTION
A couple of customers have run into issues trying to get build information for maven feeds to display. This is usually because the groupId is not included. This is a Maven feed specific requirement that calling out should help customers diagnose and resolve this problem. 

[Internal thread](https://octopusdeploy.slack.com/archives/CNHBHV2BX/p1738079840110819)