### PR TITLE
Add stderr-output to docs

### DIFF
--- a/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2025-06-05
 title: Logging messages from scripts
 description: When your scripts emit messages Octopus will display the messages in the Task Logs at the most appropriate level for the message.
 icon: fa-solid fa-clock-rotate-left

--- a/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
@@ -226,7 +226,7 @@ The following service messages can be written directly to standard output which 
 ```
 
 - `stderr-progress` will cause error log lines to be written as `verbose` log lines. 
-- `stderr-output` will cause error log lines to be written as `info` log lines (standard output).
+- `stderr-output` will cause error log lines to be written as `info` log lines (standard output). Requires version `2025.3`. 
 
 To return to the default standard error log level, write the following message:
 ```

--- a/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
@@ -217,12 +217,16 @@ To return to the default standard output log level, write the following message:
 ```
 
 
-The following service messages can be written directly to standard output which will be parsed by the server and the subsequent log lines written to standard error will be treated with the relevant log level. `stderr-progress` will cause error log lines to be written as `verbose` log lines.
+The following service messages can be written directly to standard output which will be parsed by the server and the subsequent log lines written to standard error will be treated with the relevant log level. 
 ```
 ##octopus[stderr-ignore]
 ##octopus[stderr-error]
 ##octopus[stderr-progress]
+##octopus[stderr-output]
 ```
+
+- `stderr-progress` will cause error log lines to be written as `verbose` log lines. 
+- `stderr-output` will cause error log lines to be written as `info` log lines (standard output).
 
 To return to the default standard error log level, write the following message:
 ```


### PR DESCRIPTION
Add docs for new service message `##octopus[stderr-output]`

[sc-77584]

Related to https://github.com/OctopusDeploy/OctopusDeploy/pull/33735