### PR TITLE
Add deprecation notice for the Get Events V1 endpoint

### DIFF
--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-05-10
+modDate: 2025-03-11
 title: Deprecations
 description: Upcoming and past deprecations by version for Octopus Server
 navOrder: 300

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -35,7 +35,7 @@ Further notes about this pending change can be found in the [2024.1 deprecation 
 ## Deprecations for 2025.1
 
 ### System and Space Level `/events` API Endpoint
-The `GET /events` and `GET /{spaceId}/events` API endpoints will be replaced by new versions that don't return pagination properties. Events are created constantly, minimising the value of providing individual page numbers, and calculating the total number of results can be very expensive on instances with larger data sets.
+The `GET /events` and `GET /{spaceId}/events` API endpoints will be replaced by new versions that don't return pagination properties. Events are created constantly, minimizing the value of providing individual page numbers, and calculating the total number of results can be very expensive on instances with larger data sets.
 
 For similar functionality without pagination, use the `GET /events/v2` and `GET /{spaceId}/events/v2` endpoints. To export events in CSV format, use the `GET /events/export` or `GET /events/{spaceId}/export` endpoints.
 

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -23,6 +23,11 @@ Deprecations are subject to change in detail or time frame. If you need help ass
 
 ## Planned Deprecations
 
+### System and Space Level `/events` API Endpoint in 2025.4
+The `GET /events` and `GET /{spaceId}/events` API endpoints will be replaced by new versions that don't return pagination properties. Events are created constantly, minimising the value of providing individual page numbers, and calculating the total number of results can be very expensive on instances with larger data sets.
+
+The `GET /events/v2` and `GET /{spaceId}/events/v2` endpoints will be available to retrieve events in JSON format. CSV exporting will be available with the `GET /events/export` and `GET /events/{spaceId}/export` endpoints.
+
 ### Dropping capability for Windows Server 2008 Workers and Targets in 2025.1
 Microsoft [dropped extended support](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008) for the Windows Server 2008 family in January 2020. This operating system is also the last Windows OS that does not support .NET Core, one of the languages used to build Octopus Deploy. The complexity required to support this legacy platform outweighs the value to our customers.
 

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -32,7 +32,7 @@ To provide ample time to act, from Octopus Server `2024.1`, workloads that run o
 
 Further notes about this pending change can be found in the [2024.1 deprecation blog post](https://octopus.com/blog/2024-deprecated-features#windows-server-2008)
 
-## Deprecations for 2025.1
+## Deprecations for 2025.2
 
 ### System and Space Level `/events` API Endpoint
 The `GET /events` and `GET /{spaceId}/events` API endpoints will be replaced by new versions that don't return pagination properties. Events are created constantly, minimizing the value of providing individual page numbers, and calculating the total number of results can be very expensive on instances with larger data sets.

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -23,11 +23,6 @@ Deprecations are subject to change in detail or time frame. If you need help ass
 
 ## Planned Deprecations
 
-### System and Space Level `/events` API Endpoint in 2025.4
-The `GET /events` and `GET /{spaceId}/events` API endpoints will be replaced by new versions that don't return pagination properties. Events are created constantly, minimising the value of providing individual page numbers, and calculating the total number of results can be very expensive on instances with larger data sets.
-
-The `GET /events/v2` and `GET /{spaceId}/events/v2` endpoints will be available to retrieve events in JSON format. CSV exporting will be available with the `GET /events/export` and `GET /events/{spaceId}/export` endpoints.
-
 ### Dropping capability for Windows Server 2008 Workers and Targets in 2025.1
 Microsoft [dropped extended support](https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008) for the Windows Server 2008 family in January 2020. This operating system is also the last Windows OS that does not support .NET Core, one of the languages used to build Octopus Deploy. The complexity required to support this legacy platform outweighs the value to our customers.
 
@@ -36,6 +31,13 @@ It has been [noted for several years](https://octopus.com/docs/infrastructure/de
 To provide ample time to act, from Octopus Server `2024.1`, workloads that run on Windows 2008 Servers will begin logging warnings. We urge you to upgrade your targets to a later version of Windows Server before `2025.1` to prepare for the removal of functionality.
 
 Further notes about this pending change can be found in the [2024.1 deprecation blog post](https://octopus.com/blog/2024-deprecated-features#windows-server-2008)
+
+## Deprecations for 2025.1
+
+### System and Space Level `/events` API Endpoint
+The `GET /events` and `GET /{spaceId}/events` API endpoints will be replaced by new versions that don't return pagination properties. Events are created constantly, minimising the value of providing individual page numbers, and calculating the total number of results can be very expensive on instances with larger data sets.
+
+For similar functionality without pagination, use the `GET /events/v2` and `GET /{spaceId}/events/v2` endpoints. To export events in CSV format, use the `GET /events/export` or `GET /events/{spaceId}/export` endpoints.
 
 ## Deprecations for 2024.3
 


### PR DESCRIPTION
Adds a deprecation notice for the `/api/events` and `/api/{spaceId}/events` endpoints.

[sc-104549]