### PR TITLE
Clarification of supported characters in variable names

### DIFF
--- a/src/pages/docs/projects/variables/getting-started.mdx
+++ b/src/pages/docs/projects/variables/getting-started.mdx
@@ -163,7 +163,27 @@ If you are using the [Structured configuration variables](/docs/projects/steps/c
 ## Variable Recommendations
 
 ### Use standard characters in variable names
-Prefer using standard characters when naming variables. While it's technically possible to use almost any character, variables with non-standard characters can only be accessed in limited ways - such as via the `$OctopusParameters` dictionary. For broader compatibility, including support for Octostache expressions, stick to alphanumerics, periods (`.`), hyphens (`-`), underscores (`_`), and spaces. Octostache does not support characters outside this set, so following this convention ensures your variables function reliably across all usage contexts.
+Prefer using standard characters when naming variables. While it's technically possible to include almost any character, **variable names** with non-standard characters can only be accessed in limited ways - such as via the `$OctopusParameters` dictionary. Variable values can include any character.
+
+| Variable name  | Value                                  |
+| ---------------| -------------------------------------- |
+| `WontWork`     | `#{Octopus.Action[StepA].Output.Foo!}` |
+| `Works`        | `#{Octopus.Action[StepA].Output.Ba-r}` |
+ 
+**Step A**
+```ps
+Set-OctopusVariable -name "Foo!" -value "FooValue"
+Set-OctopusVariable -name "Ba-r" -value "BarValue"
+```
+
+**Step B**
+```ps
+$OctopusParameters["Works"]                             # Returns: BarValue
+$OctopusParameters["WontWork"]                          # Returns: #{Octopus.Action[StepA].Output.Foo!}, not FooValue
+$OctopusParameters["Octopus.Action[StepA].Output.Foo!"] # Returns: FooValue
+```
+
+To ensure your variable can be accessed via Octostache expressions, stick to alphanumerics, periods (`.`), hyphens (`-`), underscores (`_`), and spaces for the **name** of the variable.
 
 ### Group variables into Variable Sets
 


### PR DESCRIPTION
[sc-96109]

# Background
There's a lack of clarity over what kind of output variable names are supported with Octostache.


# Results
Add explanation of the kind of variable naming that will work with Octostache.