### PR TITLE
Move markdown lint config into json file

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "MD013": false,
+    "emphasis": { "style": "asterisk" },
+    "no-inline-html": false,
+    "ul-style": { "style": "dash" }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,10 +5,5 @@
     },
     "[markdown]": {
     },
-    "markdownlint.run": "onSave",
-    "markdownlint.config": {
-        "emphasis": { "style": "asterisk" },
-        "no-inline-html": false,
-        "ul-style": { "style": "dash" }
-    },
+    "markdownlint.run": "onSave"
 }

--- a/src/pages/docs/administration/spaces/index.mdx
+++ b/src/pages/docs/administration/spaces/index.mdx
@@ -115,10 +115,10 @@ With a default space enabled, any REST API calls that do not specify a space in 
 
 This means that by disabling the default space - **you are opting into a non-backwards compatible scenario**, so be prepared! Things to check include:
 
- - Versions of Tentacle on target environments need to be upgraded to [Tentacle 4.0.0](https://octopus.com/downloads/2019.1.1) the latest version otherwise they will not connect.
- - Scripts you've written that directly call the API.
- - Integrations with Octopus Server are updated to their latest versions (like Azure DevOps, TFS, and Team City plugins)
- - Community library templates that use the API are updated (you can [refer to this PR](https://github.com/OctopusDeploy/Library/pull/750) as a guide).
+- Versions of Tentacle on target environments need to be upgraded to [Tentacle 4.0.0](https://octopus.com/downloads/2019.1.1) the latest version otherwise they will not connect.
+- Scripts you've written that directly call the API.
+- Integrations with Octopus Server are updated to their latest versions (like Azure DevOps, TFS, and Team City plugins)
+- Community library templates that use the API are updated (you can [refer to this PR](https://github.com/OctopusDeploy/Library/pull/750) as a guide).
 
 To disable the default space, follow these steps:
 
@@ -132,7 +132,7 @@ When you log into the Octopus Web Portal, the first item on the navigation menu 
 
 There is a hard barrier between spaces, so, for instance, a deployment target configured for Space-A isn't available to projects in Space-B. However, there are some things that aren't scoped to a space, and are available system wide.
 
-The following table shows which Octopus resources are space-scoped, system-scoped, or scoped to both. 
+The following table shows which Octopus resources are space-scoped, system-scoped, or scoped to both.
 
 :::div{.hint}
 If a resource isn't listed below, then it's space-scoped.


### PR DESCRIPTION
Tested on a page to ensure the config is picked up.

This should help markdown lint rules be applied regardless of IDE.