### PR TITLE
Move docs from ScriptCS to dotnet-script

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -430,6 +430,7 @@ swaggerui
 systemprofile
 tabindex
 tabpanel
+Tasklogs
 tagset
 tagsets
 TCPIP

--- a/src/pages/docs/deployments/custom-scripts/error-handling.md
+++ b/src/pages/docs/deployments/custom-scripts/error-handling.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Error handling
 description: Error handling for scripts in Octopus.
 icon: fa-regular fa-circle-exclamation
@@ -69,7 +69,7 @@ Fail-Step "A friendly message"
 <summary>C#</summary>
 
 ```csharp
-Octopus.FailStep("A friendly message");
+FailStep("A friendly message");
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/index.md
+++ b/src/pages/docs/deployments/custom-scripts/index.md
@@ -1,9 +1,9 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-11-01
+modDate: 2025-05-19
 title: Custom scripts
-description: Custom scripts allows you to script anything you want using PowerShell, ScriptCS, F#, Python, or Bash.
+description: Custom scripts allows you to script anything you want using PowerShell, Dotnet Script, F#, Python, or Bash.
 icon: fa-regular fa-file-code
 navOrder: 150
 ---
@@ -26,6 +26,8 @@ Octopus supports the following scripting environments:
 C# scripts (.csx) using [ScriptCS](https://github.com/scriptcs/scriptcs) will still work, but is marked for deprecation. You can find the announcement from ScriptCS that the project is no longer being maintained [here](https://github.com/scriptcs/scriptcs/issues/1323).
 
 C# scripts using ScriptCS will generate warning in your Octopus task logs from version 2024.2.7996+ advising users to use dotnet-script. For more information and ScriptCS to dotnet-script migration instructions, see our [blog announcement here](https://octopus.com/blog/rfc-migrate-scriptcs-dotnet-script).
+
+Support for ScriptCS in Octopus will be removed from `2025.3`.
 
 To view previous and upcoming deprecations, please visit our [deprecations page](https://octopus.com/docs/deprecations).
 :::

--- a/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-07-18
+modDate: 2025-05-19
 title: Logging messages from scripts
 description: When your scripts emit messages Octopus will display the messages in the Task Logs at the most appropriate level for the message.
 icon: fa-solid fa-clock-rotate-left
@@ -31,10 +31,10 @@ Write-Error "This will be logged as an Error and may cause your script to stop r
 Console.WriteLine("This will be logged as Information");
 Console.Out.WriteLine("This will be logged as Information too!");
 Console.Error.WriteLine("This will be logged as an Error.");
-Octopus.WriteVerbose("Verbose!!!");
-Octopus.WriteHighlight("This is a highlight");
-Octopus.WriteWait("Deployment is waiting on something");
-Octopus.WriteWarning("Warning");
+WriteVerbose("Verbose!!!");
+WriteHighlight("This is a highlight");
+WriteWait("Deployment is waiting on something");
+WriteWarning("Warning");
 ```
 
 </details>
@@ -107,8 +107,8 @@ Update-Progress 50 "We're halfway there!"
 <summary>C#</summary>
 
 ```csharp
-Octopus.UpdateProgress(10);
-Octopus.UpdateProgress(50, "We're halfway there!");
+UpdateProgress(10);
+UpdateProgress(50, "We're halfway there!");
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/output-variables.md
+++ b/src/pages/docs/deployments/custom-scripts/output-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-27
+modDate: 2025-05-19
 title: Output variables
 description: Your scripts can emit variables that are available in subsequent deployment steps.
 icon: fa-solid fa-file-export
@@ -24,7 +24,7 @@ Set-OctopusVariable -name "AppInstanceName" -value "MyAppInstance"
 <summary>C#</summary>
 
 ```csharp
-Octopus.SetVariable("AppInstanceName", "MyAppInstance");
+SetVariable("AppInstanceName", "MyAppInstance");
 ```
 
 </details>
@@ -67,7 +67,7 @@ $appInstanceName = $OctopusParameters["Octopus.Action[Determine App Instance Nam
 <summary>C#</summary>
 
 ```csharp
-var appInstanceName = Octopus.Parameters["Octopus.Action[Determine App Instance Name].Output.AppInstanceName"]
+var appInstanceName = OctopusParameters["Octopus.Action[Determine App Instance Name].Output.AppInstanceName"]
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/passing-parameters-to-scripts.mdx
+++ b/src/pages/docs/deployments/custom-scripts/passing-parameters-to-scripts.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Passing parameters to scripts
 description: Octopus can pass parameters to your custom script files for any of the supported scripting languages.
 icon: fa-solid fa-arrow-right-to-bracket
@@ -71,9 +71,7 @@ Write-Host "$Environment storage path: $StoragePath"
 
 ## Passing parameters to C# scripts \{#passing-parameters-csharp}
 
-<ScriptCSDeprecation />
-
-You can pass parameters to C# scripts [as described here for the ScriptCS engine](https://github.com/scriptcs/scriptcs/wiki/Pass-arguments-to-scripts). ScriptCS only supports positional parameters.
+You can pass parameters to C# scripts [as described here for the dotnet-script engine](https://github.com/dotnet-script/dotnet-script#passing-arguments-to-scripts).
 
 **Script Parameters in Octopus**
 
@@ -84,8 +82,8 @@ You can pass parameters to C# scripts [as described here for the ScriptCS engine
 **Usage in C# script**
 
 ```csharp
-var environment = Env.ScriptArgs[0]
-var storagePath = Env.ScriptArgs[1]
+var environment = Args[0]
+var storagePath = Args[1]
 Console.WriteLine("{0} storage path: {1}", environment, storagePath);
 ```
 

--- a/src/pages/docs/deployments/custom-scripts/scripts-in-packages/reference-files-within-a-package.md
+++ b/src/pages/docs/deployments/custom-scripts/scripts-in-packages/reference-files-within-a-package.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Reference files within a package
 description: How to reference files within a package.
 icon: fa-solid fa-cubes
@@ -54,9 +54,9 @@ Get-Content ".\subfolder\file.txt"
 
 ```csharp C#
 // in pre-deploy, in post-deploy if custom installation directory has not been defined
-var extractPath = Octopus.Parameters["Octopus.Action.Package.InstallationDirectoryPath"];
+var extractPath = OctopusParameters["Octopus.Action.Package.InstallationDirectoryPath"];
 // if a custom installation directory has been defined
-var customPath = Octopus.Parameters["Octopus.Action.Package.CustomInstallationDirectory"];
+var customPath = OctopusParameters["Octopus.Action.Package.CustomInstallationDirectory"];
 // original extract path,
 Console.WriteLine(File.ReadAllText(extractPath + @"\subfolder\file.txt"));
 // or when a custom installation directory has been defined,

--- a/src/pages/docs/deployments/custom-scripts/using-variables-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/using-variables-in-scripts.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Using variables in scripts
 description: With Octopus you can define variables for use with your custom scripts.
 icon: fa-regular fa-file-code
@@ -32,7 +32,7 @@ Write-Host "Connection string is: $connectionString"
 
 ```csharp
 // It's a good idea to copy the value into a local variable to avoid quoting issues
-var connectionString = Octopus.Parameters["MyApp.ConnectionString"];
+var connectionString = OctopusParameters["MyApp.ConnectionString"];
 Console.WriteLine("MyApp.ConnectionString: " + connectionString);
 ```
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-03-22
+modDate: 2025-05-19
 title: Linux Tentacle
 description: How to install and configure Octopus Tentacles on Linux Servers in either listening or polling mode.
 navOrder: 20
@@ -24,15 +24,9 @@ Linux Tentacle is a .NET application distributed as a [self-contained deployment
 
 ## Known limitations
 
-Support for ScriptCS and F# scripts are only available with **Mono 4** and above. While they require mono installed, they will still execute with the self-contained Calamari.
-
-ScriptCS has not been ported for .NET Core ([GitHub issue](https://github.com/scriptcs/scriptcs/issues/1183)).
+Support for F# scripts are only available with **Mono 4** and above. While they require mono installed, they will still execute with the self-contained Calamari.
 
 Similarly, the F# interpreter has also not yet been ported for .NET Core ([GitHub issue](https://github.com/Microsoft/visualfsharp/issues/2407)).
-
-:::div{.warning}
-ScriptCS does not work on Mono **5.16** and higher. We recommend using Mono **5.14.x**.
-:::
 
 ## Downloads
 

--- a/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-container.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-container.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Migrate to Octopus Server Linux Container from Windows Container
 description: A guide on how to migrate to the Octopus Server Linux Container from the Octopus Server Windows Container
 navOrder: 20
@@ -22,7 +22,7 @@ This guide is designed to address the differences between the Windows and Linux 
 
 - **Folder Paths:** Windows Containers follow the Windows folder structure with `\` slashes, for example, `C:\Octopus\Tasklogs`.  Linux Containers follow a Linux folder structure, including `/` slashes.
 - **Pre-installed software:** Windows Containers include PowerShell and .NET 4.7.2 (or 4.8) but not Bash.  Linux Containers typically include PowerShell Core and Bash but not .NET.
-- **Software support:** The Linux Container doesn't support running ScriptCS or F# scripts directly on the server.
+- **Software support:** The Linux Container doesn't support running F# scripts directly on the server.
 - **Authentication:** The Octopus Server Linux Container doesn't support Active Directory authentication.  Some users have had success using Active Directory with the Octopus Server Windows Container, but any workarounds won't work with the Linux Container.  If you want to use Active Directory, you must connect to it via the [LDAP authentication provider](/docs/security/authentication/ldap).
 
 :::div{.hint}

--- a/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-server.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-server.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Migrate to Octopus Server Linux Container from Windows Server
 description: A guide on how to migrate to the Octopus Server Linux Container from Octopus Server running on a Windows Server
 navOrder: 10
@@ -24,7 +24,7 @@ The differences between running Octopus Server on Windows Server and Linux Conta
 
 - **Folder Paths:** Windows uses a folder structure with `\` slashes, for example, `C:\Octopus\Tasklogs`.  Linux Containers follow a Linux folder structure, including `/` slashes.
 - **Pre-installed software:** Linux Containers typically include PowerShell Core and Bash but not .NET.  You cannot pre-install any other software on the Octopus Linux Container.
-- **Software support:** The Linux Container doesn't support running ScriptCS or F# scripts directly on the server.
+- **Software support:** The Linux Container doesn't support running F# scripts directly on the server.
 - **Authentication:** The Octopus Server Linux Container doesn't support Active Directory authentication.  If you want to use Active Directory, you must connect to it via the [LDAP authentication provider](/docs/security/authentication/ldap).
 
 :::div{.hint}

--- a/src/pages/docs/octopus-rest-api/octopus.client/using-client-in-octopus.mdx
+++ b/src/pages/docs/octopus-rest-api/octopus.client/using-client-in-octopus.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-05-19
 title: Using in an Octopus Step
 description: How to use the Octopus.Client library from inside Octopus, for example within a script step.
 navOrder: 50
@@ -22,7 +22,7 @@ Add-Type -Path 'Octopus.Client/lib/netstandard2.0/Octopus.Client.dll'
 <summary>C#</summary>
 
 ```csharp 
-#r "Octopus.Client/lib/netstandard2.0/Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 using Octopus.Client;
 using Octopus.Client.Model;
 ```

--- a/src/pages/docs/projects/deployment-process/artifacts.mdx
+++ b/src/pages/docs/projects/deployment-process/artifacts.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-12-07
+modDate: 2025-05-19
 title: Artifacts
 icon: fa-solid fa-file-lines
 description: Artifacts in Octopus provide a convenient way to collect files from remote machines during deployments.
@@ -47,11 +47,11 @@ New-OctopusArtifact -Path "C:\Windows\System32\drivers\etc\hosts" -Name "$([Syst
 
 ```csharp
 // Collect a custom log file from the current working directory using the file name as the name of the artifact
-Octopus.CreateArtifact("output.log");
+CreateArtifact("output.log");
 
 // Collect the hosts file but using a custom name for each machine so you can differentiate between them
 // Note: to collect this artifact would require the Tentacle process to be elevated as a high privileged user account
-Octopus.CreateArtifact(@"C:\Windows\System32\drivers\etc\hosts", System.Environment.MachineName + "-hosts.txt");
+CreateArtifact(@"C:\Windows\System32\drivers\etc\hosts", System.Environment.MachineName + "-hosts.txt");
 ```
 
 </details>

--- a/src/pages/docs/projects/variables/output-variables.mdx
+++ b/src/pages/docs/projects/variables/output-variables.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-29
+modDate: 2025-05-19
 title: Output variables
 icon: fa-solid fa-diagram-next
 description: Output variables allow you to set dynamic variables in one step that can be used in subsequent steps.
@@ -31,7 +31,7 @@ Set-OctopusVariable -name "TestResult" -value "Passed"
 <ScriptCSDeprecation />
 
 ```csharp
-Octopus.SetVariable("TestResult", "Passed");
+SetVariable("TestResult", "Passed");
 ```
 
 </details>
@@ -80,7 +80,7 @@ $TestResult  = $OctopusParameters["Octopus.Action[StepA].Output.TestResult"]
 <summary>C#</summary>
 
 ```csharp
-var testResult = Octopus.Parameters["Octopus.Action[StepA].Output.TestResult"]
+var testResult = OctopusParameters["Octopus.Action[StepA].Output.TestResult"]
 ```
 
 </details>
@@ -123,7 +123,7 @@ Set-OctopusVariable -name "Password" -value "correct horse battery staple" -sens
 <summary>C#</summary>
 
 ```csharp
-Octopus.SetVariable("Password", "correct horse battery staple", true);
+SetVariable("Password", "correct horse battery staple", true);
 ```
 
 </details>
@@ -205,7 +205,7 @@ You can set output variables using any of the scripting languages supported by O
 
 ### PowerShell \{#powershell}
 
-[PowerShell Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/master/source/Calamari.Common/Features/Scripting/WindowsPowerShell/)
+[PowerShell Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/main/source/Calamari.Common/Features/Scripting/WindowsPowerShell/)
 
 From a PowerShell script, you can use the PowerShell CmdLet `Set-OctopusVariable` to set the name and value of an output variable. The CmdLet takes two parameters:
 
@@ -224,19 +224,19 @@ Set-OctopusVariable -name "TestResult" -value "Passed"
 
 <ScriptCSDeprecation />
 
-[ScriptCS Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/master/source/Calamari.Common/Features/Scripting/ScriptCS)
+[Dotnet Script Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/main/source/Calamari.Common/Features/Scripting/DotnetScript)
 
 From a C# script, you can use the `public static void SetVariable(string name, string value)` method to set the name and value of an output variable.
 
 **C#**
 
 ```csharp
-Octopus.SetVariable("TestResult", "Passed");
+SetVariable("TestResult", "Passed");
 ```
 
 ### Bash \{#bash}
 
-[Bash Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/master/source/Calamari.Common/Features/Scripting/Bash)
+[Bash Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/main/source/Calamari.Common/Features/Scripting/Bash)
 
 In a Bash script you can use the `set_octopusvariable` function to set the name and value of an output variable. This function takes two positional parameters with the same purpose as the PowerShell CmdLet.
 
@@ -248,7 +248,7 @@ set_octopusvariable "TestResult" "Passed"
 
 ### F# \{#fsharp}
 
-[FSharp Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/master/source/Calamari.Common/Features/Scripting/FSharp)
+[FSharp Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/main/source/Calamari.Common/Features/Scripting/FSharp)
 
 From a F# script, you can use the `setVariable : name:string -> value:string -> unit` function to collect artifacts. The function takes two parameters with the same purpose as the PowerShell CmdLet.
 

--- a/src/shared-content/deprecated-items/scriptcs-deprecated.include.md
+++ b/src/shared-content/deprecated-items/scriptcs-deprecated.include.md
@@ -1,5 +1,5 @@
 :::div{.warning}
 On 30 September, 2022 it was [announced](https://github.com/scriptcs/scriptcs/issues/1323) that ScriptCS would no longer be maintained.
 
-As of `2024.4` ScriptCS is being deprecated in Octopus. This has been replaced with [dotnet-script](https://github.com/dotnet-script/dotnet-script). See our post on migrating from [scriptcs to dotnet-script](https://g.octopushq.com/ScriptCSDeprecation).
+As of `2024.4` ScriptCS is being deprecated in Octopus. This has been replaced with [dotnet-script](https://github.com/dotnet-script/dotnet-script). See our post on migrating from [scriptcs to dotnet-script](https://g.octopushq.com/ScriptCSDeprecation). All support for ScriptCS will be removed in `2025.3`.
 :::

--- a/src/shared-content/octopus-rest-api/project-coordination-code-samples.include.md
+++ b/src/shared-content/octopus-rest-api/project-coordination-code-samples.include.md
@@ -6,7 +6,7 @@ See the [OctopusDeploy-Api](https://github.com/OctopusDeploy/OctopusDeploy-Api) 
 These examples use the [Octopus.Client](/docs/octopus-rest-api/octopus.client/) library, see the [Loading in an Octopus Step](/docs/octopus-rest-api/octopus.client/using-client-in-octopus/) section of the [Octopus.Client](/docs/octopus-rest-api/octopus.client) documentation for details on how to load the library from inside Octopus using PowerShell or C# Script steps.
 :::
 
-## Querying the current state {#ProjectCoordinationCodeSamples-Queryingthecurrentstate}
+## Querying the current state
 
 The best way to get the current state for one or more projects is to use the Dashboard API, which is also used by the dashboards in the WebUI:
 
@@ -29,7 +29,7 @@ $repository.Dashboards.GetDashboard().Items
  http://localhost/api/dashboard
 ```
 
-## Viewing recent deployments {#ProjectCoordinationCodeSamples-Viewingrecentdeployments}
+## Viewing recent deployments
 
 The following code returns the deployments started in the last 7 days:
 
@@ -48,7 +48,7 @@ repository.Deployments.Paginate(projects, environments,
  );
 ```
 
-## Promoting a group of projects {#ProjectCoordinationCodeSamples-Promotingagroupofprojects}
+## Promoting a group of projects
 
 This example finds all the releases that are in UAT but not Production. It then queues them for deployment to Production and waits for them to complete.
 
@@ -79,7 +79,7 @@ if(completed.Any(c => c.State != TaskState.Success))
 	throw new Exception("One or more projects did not complete successfully");
 ```
 
-## Queuing a project to run later {#ProjectCoordinationCodeSamples-Queuingaprojecttorunlater}
+## Queuing a project to run later
 
 This example re-queues the currently executing project at 3am the next day.
 
@@ -99,7 +99,7 @@ repository.Deployments.Create(
 Console.WriteLine($"Queued for {tomorrow3amServerTime}");
 ```
 
-## Failing a deployment if another deployment is running {#ProjectCoordinationCodeSamples-Failingadeploymentifanotherdeploymentisrunning}
+## Failing a deployment if another deployment is running
 
 This example uses the dynamic dashboard API to check whether a different project is currently deploying to the same environment. Note that Octopus [restricts](/docs/administration/managing-infrastructure/run-multiple-processes-on-a-target-simultaneously) what can run at the same time already.
 
@@ -111,7 +111,7 @@ if (dash.Items.Any(i => i.State == TaskState.Queued || i.State == TaskState.Exec
 	throw new Exception($"{otherProject.Name} is currently queued or executing");
 ```
 
-## Failing a deployment if a dependency is not deployed {#ProjectCoordinationCodeSamples-Failingadeploymentifadependencyisnotdeployed}
+## Failing a deployment if a dependency is not deployed
 
 This example retrieves the last release to the same environment of a different project and fails if it is not the expected release version.
 
@@ -125,7 +125,7 @@ if (last == null || last.ReleaseVersion != requiredVersion)
 	throw new Exception($"This project requires version {requiredVersion} of {otherProject.Name} to be deployed to the same environment");
 ```
 
-## Triggering and waiting for another project {#ProjectCoordinationCodeSamples-Triggeringandwaitingforanotherproject}
+## Triggering and waiting for another project
 
 This example finds the latest release for a different project and deploys it if it is not currently deployed to the environment.
 
@@ -151,7 +151,7 @@ if (latestRelease != null && last.ReleaseId != latestRelease.Id)
 }
 ```
 
-## Waiting for another project to reach a certain stage {#ProjectCoordinationCodeSamples-Waitingforanotherprojecttoreachacertainstage}
+## Waiting for another project to reach a certain stage
 
 This example builds on the previous, by waiting until a particular step is complete instead of the whole task.
 

--- a/src/shared-content/octopus-rest-api/project-coordination-code-samples.include.md
+++ b/src/shared-content/octopus-rest-api/project-coordination-code-samples.include.md
@@ -84,15 +84,15 @@ if(completed.Any(c => c.State != TaskState.Success))
 This example re-queues the currently executing project at 3am the next day.
 
 ```csharp
-var releaseId = Octopus.Parameters["Octopus.Web.ReleaseLink"].Split('/').Last();
+var releaseId = OctopusParameters["Octopus.Web.ReleaseLink"].Split('/').Last();
 var tomorrow3amServerTime = new DateTimeOffset(DateTimeOffset.Now.Date, DateTimeOffset.Now.Offset).AddDays(1).AddHours(3);
 repository.Deployments.Create(
     new DeploymentResource()
     {
         ReleaseId = releaseId,
-    	ProjectId = Octopus.Parameters["Octopus.Project.Id"],
-    	ChannelId = Octopus.Parameters["Octopus.Release.Channel.Id"],
-    	EnvironmentId = Octopus.Parameters["Octopus.Environment.Id"],
+    	ProjectId = OctopusParameters["Octopus.Project.Id"],
+    	ChannelId = OctopusParameters["Octopus.Release.Channel.Id"],
+    	EnvironmentId = OctopusParameters["Octopus.Environment.Id"],
     	QueueTime = tomorrow3amServerTime
     }
 );
@@ -105,7 +105,7 @@ This example uses the dynamic dashboard API to check whether a different project
 
 ```csharp
 var otherProject = repository.Projects.FindByName("Other Project");
-var environmentId = Octopus.Parameters["Octopus.Environment.Id"];
+var environmentId = OctopusParameters["Octopus.Environment.Id"];
 var dash = repository.Dashboards.GetDynamicDashboard(new[] { otherProject.Id }, new[] { environmentId });
 if (dash.Items.Any(i => i.State == TaskState.Queued || i.State == TaskState.Executing))
 	throw new Exception($"{otherProject.Name} is currently queued or executing");
@@ -116,9 +116,9 @@ if (dash.Items.Any(i => i.State == TaskState.Queued || i.State == TaskState.Exec
 This example retrieves the last release to the same environment of a different project and fails if it is not the expected release version.
 
 ```csharp
-var requiredVersion = Octopus.Parameters["OtherProjectRequiredVersion"];
+var requiredVersion = OctopusParameters["OtherProjectRequiredVersion"];
 var otherProject = repository.Projects.FindByName("Other Project");
-var environmentId = Octopus.Parameters["Octopus.Environment.Id"];
+var environmentId = OctopusParameters["Octopus.Environment.Id"];
 var dash = repository.Dashboards.GetDynamicDashboard(new[] { otherProject.Id }, new[] { environmentId });
 var last = dash.Items.SingleOrDefault(i => i.IsCurrent);
 if (last == null || last.ReleaseVersion != requiredVersion)
@@ -130,7 +130,7 @@ if (last == null || last.ReleaseVersion != requiredVersion)
 This example finds the latest release for a different project and deploys it if it is not currently deployed to the environment.
 
 ```csharp
-var environmentId = Octopus.Parameters["Octopus.Environment.Id"];
+var environmentId = OctopusParameters["Octopus.Environment.Id"];
 var otherProject = repository.Projects.FindByName("Other Project");
 var latestRelease = repository.Projects.GetReleases(otherProject).Items.FirstOrDefault();
 var dash = repository.Dashboards.GetDynamicDashboard(new[] { otherProject.Id }, new[] { environmentId });

--- a/src/shared-content/scripts/add-a-space-with-environments-scripts.include.md
+++ b/src/shared-content/scripts/add-a-space-with-environments-scripts.include.md
@@ -117,7 +117,7 @@ foreach ($environmentName in $environments) {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-azure-ad-identity-to-users-scripts.include.md
+++ b/src/shared-content/scripts/add-azure-ad-identity-to-users-scripts.include.md
@@ -376,7 +376,7 @@ function AddAzureLogins
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-azure-web-app-scripts.include.md
+++ b/src/shared-content/scripts/add-azure-web-app-scripts.include.md
@@ -120,7 +120,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-environment-to-step-scripts.include.md
+++ b/src/shared-content/scripts/add-environment-to-step-scripts.include.md
@@ -98,7 +98,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-environment-to-team-scripts.include.md
+++ b/src/shared-content/scripts/add-environment-to-team-scripts.include.md
@@ -98,7 +98,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-environments-scripts.include.md
+++ b/src/shared-content/scripts/add-environments-scripts.include.md
@@ -87,7 +87,7 @@ foreach ($environmentName in $environments) {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-library-set-to-project-scripts.include.md
+++ b/src/shared-content/scripts/add-library-set-to-project-scripts.include.md
@@ -75,7 +75,7 @@ catch
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-script-step-to-runbook-scripts.include.md
+++ b/src/shared-content/scripts/add-script-step-to-runbook-scripts.include.md
@@ -3,7 +3,7 @@
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-target-role-scripts.include.md
+++ b/src/shared-content/scripts/add-target-role-scripts.include.md
@@ -68,7 +68,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/add-update-project-variable-scripts.include.md
+++ b/src/shared-content/scripts/add-update-project-variable-scripts.include.md
@@ -120,7 +120,7 @@ catch
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/bulk-add-tenants-to-projects.include.md
+++ b/src/shared-content/scripts/bulk-add-tenants-to-projects.include.md
@@ -404,7 +404,7 @@ foreach ($tenant in $tenants)
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 using Octopus.Client;
 using Octopus.Client.Model;
 using System;

--- a/src/shared-content/scripts/cancel-queued-deployments-scripts.include.md
+++ b/src/shared-content/scripts/cancel-queued-deployments-scripts.include.md
@@ -38,7 +38,7 @@ while ($canContinue -eq $true)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/change-feed-scripts.include.md
+++ b/src/shared-content/scripts/change-feed-scripts.include.md
@@ -75,7 +75,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/change-machine-machinepolicy-scripts.include.md
+++ b/src/shared-content/scripts/change-machine-machinepolicy-scripts.include.md
@@ -73,7 +73,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/clear-sensitive-variables-scripts.include.md
+++ b/src/shared-content/scripts/clear-sensitive-variables-scripts.include.md
@@ -142,7 +142,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 // Declare working variables
 var octopusURL = "https://your-octopus-url";

--- a/src/shared-content/scripts/create-a-lifecycle-scripts.include.md
+++ b/src/shared-content/scripts/create-a-lifecycle-scripts.include.md
@@ -142,7 +142,7 @@ else
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 using Octopus.Client;
 using Octopus.Client.Model;
 using System;

--- a/src/shared-content/scripts/create-a-tenant-scripts.include.md
+++ b/src/shared-content/scripts/create-a-tenant-scripts.include.md
@@ -127,7 +127,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-and-deploy-release-scripts.include.md
+++ b/src/shared-content/scripts/create-and-deploy-release-scripts.include.md
@@ -145,7 +145,7 @@ catch {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-and-deploy-release-with-tenants-scripts.include.md
+++ b/src/shared-content/scripts/create-and-deploy-release-with-tenants-scripts.include.md
@@ -189,7 +189,7 @@ catch {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-and-publish-runbook-scripts.include.md
+++ b/src/shared-content/scripts/create-and-publish-runbook-scripts.include.md
@@ -130,7 +130,7 @@ $repositoryForSpace.Runbooks.Modify($runbook)
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 using Octopus.Client;
 using Octopus.Client.Model;
 using System;

--- a/src/shared-content/scripts/create-api-key-scripts.include.md
+++ b/src/shared-content/scripts/create-api-key-scripts.include.md
@@ -76,7 +76,7 @@ catch
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
 
 // Reference Octopus.Client
-//#r "path\to\Octopus.Client.dll"
+//#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-aws-account-scripts.include.md
+++ b/src/shared-content/scripts/create-aws-account-scripts.include.md
@@ -146,7 +146,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-azure-service-principal-scripts.include.md
+++ b/src/shared-content/scripts/create-azure-service-principal-scripts.include.md
@@ -117,7 +117,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-certificate-scripts.include.md
+++ b/src/shared-content/scripts/create-certificate-scripts.include.md
@@ -94,7 +94,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-channel-scripts.include.md
+++ b/src/shared-content/scripts/create-channel-scripts.include.md
@@ -68,7 +68,7 @@ $repositoryForSpace.Channels.Create($channel)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-google-cloud-account-scripts.include.md
+++ b/src/shared-content/scripts/create-google-cloud-account-scripts.include.md
@@ -149,7 +149,7 @@ catch
 // It also requires version 11.3.3355 or higher of the Octopus.Client library
 
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-nuget-feed-scripts.include.md
+++ b/src/shared-content/scripts/create-nuget-feed-scripts.include.md
@@ -114,7 +114,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-project-scripts.include.md
+++ b/src/shared-content/scripts/create-project-scripts.include.md
@@ -83,7 +83,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-projectgroup-scripts.include.md
+++ b/src/shared-content/scripts/create-projectgroup-scripts.include.md
@@ -123,7 +123,7 @@ $repositoryForSpace.ProjectGroups.Create($projectGroup)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-release-with-version-scripts.include.md
+++ b/src/shared-content/scripts/create-release-with-version-scripts.include.md
@@ -131,7 +131,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-runbook-scripts.include.md
+++ b/src/shared-content/scripts/create-runbook-scripts.include.md
@@ -88,7 +88,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-scheduled-runbook-trigger-scripts.include.md
+++ b/src/shared-content/scripts/create-scheduled-runbook-trigger-scripts.include.md
@@ -171,7 +171,7 @@ Write-Host "Created runbook trigger: $($createdRunbookTrigger.Id) ($runbookTrigg
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-script-step-scripts.include.md
+++ b/src/shared-content/scripts/create-script-step-scripts.include.md
@@ -137,7 +137,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/create-tagset-scripts.include.md
+++ b/src/shared-content/scripts/create-tagset-scripts.include.md
@@ -105,7 +105,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/deactivate-tenant-scripts.include.md
+++ b/src/shared-content/scripts/deactivate-tenant-scripts.include.md
@@ -70,7 +70,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-a-space-scripts.include.md
+++ b/src/shared-content/scripts/delete-a-space-scripts.include.md
@@ -71,7 +71,7 @@ try {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-feed-scripts.include.md
+++ b/src/shared-content/scripts/delete-feed-scripts.include.md
@@ -65,7 +65,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-project-by-name-scripts.include.md
+++ b/src/shared-content/scripts/delete-project-by-name-scripts.include.md
@@ -63,7 +63,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-project-releases-scripts.include.md
+++ b/src/shared-content/scripts/delete-project-releases-scripts.include.md
@@ -77,7 +77,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-projects-without-processes-scripts.include.md
+++ b/src/shared-content/scripts/delete-projects-without-processes-scripts.include.md
@@ -82,7 +82,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-targets-by-name-scripts.include.md
+++ b/src/shared-content/scripts/delete-targets-by-name-scripts.include.md
@@ -75,7 +75,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/delete-targets-by-role-scripts.include.md
+++ b/src/shared-content/scripts/delete-targets-by-role-scripts.include.md
@@ -71,7 +71,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/deploy-release-scripts.include.md
+++ b/src/shared-content/scripts/deploy-release-scripts.include.md
@@ -102,7 +102,7 @@ catch {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/deploy-release-with-prompted-variables-scripts.include.md
+++ b/src/shared-content/scripts/deploy-release-with-prompted-variables-scripts.include.md
@@ -157,7 +157,7 @@ $deployment = $repositoryForSpace.Deployments.Create($deployment)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/disable-project-triggers-scripts.include.md
+++ b/src/shared-content/scripts/disable-project-triggers-scripts.include.md
@@ -79,7 +79,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/download-artifact-from-deployment-scripts.include.md
+++ b/src/shared-content/scripts/download-artifact-from-deployment-scripts.include.md
@@ -128,7 +128,7 @@ foreach ($artifact in $artifacts.Items)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/download-artifact-from-runbook-scripts.include.md
+++ b/src/shared-content/scripts/download-artifact-from-runbook-scripts.include.md
@@ -105,7 +105,7 @@ foreach ($runbookRun in $runbookRuns.Items)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/download-package-scripts.include.md
+++ b/src/shared-content/scripts/download-package-scripts.include.md
@@ -71,7 +71,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/enable-disable-machine-scripts.include.md
+++ b/src/shared-content/scripts/enable-disable-machine-scripts.include.md
@@ -70,7 +70,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/environment-permissions-report.include.md
+++ b/src/shared-content/scripts/environment-permissions-report.include.md
@@ -1060,7 +1060,7 @@ foreach ($permission in $permissionsReport)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-events-by-date-scripts.include.md
+++ b/src/shared-content/scripts/find-events-by-date-scripts.include.md
@@ -129,7 +129,7 @@ catch
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 using Octopus.Client;
 using Octopus.Client.Model;
 using System;

--- a/src/shared-content/scripts/find-projects-using-variable-set-scripts.include.md
+++ b/src/shared-content/scripts/find-projects-using-variable-set-scripts.include.md
@@ -84,7 +84,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-target-usage-no-tenants.include.md
+++ b/src/shared-content/scripts/find-target-usage-no-tenants.include.md
@@ -686,7 +686,7 @@ else
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-teams-with-role-scripts.include.md
+++ b/src/shared-content/scripts/find-teams-with-role-scripts.include.md
@@ -108,7 +108,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-unused-projects.include.md
+++ b/src/shared-content/scripts/find-unused-projects.include.md
@@ -230,7 +230,7 @@ foreach ($project in $oldProjects)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-unused-targets.include.md
+++ b/src/shared-content/scripts/find-unused-targets.include.md
@@ -547,7 +547,7 @@ static CategorizedMachines UpdateCategorizedMachines (CategorizedMachines catego
 }
 
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-variable-usage-scripts.include.md
+++ b/src/shared-content/scripts/find-variable-usage-scripts.include.md
@@ -436,7 +436,7 @@ if ($variableTracking.Count -gt 0)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-variable-value-usage-scripts.include.md
+++ b/src/shared-content/scripts/find-variable-value-usage-scripts.include.md
@@ -194,7 +194,7 @@ if($variableTracking.Count -gt 0) {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/find-variableset-variables-usage-scripts.include.md
+++ b/src/shared-content/scripts/find-variableset-variables-usage-scripts.include.md
@@ -348,7 +348,7 @@ if($variableTracking.Count -gt 0) {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/get-feeds-scripts.include.md
+++ b/src/shared-content/scripts/get-feeds-scripts.include.md
@@ -68,7 +68,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/get-steps-using-package-scripts.include.md
+++ b/src/shared-content/scripts/get-steps-using-package-scripts.include.md
@@ -92,7 +92,7 @@ foreach ($project in $projectList) {
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/get-steps-using-role-scripts.include.md
+++ b/src/shared-content/scripts/get-steps-using-role-scripts.include.md
@@ -89,7 +89,7 @@ foreach($project in $projectList)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/list-deployments-to-environment-scripts.include.md
+++ b/src/shared-content/scripts/list-deployments-to-environment-scripts.include.md
@@ -83,7 +83,7 @@ Write-Host "Retrieved $($deployments.Count) deployments to environment $($enviro
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/list-users-scripts.include.md
+++ b/src/shared-content/scripts/list-users-scripts.include.md
@@ -264,7 +264,7 @@ $usersList | Format-Table
 
 ```csharp
 
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/list-users-with-editing-roles-scripts.include.md
+++ b/src/shared-content/scripts/list-users-with-editing-roles-scripts.include.md
@@ -129,7 +129,7 @@ if (![string]::IsNullOrWhiteSpace($csvExportPath))
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/promote-releases-not-in-destination.include.md
+++ b/src/shared-content/scripts/promote-releases-not-in-destination.include.md
@@ -274,7 +274,7 @@ foreach ($name in $projectNameList)
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/publish-runbook-scripts.include.md
+++ b/src/shared-content/scripts/publish-runbook-scripts.include.md
@@ -82,7 +82,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/push-package-scripts.include.md
+++ b/src/shared-content/scripts/push-package-scripts.include.md
@@ -104,7 +104,7 @@ finally
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/register-listening-tentacle-scripts.include.md
+++ b/src/shared-content/scripts/register-listening-tentacle-scripts.include.md
@@ -108,7 +108,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/register-polling-tentacle-scripts.include.md
+++ b/src/shared-content/scripts/register-polling-tentacle-scripts.include.md
@@ -121,7 +121,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/remove-project-from-team-scripts.include.md
+++ b/src/shared-content/scripts/remove-project-from-team-scripts.include.md
@@ -87,7 +87,7 @@ catch
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/replace-certificate-scripts.include.md
+++ b/src/shared-content/scripts/replace-certificate-scripts.include.md
@@ -96,7 +96,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/run-a-runbook-with-prompted-variables.include.md
+++ b/src/shared-content/scripts/run-a-runbook-with-prompted-variables.include.md
@@ -236,7 +236,7 @@ if ($runbookWaitForFinish -eq $true)
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/run-healthcheck-scripts.include.md
+++ b/src/shared-content/scripts/run-healthcheck-scripts.include.md
@@ -110,7 +110,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/run-runbook-scripts.include.md
+++ b/src/shared-content/scripts/run-runbook-scripts.include.md
@@ -107,7 +107,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/update-release-variable-snapshot-scripts.include.md
+++ b/src/shared-content/scripts/update-release-variable-snapshot-scripts.include.md
@@ -79,7 +79,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/update-tenant-variable-scripts.include.md
+++ b/src/shared-content/scripts/update-tenant-variable-scripts.include.md
@@ -185,7 +185,7 @@ catch
     
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/update-variable-set-variable-value-scripts.include.md
+++ b/src/shared-content/scripts/update-variable-set-variable-value-scripts.include.md
@@ -97,7 +97,7 @@ $repositoryForSpace.VariableSets.Modify($variableSet)
 <summary>C#</summary>
 
 ```csharp
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;

--- a/src/shared-content/scripts/upgrade-machines-scripts.include.md
+++ b/src/shared-content/scripts/upgrade-machines-scripts.include.md
@@ -93,7 +93,7 @@ catch
 
 ```csharp
 // If using .net Core, be sure to add the NuGet package of System.Security.Permissions
-#r "path\to\Octopus.Client.dll"
+#r "nuget: Octopus.Client"
 
 using Octopus.Client;
 using Octopus.Client.Model;


### PR DESCRIPTION
This is a fresh version of #2035
This updates references to ScriptCS and example usage to bring the docs in line with the dotnet-script changes. As this is a 2023.4 change it may make more sense to call out each of the individual scripting libraries rather than just update in place as I've done here. The migration is highlighted in the blog post with recent changes here https://github.com/OctopusDeploy/blog/pull/1077