### PR TITLE
replace broken link to SQL express in docs

### DIFF
--- a/src/pages/docs/installation/index.mdx
+++ b/src/pages/docs/installation/index.mdx
@@ -34,7 +34,7 @@ When installed, the self-hosted Octopus Server:
 - Runs
   - As a Windows Service called **OctopusDeploy**, installed via an MSI.
   - In a [Linux](/docs/installation/octopus-server-linux-container) container.
-- Stores its data in an [SQL Server Database](/docs/installation/sql-server-database/). ([SQL Server Express](http://downloadsqlserverexpress.com) is an easy way of getting started.)
+- Stores its data in an [SQL Server Database](/docs/installation/sql-server-database/). ([SQL Server Express](https://oc.to/downloadsqlserverexpress) is an easy way of getting started.)
 - Includes an embedded HTTP server which serves the [Octopus REST API](/docs/octopus-rest-api/) and the  **Octopus Web Portal** that you will use to manage your [infrastructure](/docs/infrastructure/), [deployments](/docs/projects/deployment-process/), [runbooks](/docs/runbooks/), and coordinate your [releases](/docs/releases).
 
 Before you install Octopus Deploy, review the software and hardware [requirements](/docs/installation/requirements/), and make sure you have access to an instance of [SQL Server Database](/docs/installation/sql-server-database) that you can use with Octopus Deploy.

--- a/src/pages/docs/installation/index.mdx
+++ b/src/pages/docs/installation/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-05-24
+modDate: 2024-05-01
 title: Installation of Octopus Server
 subtitle: How to install Octopus Server
 icon: fa-solid fa-server

--- a/src/pages/docs/installation/sql-database/index.mdx
+++ b/src/pages/docs/installation/sql-database/index.mdx
@@ -17,7 +17,7 @@ Octopus Deploy stores projects, environments, and deployment history in a Micros
 
 ## Using SQL Server Express \{#SQLServerDatabaseRequirements-UsingSQLServerExpress}
 
-The easiest and cheapest way to get started is with [SQL Server Express](http://downloadsqlserverexpress.com/) and install the Octopus Server and SQL Server Express side-by-side on your server. This is a great way to test Octopus for a proof of concept. Depending on your needs, you might decide to use SQL Server Express, or upgrade to another supported edition.
+The easiest and cheapest way to get started is with [SQL Server Express](https://oc.to/downloadsqlserverexpress) and install the Octopus Server and SQL Server Express side-by-side on your server. This is a great way to test Octopus for a proof of concept. Depending on your needs, you might decide to use SQL Server Express, or upgrade to another supported edition.
 
 ## Configuration Guidelines
 

--- a/src/pages/docs/installation/sql-database/index.mdx
+++ b/src/pages/docs/installation/sql-database/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-05-22
+modDate: 2024-05-01
 title: SQL Database
 navTitle: Overview
 navSection: SQL Database


### PR DESCRIPTION
# Background
Octopus previously used a link to download SQL express server provided by [an external blog post](https://www.hanselman.com/blog/download-sql-server-express). However the link has since broken.
[[sc-108133]](https://app.shortcut.com/octopusdeploy/story/108133/sev-3-the-url-we-use-for-sql-express-in-the-server-install-does-not-work-requested-by-james-cornford)

## Results
A new link was created using an oct.to url which links directly to the micosoft SQL express download page.
Fixes https://github.com/OctopusDeploy/Issues/issues/9352

### Before
http://downloadsqlserverexpress.com/

### After
https://oc.to/downloadsqlserverexpress