### PR TITLE
Add in mention of polling proxy.md

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/polling-tentacles-over-port-443.md
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/polling-tentacles-over-port-443.md
@@ -18,7 +18,9 @@ navOrder: 50
 
 The procedure for configuring Polling Tentacles to use port 443 varies based upon your chosen method of hosting Octopus Server.
 
+:::hint
 It may be helpful to know that the Tentacle agent supports command-line operations. If you're using a Polling Tentacle and need to configure a Polling Proxy, you can refer to our documentation on [Polling Proxy](docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy) for more details.
+:::
 
 ## Octopus Cloud
 


### PR DESCRIPTION
Added in a link to our polling proxy support when using polling tentacles.

> It may be helpful to know that the Tentacle agent supports command-line operations. If you're using a Polling Tentacle and need to configure a Polling Proxy, you can refer to our documentation on [Polling Proxy](docs/octopus-rest-api/tentacle.exe-command-line/polling-proxy) for more details.