### PR TITLE
Update index.md

### DIFF
--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -13,9 +13,9 @@ Occasionally, Octopus will deprecate features that will no longer be supported. 
 
 Deprecations have the following lifecycle:
 
-- Announce deprecation
-- (+6 months) Toggle off deprecated functionality
-- (+1 year) Remove deprecated functionality
+- Announce deprecation with in-app warnings, newsletters and/or blog posts
+- (+6 months) Disable deprecated functionality
+- (+6 months) Remove deprecated functionality
 
 :::div{.warning}
 Deprecations are subject to change in detail or time frame. If you need help assessing the impact of the deprecation of a feature on your particular Octopus Server configuration, please contact our [support team](https://octopus.com/support).


### PR DESCRIPTION
Based on some [updated plans around deprecations](https://octopushq.atlassian.net/wiki/spaces/RND/pages/2500493448/Managing+Deprecations) we will now instead consider the removal at 6 moths rather than 12 months as standard practice.