### PR TITLE
Add troubleshooting section for script pod exec error

### DIFF
--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
@@ -122,7 +122,7 @@ scriptPods:
                 - [ARCH]
 ```
 
-3. In a terminal connected to the cluster with the agent installed, run a Helm upgrade referencing the yaml file created above. You can get the `HELM-RELEASE-NAME` and `NAMESPACE` from the **Connectivity** page on the **Deployment Target** or **Worker** details page
+3. In a terminal connected to the cluster with the agent installed, run a Helm upgrade referencing the YAML file created above. You can get the `HELM-RELEASE-NAME` and `NAMESPACE` from the **Connectivity** page on the **Deployment Target** or **Worker** details page
 
 ```bash
 helm upgrade --atomic --namespace [NAMESPACE] --reset-then-reuse-values -f [YAML-FILENAME] [HELM-RELEASE-NAME] oci://registry-1.docker.io/octopusdeploy/kubernetes-agent

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
@@ -88,7 +88,7 @@ To mitigate this issue, you can set the pod affinity for both the Tentacle and s
 The steps to do this are:
 
 1. Determine what node architecture you want to run on. This will be either `amd64` or `arm64`
-2. Create a yaml file with the following content (replacing `[ARCH]` with the architecture determined in 1.):
+2. Create a YAML file with the following content (replacing `[ARCH]` with the architecture determined in 1.):
 
 ```yaml
 agent:

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
@@ -128,7 +128,6 @@ scriptPods:
 helm upgrade --atomic --namespace [NAMESPACE] --reset-then-reuse-values -f [YAML-FILENAME] [HELM-RELEASE-NAME] oci://registry-1.docker.io/octopusdeploy/kubernetes-agent
 ```
 
-
 ## Health Checks and Upgrades
 
 ### `error looking up service account octopus-agent-XXX/octopus-agent-auto-upgrader: serviceaccount \"octopus-agent-auto-upgrader\" not found`

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/troubleshooting/index.md
@@ -97,6 +97,10 @@ agent:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
             - key: kubernetes.io/arch
               operator: In
               values:
@@ -108,6 +112,10 @@ scriptPods:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
             - key: kubernetes.io/arch
               operator: In
               values:


### PR DESCRIPTION
Adds a new troubleshooting section for the exec error for the Kubernetes agent/worker

![image](https://github.com/user-attachments/assets/7b3da01b-df5c-45fb-81a6-9bc8eff8382e)
