### PR TITLE
Minor update to fix Markdown anchor for feeds

### DIFF
--- a/src/pages/docs/infrastructure/accounts/openid-connect.md
+++ b/src/pages/docs/infrastructure/accounts/openid-connect.md
@@ -37,7 +37,7 @@ The subject can be modified for the three different uses within Octopus:
 - [Deployments and Runbooks](#deployments-and-runbooks)
 - [Health Checks](#health-checks)
 - [Account Test](#account-test)
-- [Feeds] (#feeds)
+- [Feeds](#feeds)
 
 ### Subject key parts
 


### PR DESCRIPTION
The feeds anchor had a space init making it so the markdown didn't interpret it as an achor.