### PR TITLE
Adding official support for Windows Server 2025 for Octopus Server

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/windows/requirements/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/windows/requirements/index.mdx
@@ -18,8 +18,9 @@ The installation requirements for the latest version of Tentacle are:
 -  Windows Server 2012
 -  Windows Server 2012 R2
 -  Windows Server 2016 (Both "Server Core" and "Server with a GUI" installations are supported for Tentacle).
--  Windows Server 2019 
+-  Windows Server 2019
 -  Windows Server 2022
+-  Windows Server 2025
 -  Windows 10 Enterprise LTSC 2021 (Version 21H2)
 
 :::div{.warning}

--- a/src/pages/docs/installation/requirements.mdx
+++ b/src/pages/docs/installation/requirements.mdx
@@ -21,12 +21,13 @@ However, once your Octopus Server is up and running, you can deploy to Windows s
 
 ### Windows Server
 
-Octopus Server can be hosted on **Windows Server 2012 R2 or higher**. We automatically test Octopus Server on the following versions of Windows Server:
+Octopus Server can be hosted on **Windows Server 2012 R2 or higher**. We support Octopus Server on the following versions of Windows Server:
 
 - Windows Server 2012 R2
 - Windows Server 2016
 - Windows Server 2019
 - Windows Server 2022
+- Windows Server 2025
 
 Octopus Server will run on [Windows Server (Core)](https://docs.microsoft.com/en-us/windows-server/administration/server-core/what-is-server-core) without the Desktop experience. However, the easiest installation path is to use "Server with Desktop Experience" which has a GUI and supports running our installation wizard. If you want to use Windows Server Core, you will need to add some missing Windows Features and configure the Octopus Server yourself.
 


### PR DESCRIPTION
Our installation requirements do not yet list Windows Server 2025 in our list of supported platforms for Octopus Server. This PR updates that.

While here, we're also modifying the wording to clarify that we do not guarantee automatic testing any of these platforms (which is not sustainable based on the number of combinations of platforms/agents we'd need to setup), only that we support them.