### PR TITLE
General spring-clean of Octopus Cloud docs.

### DIFF
--- a/src/pages/docs/octopus-cloud/disaster-recovery.md
+++ b/src/pages/docs/octopus-cloud/disaster-recovery.md
@@ -1,20 +1,20 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-04-23
+modDate: 2025-06-06
 title: Disaster recovery for Octopus Cloud
 navTitle: Disaster recovery
-navOrder: 40
-description: How to work with your data and disaster recovery in an Octopus Cloud instance.
+navOrder: 90
+description: How to work with your data and disaster recovery in Octopus Cloud
 ---
 
 This page describes the disaster recovery procedure and data imports/exports for Octopus Cloud.
 
 ## Disaster Recovery Procedure
 
-Octopus Deploy hosts the cloud offering (Octopus Cloud) on Microsoft Azure utilizing several Azure services. Octopus Deploy shall endeavor to ensure business continuity of Octopus Cloud in the event of any disaster.  Octopus Cloud disaster resiliency and recovery are largely determined by the disaster recovery measures that are provided by these services, in addition to the Customer's own disaster recovery preparations such as determining which restore point to use for the recovery. Depending upon the nature of the event, Octopus Deploy's response may be limited to assisting customers and Azure support to restore service. 
+Octopus Deploy hosts the cloud offering (Octopus Cloud) on Microsoft Azure utilizing several Azure services. Octopus Deploy shall endeavor to ensure business continuity of Octopus Cloud in the event of any disaster.  Octopus Cloud disaster resiliency and recovery are largely determined by the disaster recovery measures that are provided by these services, in addition to the Customer's own disaster recovery preparations such as determining which restore point to use for the recovery. Depending upon the nature of the event, Octopus Deploy's response may be limited to assisting customers and Azure support to restore service.
 
-Consequently, this information is provided as guidance information only and does not form part of our Customer Agreement, nor does it affect or limit the operation of any force majeure releases. Customers should ensure that they have their own disaster recovery procedures in place following disaster recovery best practice. 
+Consequently, this information is provided as guidance information only and does not form part of our Customer Agreement, nor does it affect or limit the operation of any force majeure releases. Customers should ensure that they have their own disaster recovery procedures in place following disaster recovery best practice.
 
 ### Customer instances
 
@@ -31,9 +31,9 @@ For further information, customers should refer to [Microsoft's disaster recover
 
 ### Octopus Cloud administration portal (internal system)
 
-The Octopus Cloud administration portal is used to manage customer instances. 
+The Octopus Cloud administration portal is used to manage customer instances.
 
-Note: The portal is hosted in a separate Azure region from customer instances and is not required to be online for continuity of service to customers. The disaster recovery measures taken, as detailed below, will allow the portal to be restored according to the following table: 
+Note: The portal is hosted in a separate Azure region from customer instances and is not required to be online for continuity of service to customers. The disaster recovery measures taken, as detailed below, will allow the portal to be restored according to the following table:
 
 | Level of Disaster                              | Impact                                 | Data Redundancy                        | Data durability | RTO | RPO | Parties involved             |
 |------------------------------------------------|----------------------------------------|----------------------------------------|-----------------|-------------------------------|---------------------------------------------|------------------------------|
@@ -48,7 +48,7 @@ For further information, customers should refer to [Microsoft's disaster recover
 
 ### Azure region failure
 
-In the case of an Azure region wide disaster the time to restore services will vary depending on the nature of the disaster. For short duration outages the best strategy may be to wait for Microsoft to restore services within the region. In the case of region wide disasters affecting customer instances, for longer duration disasters restoration of services will entail provisioning a new customer instance in a new Azure region (in the same PII jurisdiction) and restoring the customer's database from the geo-redundant backup. For customer instances and the Octopus Cloud portal the time to restore operations is estimated to be 24 hrs once a new region is made available by Microsoft. The RPO in is 1 hr or to the customer specified restore point, as applicable. Note that there is not a geo-redundant copy of the Octopus Cloud File store, and the customer will need to re-build, upload, and/or regenerate any required packages and artifacts, as required by their deployments. 
+In the case of an Azure region wide disaster the time to restore services will vary depending on the nature of the disaster. For short duration outages the best strategy may be to wait for Microsoft to restore services within the region. In the case of region wide disasters affecting customer instances, for longer duration disasters restoration of services will entail provisioning a new customer instance in a new Azure region (in the same PII jurisdiction) and restoring the customer's database from the geo-redundant backup. For customer instances and the Octopus Cloud portal the time to restore operations is estimated to be 24 hrs once a new region is made available by Microsoft. The RPO in is 1 hr or to the customer specified restore point, as applicable. Note that there is not a geo-redundant copy of the Octopus Cloud File store, and the customer will need to re-build, upload, and/or regenerate any required packages and artifacts, as required by their deployments.
 
 ### Definitions
 

--- a/src/pages/docs/octopus-cloud/dynamic-worker.md
+++ b/src/pages/docs/octopus-cloud/dynamic-worker.md
@@ -1,10 +1,11 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-03-07
-modDate: 2025-03-07
+modDate: 2025-06-06
 title: Dynamic workers
-navOrder: 45
-description: Describes what dynamic workers are, how they work, their limitations and other worker type options available for Octopus Cloud
+navTitle: Dynamic workers
+navOrder: 50
+description: What dynamic workers are, how they work, their limitations and other worker options available for Octopus Cloud
 ---
 
 [Workers](docs/infrastructure/workers) are machines that can execute tasks that don’t need to be run on the Octopus Server or individual deployment targets.

--- a/src/pages/docs/octopus-cloud/frequently-asked-questions.md
+++ b/src/pages/docs/octopus-cloud/frequently-asked-questions.md
@@ -1,13 +1,13 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2024-11-08
-modDate: 2024-11-08
+modDate: 2025-06-06
 title: Octopus Cloud Frequently Asked Questions
 navTitle: Octopus Cloud FAQ
-navOrder: 70
-description: Common questions about Octopus Cloud, with answers and links to more detail.
+navOrder: 110
+description: Answers for common questions about Octopus Cloud
 ---
-This page answers the most common questions about Octopus Cloud. 
+This page answers the most common questions about Octopus Cloud.
 
 If you have an unanswered question, please use the "Send Feedback" button at the foot of this page or [contact our Sales team](https://octopus.com/company/contact).
 
@@ -15,15 +15,15 @@ If you have an unanswered question, please use the "Send Feedback" button at the
 
 ### What is Octopus Cloud?
 
-Octopus Cloud is the easiest way to start with Octopus Deploy; we take care of everything for you. Octopus Cloud has the same functionality as Octopus Server, delivered as a highly available, scalable, secure SaaS application hosted for you. 
+Octopus Cloud is the easiest way to start with Octopus Deploy; we take care of everything for you. Octopus Cloud has the same functionality as Octopus Server, delivered as a highly available, scalable, secure SaaS application hosted for you.
 
 ### Where do I begin?
 
 Many customers begin with our [getting started](/docs/getting-started) guide, which covers the key concepts and terminology we use. When you’re ready, [start a free trial](https://octopus.com/start) to explore Octopus Cloud.
 
-### How is Octopus Cloud built? 
+### How is Octopus Cloud built?
 
-Our [Octopus Cloud architecture](https://octopus.com/blog/octopus-cloud-architecture) overview describes how we deliver Octopus Cloud. 
+Our [Octopus Cloud architecture](https://octopus.com/blog/octopus-cloud-architecture) overview describes how we deliver Octopus Cloud.
 
 ## Training and setup
 
@@ -31,17 +31,17 @@ Our [Octopus Cloud architecture](https://octopus.com/blog/octopus-cloud-architec
 
 Our [Resource Center](https://octopus.com/resource-center) provides high-quality webinars, blog posts, white papers, and free tools. We also offer [books with free PDF versions](https://octopus.com/publications) covering Octopus and broader DevOps topics. We pride ourselves on the quality of our [developer documentation](/docs) and provide free [training video tutorials](https://www.youtube.com/playlist?list=PLAGskdGvlaw268i2ZTPC1ZrxwFjjKIdKH). We support a [community Slack channel](https://octopususergroup.slack.com/join/shared_invite/zt-170c1xzfl-J_pWvCeNZ4H_LmGVE4XNtw#/shared-invite/email) where our staff regularly assist with customer inquiries.
 
-Professional and Enterprise tier customers receive access to our Support team and expert-guided onboarding. Enterprise tier customers can add on Technical Account Management services. For Enterprise tier customers with over USD $50,000 licenses, we assign a Customer Success Manager. 
+Professional and Enterprise tier customers receive access to our Support team and expert-guided onboarding. Enterprise tier customers can add on Technical Account Management services. For Enterprise tier customers with over USD $50,000 licenses, we assign a Customer Success Manager.
 
 ### Can we get support for our initial setup?
 
-Professional and Enterprise tier customers receive our expert-guided onboarding Support. Our [Sales and Support teams](https://octopus.com/company/contact) are highly responsive and available to every customer. 
+Professional and Enterprise tier customers receive our expert-guided onboarding Support. Our [Sales and Support teams](https://octopus.com/company/contact) are highly responsive and available to every customer.
 
 ## Purchasing
 
 ### How do I purchase Octopus Cloud?
 
-We recommend new customers [start a free trial](https://octopus.com/pricing/overview) to get 30 days of access to Octopus Cloud Professional. A credit card is not required. [Contact Sales](https://octopus.com/company/contact) during the trial period to convert to an annual subscription with no data loss. 
+We recommend new customers [start a free trial](https://octopus.com/pricing/overview) to get 30 days of access to Octopus Cloud Professional. A credit card is not required. [Contact Sales](https://octopus.com/company/contact) during the trial period to convert to an annual subscription with no data loss.
 
 ### How can I trial Enterprise tier?
 
@@ -51,7 +51,7 @@ Please [contact Sales](https://octopus.com/company/contact) to trial Octopus Clo
 
 We license Octopus Cloud in tiers. Our Starter tier costs USD $360 per year, and it allows 10 projects, 10 tenants, 10 machines, and task cap of 5. There are no additional platform fees.
 
-Our Professional and Enterprise tiers are [annual licenses priced per project](https://octopus.com/pricing/overview), with tenants and machines sold as add-ons to suit your requirements. We also charge Professional and Enterprise tier customers a [flat annual platform fee](https://octopus.com/pricing/faq#what-is-the-pricing-for-octopus-cloud) based on the task cap selected, which defines the number of concurrent deployments/runbook runs your instance can perform. 
+Our Professional and Enterprise tiers are [annual licenses priced per project](https://octopus.com/pricing/overview), with tenants and machines sold as add-ons to suit your requirements. We also charge Professional and Enterprise tier customers a [flat annual platform fee](https://octopus.com/pricing/faq#what-is-the-pricing-for-octopus-cloud) based on the task cap selected, which defines the number of concurrent deployments/runbook runs your instance can perform.
 
 ### Do you support monthly billing?
 
@@ -59,11 +59,11 @@ No. Annual billing is the only option for Octopus Cloud subscriptions.
 
 ### How do I get a quote?
 
-Our Sales team can [provide a quote](https://octopus.com/company/contact) that meets your needs. 
+Our Sales team can [provide a quote](https://octopus.com/company/contact) that meets your needs.
 
 ### How do I use a purchase order?
 
-For customers purchasing or renewing on Starter, simply enter a Customer Reference in the online form. This value will appear on our quote or invoice PDF. 
+For customers purchasing or renewing on Starter, simply enter a Customer Reference in the online form. This value will appear on our quote or invoice PDF.
 
 For customers on Professional or Enterprise, please provide our Sales team with your purchase order, which we'll include in your quote or invoice.
 
@@ -73,7 +73,7 @@ Please refer to our dedicated [Octopus pricing overview page](https://octopus.co
 
 ## Data centers
 
-### Where is Octopus Cloud hosted? 
+### Where is Octopus Cloud hosted?
 
 We [host Octopus Cloud](/docs/octopus-cloud#octopus-cloud-hosting-locations) in the following Azure regions:
 
@@ -83,9 +83,9 @@ We [host Octopus Cloud](/docs/octopus-cloud#octopus-cloud-hosting-locations) in 
   
 Each customer's Octopus Cloud is wholly located in a single Azure region.
 
-### Where are the data centers located? 
+### Where are the data centers located?
 
-Each customer's Octopus Cloud is wholly located in a single Azure region. Microsoft publishes [data center information](https://datacenters.microsoft.com/) for each Azure region. 
+Each customer's Octopus Cloud is wholly located in a single Azure region. Microsoft publishes [data center information](https://datacenters.microsoft.com/) for each Azure region.
 
 ### Can we choose another Azure region?
 
@@ -99,11 +99,11 @@ Yes. [Contact Support](https://octopus.com/company/contact) to arrange the reloc
 
 ### How does Octopus Cloud approach security?
 
-We pride ourselves on making Octopus Deploy a [secure product](/docs/security#octopus-cloud). In addition, Octopus Cloud instances are [secure and compliant](/docs/octopus-cloud#secure-and-compliant-out-of-the-box) out-of-the-box. 
+We pride ourselves on making Octopus Deploy a [secure product](/docs/security#octopus-cloud). In addition, Octopus Cloud instances are [secure and compliant](/docs/octopus-cloud#secure-and-compliant-out-of-the-box) out-of-the-box.
 
 ### Is Octopus Cloud compliant with GDPR?
 
-Octopus complies with the European Union's General Data Protection Regulation ([GDPR](https://octopus.com/legal/gdpr)). 
+Octopus complies with the European Union's General Data Protection Regulation ([GDPR](https://octopus.com/legal/gdpr)).
 
 ### Is Octopus Cloud compliant with SOC 2?
 
@@ -115,7 +115,7 @@ Our information security management system has been assessed and found to confor
 
 ### Is Octopus Cloud compliant with HIPAA?
 
-Octopus Deploy is not a covered entity under HIPAA. We don't process personally identifiable health data directly or on behalf of our customers. Octopus Cloud has global healthcare industry customers operating on our platform. 
+Octopus Deploy is not a covered entity under HIPAA. We don't process personally identifiable health data directly or on behalf of our customers. Octopus Cloud has global healthcare industry customers operating on our platform.
 
 ### Where can I learn more about Octopus Deploy compliance?
 
@@ -137,33 +137,33 @@ Octopus Cloud communicates with Tentacles you deploy on your targets via TLS-enc
 
 Every process within a Tentacle is executed by the user account configured on its service. You can configure Tentacles to run under a [specific user account](/docs/infrastructure/deployment-targets/tentacle/windows/running-tentacle-under-a-specific-user-account) if you need elevated or alternative permissions. The user account configured constrains the Tentacle's access to data.
 
-### Does Octopus Cloud have any security vulnerabilities? 
+### Does Octopus Cloud have any security vulnerabilities?
 
 We make a list of all [our security advisories](https://advisories.octopus.com/) public, including any current vulnerabilities. We practice responsible disclosure as detailed in our [security disclosure policy](https://octopus.com/security/disclosure).
 
 ### Has Octopus Cloud had any vulnerabilities in the past?
 
-Yes. We pride ourselves on making Octopus Deploy a secure product, but no software is ever bug-free, and occasionally, there have been security issues. We've published [all of our historical advisories](https://advisories.octopus.com/) since 2021. 
+Yes. We pride ourselves on making Octopus Deploy a secure product, but no software is ever bug-free, and occasionally, there have been security issues. We've published [all of our historical advisories](https://advisories.octopus.com/) since 2021.
 
 ## Migration
 
-### How do I migrate from self-hosted Octopus Server to Octopus Cloud? 
+### How do I migrate from self-hosted Octopus Server to Octopus Cloud?
 
-We have a [step-by-step](/docs/octopus-cloud/migrations) guide. 
+We have a [step-by-step](/docs/octopus-cloud/migrations) guide.
 
 The benefits of migrating from self-hosted to Octopus Cloud include:
 
 - Likely lower total cost of hosting - taking into account the saving of having your people focused on your mission, not maintenance.
 - Cloud customers get access to the latest features and functionality.
-- Lower risk - Once a CVE or bug is found, we issue a patch and automatically apply it. 
+- Lower risk - Once a CVE or bug is found, we issue a patch and automatically apply it.
 - We perform maintenance that many customers do not (rebuild indexes, backup files and databases, have a recovery plan).
 - Monitoring and uptime - We monitor every instance to ensure it's online. When it goes offline, we attempt to automatically recover it, and failing that, we start paging our Support teams.
 
-### Can we trial Octopus Cloud while we decide on migration? 
+### Can we trial Octopus Cloud while we decide on migration?
 
 Yes. We can arrange temporary licenses to ensure you're not being double-billed during the trial. Please [contact our Sales team](https://octopus.com/company/contact) to arrange this.
 
-### How can I determine my current Octopus Server use? 
+### How can I determine my current Octopus Server use?
 
 We have diagnostic scripts we can share with you that make it easy to gather metrics about your configuration and use. [Contact our Support team](https://octopus.com/company/contact) to request access.
 
@@ -171,7 +171,7 @@ We have diagnostic scripts we can share with you that make it easy to gather met
 
 ### How often is Octopus Cloud updated?
 
-Octopus Cloud is a modern SaaS application that receives frequent updates. New features become available in Octopus Cloud before they become available to our self-host customers. We release bug fixes and improvements regularly and, when necessary, apply these during your [maintenance window](/docs/octopus-cloud/maintenance-window), typically once or twice weekly. 
+Octopus Cloud is a modern SaaS application that receives frequent updates. New features become available in Octopus Cloud before they become available to our self-host customers. We release bug fixes and improvements regularly and, when necessary, apply these during your [maintenance window](/docs/octopus-cloud/maintenance-window), typically once or twice weekly.
 
 ### When are updates performed?
 
@@ -185,7 +185,7 @@ We publish our [release updates](https://octopus.com/whatsnew) and provide a [re
 
 ### What is Octopus Cloud’s uptime SLO?
 
-Octopus Cloud's monthly [uptime SLO](/docs/octopus-cloud/uptime-slo) is 99.99%, measured for the 95th percentile of paid Cloud instances. We calculate uptime as 100% of the month, less all unplanned downtime. 
+Octopus Cloud's monthly [uptime SLO](/docs/octopus-cloud/uptime-slo) is 99.99%, measured for the 95th percentile of paid Cloud instances. We calculate uptime as 100% of the month, less all unplanned downtime.
 
 ### How is uptime monitored?
 
@@ -195,20 +195,19 @@ Our Cloud Platform team observes uptime and planned downtime durations as part o
 
 We publish Octopus Cloud’s [uptime track record](/docs/octopus-cloud/uptime-slo) monthly.
 
-
 ### How can we check Octopus Cloud's status?
 
 We publish Octopus Cloud's [operational status](https://status.octopus.com/). You can subscribe to status change emails from our [operational status page](https://status.octopus.com/).
 
 ## Logs and data
 
-### How do we access deployment and audit logs? 
+### How do we access deployment and audit logs?
 
 You can view and download deployment and access logs from Octopus Cloud. Enterprise-tier customers can [stream audit logs](/docs/security/users-and-teams/auditing/audit-stream) to their SIEM system.
 
 ### What is the data backup and retention policy?  
 
-Our [retention policies](/docs/administration/retention-policies) let you control which releases, packages, and files Octopus will keep. The retention policy is set to 30 days by default. [Backups](/docs/administration/data/backup-and-restore) are subject to [storage thresholds](/docs/octopus-cloud#octopus-cloud-storage-limits), 1TB by default. You can arrange more with our Sales team if required. 
+Our [retention policies](/docs/administration/retention-policies) let you control which releases, packages, and files Octopus will keep. The retention policy is set to 30 days by default. [Backups](/docs/administration/data/backup-and-restore) are subject to [storage thresholds](/docs/octopus-cloud#octopus-cloud-storage-limits), 1TB by default. You can arrange more with our Sales team if required.
 
 ### What access do Octopus staff have to our data?
 
@@ -220,31 +219,30 @@ Microsoft Azure may have infrastructure access and, as such, would also have acc
 
 Also, Octopus Cloud publishes [limited telemetry](/docs/security/outbound-requests/telemetry), which we use to track quality of service.
 
-### Is access to our data logged? 
+### Is access to our data logged?
 
 We log all access to Octopus Cloud instance databases and file storage.
 
-### Is data access actively monitored? 
+### Is data access actively monitored?
 
 Our SecOps team has monitoring and alerting in place based on patterns of suspicious activity. Monitoring focuses on Support Users being granted temporary access to a Cloud instance and queries being run by our staff against Cloud instance databases. Both of these activities are tightly controlled and logged, and access mechanisms are automatically revoked.
 
-Only authorized, skilled, and trained engineers employed by Octopus Deploy may be granted temporary access. 
+Only authorized, skilled, and trained engineers employed by Octopus Deploy may be granted temporary access.
 
 Microsoft Azure may have infrastructure access and, as such, would also have access, as controlled by our service agreements with them.
 
 ### How is data storage redundancy provided?
 
-All data storage is redundant. We use [Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy), allowing us to have geo-redundant backups of your Octopus Cloud database and zone-redundant backups of your Octopus Cloud file share. 
+All data storage is redundant. We use [Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy), allowing us to have geo-redundant backups of your Octopus Cloud database and zone-redundant backups of your Octopus Cloud file share.
 
 ### What is your disaster recovery process?
 
 Octopus Cloud has a well-defined [disaster recovery](/docs/octopus-cloud/disaster-recovery) process.
 
-### How often are backups performed? 
+### How often are backups performed?
 
-We take Octopus Cloud database backups using Azure’s [automated backup](https://learn.microsoft.com/en-us/azure/azure-sql/database/automated-backups-overview?view=azuresql&tabs=single-database#backup-frequency) process. We perform: 
+We take Octopus Cloud database backups using Azure’s [automated backup](https://learn.microsoft.com/en-us/azure/azure-sql/database/automated-backups-overview?view=azuresql&tabs=single-database#backup-frequency) process. We perform:
 
 - Full backups weekly
 - Differential backups every 12 or 24 hours
 - Transaction log backups approximately every 10 minutes
-

--- a/src/pages/docs/octopus-cloud/getting-started-with-cloud.mdx
+++ b/src/pages/docs/octopus-cloud/getting-started-with-cloud.mdx
@@ -1,10 +1,11 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-16
+modDate: 2025-06-06
 title: Getting started with Cloud
-navOrder: 5
-description: Learn how to set up and manage your Octopus Cloud instance.
+navTitle: Getting started with Cloud
+navOrder: 20
+description: Learn how to set up and manage your Octopus Cloud instance
 ---
 
 ## Create an Octopus account \{#create-an-octopus-account}
@@ -37,7 +38,7 @@ You'll see the account provisioning screen. Your Octopus Cloud instance should b
 
 You can access your Octopus Cloud instance using the URL you chose during registration. In this example URL, `your-url` is the part of the URL you provided:
 
-```
+```html
 https://your-url.octopus.app/app#/users/sign-in
 ```
 
@@ -60,7 +61,7 @@ To invite a user to your Octopus Cloud instance:
 
 #### Email invitation \{#email-invitation}
 
-The invited user will receive an email invitation. 
+The invited user will receive an email invitation.
 
 If they already have an [Octopus ID](/docs/security/authentication/octopusid-authentication) (Octopus Deploy account), they just need to click **Accept invite** in the email to gain access to the subscription and then click **Sign in** to view the Octopus instance.
 
@@ -86,8 +87,10 @@ By default, the “Everyone” team includes no user roles, so users assigned to
 
 :::div{.hint}
 To give an “Everyone” team user (Cloud Subscription User) the correct permissions, you can do one or both of the following in your Octopus Cloud instance:
+
 - Edit the “Everyone” team to include the minimum permissions all users need.
 - Add the user to other teams with the correct permissions after they first sign in.
+
 :::
 
 To adjust a user’s permissions, you can add them to other teams:

--- a/src/pages/docs/octopus-cloud/index.mdx
+++ b/src/pages/docs/octopus-cloud/index.mdx
@@ -1,14 +1,14 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-05-24
+modDate: 2025-06-06
 title: Octopus Cloud
 subtitle: We host Octopus for you
 icon: fa-solid fa-cloud
 navTitle: Overview
 navSection: Octopus Cloud
 navOrder: 10
-description: How to work with Octopus Cloud.
+description: How to work with Octopus Cloud
 hideInThisSectionHeader: true
 ---
 import OctopusAccount from 'src/shared-content/octopus-cloud/octopus-account.include.md';
@@ -16,45 +16,54 @@ import OctopusCloudInstance from 'src/shared-content/octopus-cloud/octopus-cloud
 import OctopusCloudRegions from 'src/shared-content/octopus-cloud/octopus-cloud-regions.include.md';
 import OctopusCloudStorageLimits from 'src/shared-content/octopus-cloud/octopus-cloud-storage-limits.include.md';
 
-Octopus Cloud is the easiest way to run Octopus Deploy. It has the same functionality as Octopus Server, delivered as a highly available, scalable, secure SaaS application hosted for you. You get the best Octopus experience from the experts in hosting, maintaining, scaling, and securing Octopus Deploy. We recommend Octopus Cloud over Octopus Server for the following reasons:
+Octopus Cloud is the easiest way to run Octopus Deploy. It has the same functionality as Octopus Server, delivered as a highly available, scalable, secure SaaS application hosted for you. You get the best Octopus experience from the experts in hosting, maintaining, scaling, and securing Octopus Deploy.
+
+We recommend Octopus Cloud over Octopus Server for the following reasons:
 
 ## Minimize downtime and increase resilience
+
 - We take care of any issues that arise so you don't have to worry about downtime, data loss, or disruptions
-    - Our 24x7 monitoring and alerting and proactive issue detection means problems get addressed before they impact your operations
-    - Automatic recovery with comprehensive [disaster recovery](https://octopus.com/docs/octopus-cloud/disaster-recovery#disaster-recovery-procedure) procedures means your data is safe and quickly recoverable in case of a failure
+  - Our 24x7 monitoring and alerting and proactive issue detection means problems get addressed before they impact your operations
+  - Automatic recovery with comprehensive [disaster recovery](https://octopus.com/docs/octopus-cloud/disaster-recovery#disaster-recovery-procedure) procedures means your data is safe and quickly recoverable in case of a failure
 
 ## Secure and compliant out-of-the-box
+
 - Peace of mind with internationally recognized security standards, ensuring business compliance and protecting your reputation
-    - ISO 27001 and SOC II certifications with regular audits, ensuring your deployments and data are safe and secure
-    - Data and application layer isolation per customer, so there are no noisy neighbors or cross-talk
-    - OpenID Connect (OIDC) support so you can integrate with other services securely and without needing to manage credentials
-    - Network security and static IP addresses
-    - Flexibility of hosting region choices
+  - ISO 27001 and SOC II certifications with regular audits, ensuring your deployments and data are safe and secure
+  - Data and application layer isolation per customer, so there are no noisy neighbors or cross-talk
+  - OpenID Connect (OIDC) support so you can integrate with other services securely and without needing to manage credentials
+  - Network security and static IP addresses
+  - Flexibility of hosting region choices
 
 ## Increase team efficiency
+
 - Stay ahead of the competition with less time maintaining software and more time shipping new features
-    - Automatic upgrades to the latest version of Octopus, including improvements, bug fixes, security enhancements, and [new features](https://octopus.com/whatsnew) before they’re released on Octopus Server
-    - Expert support by experienced Octopus Support and Cloud Operations teams who swiftly resolve issues and provide regular maintenance
+  - Automatic upgrades to the latest version of Octopus, including improvements, bug fixes, security enhancements, and [new features](https://octopus.com/whatsnew) before they’re released on Octopus Server
+  - Expert support by experienced Octopus Support and Cloud Operations teams who swiftly resolve issues and provide regular maintenance
 
 ## Effortlessly scale your deployments
+
 - Your teams can scale their use without the hassle of resource management and additional infrastructure costs
-    - We provide appropriate resources and automatic scaling for seamless performance 
-    - Ample bandwidth and storage resources to handle your data and traffic without additional costs
-    - Windows and Linux dynamic workers provide flexible and scalable deployment options
+  - We provide appropriate resources and automatic scaling for seamless performance
+  - Ample bandwidth and storage resources to handle your data and traffic without additional costs
+  - Windows and Linux dynamic workers provide flexible and scalable deployment options
 
 :::figure
-![](/docs/octopus-cloud/images/octopus-cloud-architecture-diagram.png)
+![Octopus Cloud architecture diagram](/docs/octopus-cloud/images/octopus-cloud-architecture-diagram.png)
 :::
 
 When you’re ready, [start a free trial](https://octopus.com/start) to explore Octopus.
 
 ## Are there any differences between Octopus Cloud and Server?
-In providing Octopus as a service, some configuration and diagnostic functions in Octopus Cloud differ from the Octopus Server. These include disabling specific items related to the cloud server's provisioning and management. You can learn more on the [migration page](/docs/octopus-cloud/migrations#differences-between-octopus-cloud-and-octopus-server). 
+
+In providing Octopus as a service, some configuration and diagnostic functions in Octopus Cloud differ from the Octopus Server. These include disabling specific items related to the cloud server's provisioning and management. You can learn more on the [migration page](/docs/octopus-cloud/migrations#differences-between-octopus-cloud-and-octopus-server).
 
 ## Where is Octopus Cloud hosted? \{#octopus-cloud-hosting-locations}
-Octopus Cloud runs in the Microsoft Azure cloud. When you create an Octopus Cloud instance, we provision a Linux container to run the Octopus Server in, along with all the other resources we need to provide Octopus as a service. We deploy this to one of our Kubernetes clusters. 
+
+Octopus Cloud runs in the Microsoft Azure cloud. When you create an Octopus Cloud instance, we provision a Linux container to run the Octopus Server in, along with all the other resources we need to provide Octopus as a service. We deploy this to one of our Kubernetes clusters.
 
 We host Octopus Cloud in the following Azure regions:
+
 - West US 2
 - West Europe
 - Australia East
@@ -62,6 +71,7 @@ We host Octopus Cloud in the following Azure regions:
 If you’d like to move an existing Octopus Cloud instance to one of the other regions or request a new region, please [contact us](https://octopus.com/company/contact).
 
 ## Octopus Cloud storage thresholds \{#octopus-cloud-storage-limits}
+
 Octopus Cloud instances are subject to storage thresholds.
 
 - Maximum file storage for artifacts, task logs, packages, package cache, and event exports is limited to 1 TB.
@@ -74,6 +84,7 @@ If you think you will exceed these thresholds, please [contact our Sales team](h
 Please see our [Cloud pricing FAQ](https://octopus.com/pricing/faq#are-there-any-storage-limits) for further details.
 
 ## Learn more
+
 - [Octopus Cloud FAQs](/docs/octopus-cloud/frequently-asked-questions)
 - [Octopus Cloud pricing FAQs](https://octopus.com/pricing/faq#are-there-any-differences-between-cloud-and-server)
 - [Octopus pricing page](https://octopus.com/pricing/overview)

--- a/src/pages/docs/octopus-cloud/maintenance-window.md
+++ b/src/pages/docs/octopus-cloud/maintenance-window.md
@@ -1,29 +1,30 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-11-27
-title: Octopus Cloud Maintenance Window
-navOrder: 55
-description: Details about the Octopus Cloud maintenance window
+modDate: 2025-06-06
+title: Maintenance windows
+navTitle: Maintenance windows
+navOrder: 80
+description: Octopus Cloud maintenance windows explained
 ---
 
 We are dedicated to keeping Octopus Cloud running smoothly and providing a reliable, scalable, and secure service. In order to do that, we must perform occasional maintenance, including updates and optimizations on your instance.
 Most of these won't affect your instance's availability, but occasionally, we might need to take it offline briefly for tasks like software upgrades or infrastructure improvements.
 
-
 :::div{.hint}
 We don’t need to perform actions on your instance daily, and most of our maintenance actions won’t take your instance offline. At most, you might notice a performance impact. The steps that require an outage typically only take a short time to complete.
 
-In the 4 months up to and including October 2024, Octopus Cloud instances: 
+In the 4 months up to and including October 2024, Octopus Cloud instances:
+
 - Had an average downtime of fewer than 8 minutes per week
 - Experienced any downtime on average fewer than 2 days a week
-:::
 
+:::
 
 ## You’re in control of the schedule
 
 You get to choose a two-hour time slot for maintenance activities. Pick a time outside your regular business hours to minimize potential impact.
-You can adjust your maintenance window anytime, but make sure to do it before your current window begins to avoid interrupting ongoing maintenance tasks. 
+You can adjust your maintenance window anytime, but make sure to do it before your current window begins to avoid interrupting ongoing maintenance tasks.
 
 ## View or change your maintenance window
 
@@ -41,16 +42,16 @@ At the start of each window, an evaluation is performed to determine which maint
 
 Those tasks include (but are not limited to) the following:
 
-- Database maintenance. This involves reindexing and compacting your Octopus Cloud instance database so that it can perform at its best. 
+- Database maintenance. This involves reindexing and compacting your Octopus Cloud instance database so that it can perform at its best.
 - Performing any Octopus Server software upgrades.
-- Moving your instance to new infrastructure. These operations don't happen as often, but are required when we roll out improvements to the underlying infrastructure. 
+- Moving your instance to new infrastructure. These operations don't happen as often, but are required when we roll out improvements to the underlying infrastructure.
 - Processing any billing events, such as applying the latest license key to the instance or changing the task cap.
 
 Most maintenance operations can be performed without taking the instance offline, such as database maintenance. Your instance may feel a little slower while any online maintenance operations are running.  For tasks that cause an outage, typically only a subset of steps require the instance to be offline. For all the other steps, we keep the instance online.
 
-Many of those tasks have guard clauses. For example, we won't de-fragment a database that has 10% fragmentation. In addition, we would only attempt to upgrade an instance if a new version exists. 
+Many of those tasks have guard clauses. For example, we won't de-fragment a database that has 10% fragmentation. In addition, we would only attempt to upgrade an instance if a new version exists.
 
-It is important to note that most maintenance tasks do not start at the beginning of your maintenance window. We host thousands of customer instances. Because of that, we perform maintenance tasks in bulk. When we run a maintenance task, your instance might be the first, somewhere in the middle, or at the end of the list of instances. In some cases, by the time we finish processing other instances, your maintenance window is about to end. When that happens, your instance is skipped and that task won't be processed until the next day. That typically happens when performing upgrades. 
+It is important to note that most maintenance tasks do not start at the beginning of your maintenance window. We host thousands of customer instances. Because of that, we perform maintenance tasks in bulk. When we run a maintenance task, your instance might be the first, somewhere in the middle, or at the end of the list of instances. In some cases, by the time we finish processing other instances, your maintenance window is about to end. When that happens, your instance is skipped and that task won't be processed until the next day. That typically happens when performing upgrades.
 
 :::div{.hint}
 Upgrading an instance is the primary cause of outages. The most noticeable impact of an outage is deployments and runbook runs may fail. We are actively working on [Resilient Scalable Deployments](https://roadmap.octopus.com/c/95-alpha-program-resilient-scalable-deployments-in-octopus-cloud) to allow deployments and runbook runs to continue post-upgrade.  
@@ -59,12 +60,12 @@ Upgrading an instance is the primary cause of outages. The most noticeable impac
 ## Taking your instance offline
 
 If we need to take your instance offline to perform any maintenance:
+
 - Your instance will be given a few minutes to shut down cleanly. This will allow any in-progress tasks to complete. Any tasks still running at the end of the timeout will be abandoned.
 - A maintenance page will be displayed to users and any requests to the API will return a 503 Service Unavailable status code.
 - The maintenance operations will be performed.
 - Your instance will start up again and we will check that it is in a healthy state.
 - The maintenance page is removed and your instance is accessible again. Any tasks that were paused during shut down will be resumed, and any tasks that were scheduled to start during the outage will be started.
-
 
 ## How we communicate maintenance windows
 

--- a/src/pages/docs/octopus-cloud/migrations.md
+++ b/src/pages/docs/octopus-cloud/migrations.md
@@ -1,10 +1,11 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-02-18
+modDate: 2025-06-06
 title: Migrating to Octopus Cloud
+navTitle: Migrating to Octopus Cloud
 navOrder: 30
-description:  This guide outlines the benefits of Octopus Cloud, the effort involved in migrating, and step-by-step instructions to help you have a smooth transition.
+description: This guide outlines the benefits of Octopus Cloud, the effort involved in migrating, and step-by-step instructions to help you have a smooth transition
 ---
 
 Migrating from a self-hosted instance of Octopus Deploy to Octopus Cloud can streamline your deployment processes by removing infrastructure overhead while ensuring you continue to enjoy the robust capabilities of Octopus.
@@ -15,20 +16,22 @@ For large or complex migrations, unsupported scenarios or any questions, we stro
 ## Benefits of migrating to Octopus Cloud
 
 Before diving into the migration process, it’s worth evaluating the benefits of Octopus Cloud. Octopus Cloud is the easiest way to run Octopus Deploy. It has the same functionality as Octopus Server, delivered as a highly available, scalable, secure SaaS application hosted for you. You get the best Octopus experience from the experts in hosting, maintaining, scaling, and securing Octopus Deploy. We recommend Octopus Cloud over Octopus Server for the following reasons:
+
 - **Minimize downtime and increase resilience**
-    - We handle backups, upgrades, and maintenance so you don’t have to worry about downtime, data loss, or disruptions
+  - We handle backups, upgrades, and maintenance so you don’t have to worry about downtime, data loss, or disruptions
 - **Secure and compliant out-of-the-box**
-    - Peace of mind with internationally recognized security standards (ISO 27001 and SOC II certifications), ensuring business compliance and protecting your reputation.
+  - Peace of mind with internationally recognized security standards (ISO 27001 and SOC II certifications), ensuring business compliance and protecting your reputation.
 - **Faster Feature Updates**: Access the latest Octopus Deploy features automatically.
-    - Automatic upgrades to the latest version of Octopus, including improvements, bug fixes, security enhancements, and new features 
+  - Automatic upgrades to the latest version of Octopus, including improvements, bug fixes, security enhancements, and new features
 - **Effortlessly scale your deployments**
-    - Your teams can scale their use without the hassle of resource management and additional infrastructure costs
+  - Your teams can scale their use without the hassle of resource management and additional infrastructure costs
 - **Cost Efficiency**: Reduce infrastructure and operational costs.
 
-In short, Octopus Cloud offloads your maintenance burden and provides the best experience for the majority of our customers. However, if your organization primarily uses self-hosted tools, you may encounter some challenges enabling connectivity between Octopus Cloud and other resources and tools within your ecosystem. 
+In short, Octopus Cloud offloads your maintenance burden and provides the best experience for the majority of our customers. However, if your organization primarily uses self-hosted tools, you may encounter some challenges enabling connectivity between Octopus Cloud and other resources and tools within your ecosystem.
 If you're uncertain whether Octopus Cloud is the right choice for your organization, contact our [Sales team](mailto:sales@octopus.com) to discuss your needs and determine the best fit.
 
 ## Migration assessment and planning
+
 ### Estimating Migration Effort
 
 Before you start planning your migration, it’s worth setting some expectations upfront about the level of effort involved. No two instances are identical, so this doesn't cover every possible scenario. Based on our experience, the figures here are estimates you can use to plan how long your own migration may take.
@@ -41,7 +44,7 @@ Before you start planning your migration, it’s worth setting some expectations
 
 #### Effort factors to refine your estimate
 
-Use this checklist to guide you as to the complexity of your migration. The more effort factors you need to resolve, the longer or more complex your migration will be. 
+Use this checklist to guide you as to the complexity of your migration. The more effort factors you need to resolve, the longer or more complex your migration will be.
 
 | **Question**         | **Considerations** |
 | ------------------------- | ----------- |
@@ -68,7 +71,7 @@ If your instance includes **unsupported features** or matches several of the **e
 
 ### Migration approach: self-serve or supported?
 
-If you’re confident Octopus Cloud is right for you, and you have a relatively straightforward migration path, we encourage you to use this guide to get started and wish you a speedy and smooth migration. 
+If you’re confident Octopus Cloud is right for you, and you have a relatively straightforward migration path, we encourage you to use this guide to get started and wish you a speedy and smooth migration.
 If you're uncertain whether Octopus Cloud is the right choice for your organization or there are complicating factors in your migration, we recommend you contact our [Sales team](mailto:sales@octopus.com) to discuss your needs and determine the best fit. We can discuss several options, from extending your trial during a longer migration to connecting you with a professional services partner who can help you complete the migration.
 
 #### Pilot project migration
@@ -76,6 +79,7 @@ If you're uncertain whether Octopus Cloud is the right choice for your organizat
 If you need more precise estimates or to understand the complexity of the challenges you may face, migrate a pilot project to see how long one project takes. You will get more efficient with each additional project; however, this is a good base for multiplying your efforts.
 
 ## Self-directed migration using Export/Import
+
 ### Overview
 
 :::div{.hint}
@@ -109,11 +113,13 @@ We recommend making a backup of your self-hosted DB including historical data sh
   - Manual Intervention logs
 - Audit History
 - Event Exports
+
 :::
 
 ## 1. Preparation
 
 **Before starting your migration to Octopus Cloud, you will need to address the following:**
+
 1. Understand the differences between Octopus Cloud and your Octopus Server.
 1. Upgrading your Octopus Server instance to the latest release of Octopus Deploy.
 1. Determine whether you need to convert your [Listening tentacles to Polling Tentacles](https://octopus.com/docs/infrastructure/deployment-targets/tentacle/tentacle-communication) for your deployment targets and workers.
@@ -124,6 +130,7 @@ We recommend making a backup of your self-hosted DB including historical data sh
 1. Creating your Octopus Cloud users.
 
 ### 1. Differences between Octopus Cloud and Octopus Server
+
 Octopus Cloud and Octopus Server are built on the same code base. The differences stem from the additional configuration steps we perform during the Octopus Cloud build. The differences are:
 
 |   | **Self-host** | **Cloud** |
@@ -132,41 +139,49 @@ Octopus Cloud and Octopus Server are built on the same code base. The difference
 | Infrastructure | Your responsibility.  | Our responsibility |
 | Compliance | Your responsibility.  | ISO 27001 and SOC II certifications with regular audits, ensuring your deployments and data are safe and secure |
 | Roles | Highest level of user privileges is the role of Octopus Administrator | Highest level of user privileges is the role of Octopus Manager |
-| Auth | | Octopus Cloud does not support Active Directory or LDAP. Please see the [authentication provider compatibility page](https://octopus.com/docs/security/authentication/auth-provider-compatibility) for an up to date list of what is available.
+| Auth | | Octopus Cloud does not support Active Directory or LDAP. Please see the [authentication provider compatibility page](https://octopus.com/docs/security/authentication/auth-provider-compatibility) for an up to date list of what is available |
 | Storage limits | Your responsibility. | Octopus Cloud is subject to [storage limits and default retention policies](https://octopus.com/docs/octopus-cloud/#octopus-cloud-storage-limits). <br/><br/><ul><li>Maximum file storage for artifacts, task logs, packages, package cache, and event exports is limited to 1 TB.</li><li>Maximum database size for configuration data (for example, projects, deployment processes, and inline scripts) is limited to 100 GB.</li><li>Maximum size for any single package is 5 GB.</li><li>[Retention policies](https://octopus.com/docs/administration/retention-policies) default to 30 days, but you can change this figure as needed.<br/>If any of these limits are a concern for your migration, please reach out to our [Sales team](mailto:sales@octopus.com).</li></ul> |
 | Functional differences | | Octopus Cloud does not support running tasks on the server itself. Everything must run on a deployment target or worker. To help, Octopus Cloud includes [dynamic worker pools](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools) with both Windows and Linux workers. |
 
 Before starting your migration, please ensure you are familiar with these fundamental differences (and limitations). Depending on your requirements, Octopus Cloud, in its current form, might not be suitable for you. If any of these limitations are deal-breakers, we’d love to know; please contact our [Sales team](mailto:sales@octopus.com). We are constantly improving Octopus Cloud; a current limit has a strong likelihood of changing in the future.
 
 ### 2. Upgrading your Octopus Server instance to the latest release of Octopus Deploy
+
 You must be running Octopus **2021.1.x** or higher to leverage the [Export/Import Projects](https://octopus.com/docs/projects/export-import) feature in order to migrate your projects. We recommend upgrading to the latest version of Octopus Deploy prior to starting your upgrade.
 
-### 3. Determine whether you need to convert your [Listening tentacles to Polling Tentacles](https://octopus.com/docs/infrastructure/deployment-targets/tentacle/tentacle-communication) for your deployment targets and workers 
+### 3. Determine whether you need to convert your [Listening tentacles to Polling Tentacles](https://octopus.com/docs/infrastructure/deployment-targets/tentacle/tentacle-communication) for your deployment targets and workers
+
 Listening Tentacles require an inbound connection from Octopus Cloud to your infrastructure. Listening tentacles are required to have a public hostname or IP address Octopus Cloud can see. Polling Tentacles require an outbound connection from your infrastructure to Octopus Cloud. Because of that difference, our customers tend to use Polling Tentacles.
 
 ### 4. Create your Octopus Cloud instance
-The remaining prep work involves testing connectivity. You will need to create an Octopus Cloud instance at this time if you haven’t already done so. You can sign-up for an Octopus Cloud instance [here](https://octopus.com/start/cloud).
+
+The remaining prep work involves testing connectivity. You will need to [create an Octopus Cloud instance](https://octopus.com/start/cloud) at this time if you haven’t already done so.
 
 ### 5. Firewall settings for your Tentacles
+
 Regardless of your tentacle communication mode, ensure you have the appropriate firewall rules configured. The default rules are:
+
 - Listening Tentacle
-    - Port `443` outbound (to register the tentacle with Octopus Cloud)
-    - Port `10933` inbound (communications)
+  - Port `443` outbound (to register the tentacle with Octopus Cloud)
+  - Port `10933` inbound (communications)
 - Polling Tentacle
-    - Port `443` outbound (to register the tentacle with Octopus Cloud)
-    - Port `10943` or `443` outbound (communications). [We recommend using Port 10943](https://octopus.com/docs/infrastructure/deployment-targets/tentacle/polling-tentacles-over-port-443).
+  - Port `443` outbound (to register the tentacle with Octopus Cloud)
+  - Port `10943` or `443` outbound (communications). [We recommend using Port 10943](https://octopus.com/docs/infrastructure/deployment-targets/tentacle/polling-tentacles-over-port-443).
 
 :::div{.hint}
-Our recommendation is to create a test server in each of your data centers, install a tentacle on it with the desired communication mode, and register it with Octopus Cloud. Work out any firewall configuration issues before starting the migration. 
+Our recommendation is to create a test server in each of your data centers, install a tentacle on it with the desired communication mode, and register it with Octopus Cloud. Work out any firewall configuration issues before starting the migration.
 :::
 
 ### 6. Configuring Workers and Worker Pools
-Octopus Cloud does not support running steps directly on the server. Instead, we provide each Octopus Cloud instance with [dynamic workers](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools). The dynamic workers are there to help get you started but have the following limitations.
+
+Octopus Cloud does not support running steps directly on the server. Instead, we provide each Octopus Cloud instance with [dynamic workers](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools). The dynamic workers are there to help get you started but have the following limitations:
+
 - Dynamic workers cannot see any of your internal infrastructure. That includes file shares, database servers, and internal load balancers.
 - Dynamic workers cannot see any cloud infrastructure behind a firewall or on a virtual network with restricted access. That includes K8s clusters, database servers, file shares, load balancers, and more.
 - Dynamic workers have a max life of **72 hours**. While you can install software on a dynamic worker, your deployment process will need to ensure any required software is installed at the start of each deployment.
 
 Our recommendation is to:
+
 1. Create a worker pool (or pools) per local data center or cloud provider. For example, if you have a data center in Omaha and are using AWS, you’d have two worker pools, one for your Omaha data center and another for AWS.
 1. If you already use or are comfortable using Kubernetes, we recommend using Kubernetes worker — a scalable worker developed for optimal use of compute when running multiple deployment tasks. To use the Kubernetes worker, you need to install a worker once on a cluster and [configure autoscaling](https://octopus.com/blog/kubernetes-worker).
 <br/>If you cannot use Kubernetes, create virtual machines and install tentacles as workers for each worker pool. For redundancy, we recommend a minimum of two (2) workers per worker pool. Install any required software on each worker.
@@ -178,18 +193,22 @@ Please do not skip Step 4. In doing step 4, you will start your migration in a k
 :::
 
 ### 7. Testing External Package Repository Connectivity
+
 If you use an external package repository, such as a self-hosted Artifactory instance, you’ll need to test that Octopus Cloud can see and connect to it. You might have to expose that server to the internet, or leverage a [proxy server](https://octopus.com/docs/infrastructure/deployment-targets/proxy-support/#external-nuget-feed).
 
 ### 8. User migration
+
 The project export/import feature does not include users. All users must be created from scratch. If you are using an external authentication provider, such as Azure AD, or Okta, you can turn on the [Automatic user creation](https://octopus.com/docs/security/authentication/auto-user-creation) feature.
 
 ## 2. Migration
 
 The migration will use the **Export/Import Projects** feature. This feature was specifically designed for [migrating from Octopus Server to Octopus Cloud](https://octopus.com/docs/projects/export-import). Our recommendations when using this tool are:
+
 - Migrate using a phased approach over migrating everything at once. Migrate a project group or suite of applications to Octopus Cloud, test some deployments, then move onto the next batch.
 - The first couple of projects will take more time as you work through any configuration issues. As such, pick some non-mission-critical projects or applications first.
 
-Your process for each project or application will generally follow these steps.
+Your process for each project or application will generally follow these steps:
+
 1. **Export and Import** the project from your Octopus Server instance into your Octopus Cloud instance.
 1. Upload any packages, project images, and reconfigure triggers.
 1. Copy or Create deployment targets.
@@ -204,13 +223,17 @@ Following this approach, you will have a time period with both an Octopus Server
 :::
 
 ### 1. Export and import the project
+
 Follow the instructions on [exporting and importing page](https://octopus.com/docs/projects/export-import) to export and import a project. Make a note of what is *not* exported. Releases and deployments are exported, but only “shells” (not the full deployment) to ensure any pre-existing releases can be promoted.
 
 ### 2. Upload any packages, project images, and reconfigure triggers
+
 As stated on the [export and import page](https://octopus.com/docs/projects/export-import/#what-is-imported), packages, project images, and project triggers are **not exported**. If you have any pre-existing releases you intend to promote and use the internal package feed; you’ll need to manually upload packages associated with those releases. You will also have to upload project images and reconfigure any triggers.
 
 ### 3. Copy or Create Deployment Targets
+
 A Windows or Linux server can have [1 to N tentacle instances](https://octopus.com/docs/administration/managing-infrastructure/managing-multiple-instances). Our recommendation is to create a second tentacle instance on your server.
+
 1. Original Tentacle Instance -> connects to your Octopus Server.
 1. New Tentacle Instance -> connects to Octopus Cloud.
 
@@ -223,19 +246,25 @@ That script requires PowerShell 5.1 or greater for Windows.  We recommend PowerS
 That script only works for servers running tentacles. Any other deployment targets, such as Azure Web Apps, Kubernetes clusters, or SSH targets, will need to be manually recreated.
 
 ### 4. Update your build server
+
 For the project(s) you have migrated, update the corresponding build configurations in your build server. Updating the build server will typically involve:
+
 - Ensuring you have the latest build server plug-in installed.
 - Updating the Octopus URL
 - Updating the Octopus API Key
 
 ### 5. Test the migration
+
 After the build server has been updated, create a small change to trigger your CI/CD pipeline for that application to test:
+
 - The build server to Octopus Cloud connection is working.
 - Octopus Deploy can connect to your deployment targets and workers.
 - Octopus Deploy can successfully deploy to your deployment targets.
 
 ### 6. Disable the project in your Octopus Server instance
+
 Disabling a project will prevent it from being able to create and deploy releases. It is also an excellent signal to all Octopus users that the project has been migrated.
+
 - Go to **Project Settings**
 - Click the overflow menu (`...`)
 - Select **Disable** on the menu
@@ -243,6 +272,7 @@ Disabling a project will prevent it from being able to create and deploy release
 If anything goes wrong immediately after the migration, you can re-enable this project so your application can still be deployed while troubleshooting the migration.
 
 ## 3. Clean up & deprecate
+
 ### 3.1 Deprecate your Octopus Server instance
 
 Eventually, you will migrate all your projects over to Octopus Cloud. When that day comes, we recommend [turning on maintenance mode](https://octopus.com/docs/administration/managing-infrastructure/maintenance-mode/) and setting the [task cap to 0](https://octopus.com/docs/support/increase-the-octopus-server-task-cap) on your Octopus Server. That will make your Octopus Server read-only. No new deployments will be triggered. Keep this running for a short while to review any old audit logs.
@@ -252,6 +282,7 @@ At this point, we recommend deleting all the tentacle instances still pointing t
 ```powershell
 & "C:\Program Files\Octopus Deploy\tentacle\tentacle.exe" delete-instance --instance="Tentacle"
 ```
+
 In our experience, most people turn off their Octopus Server in about three to six months. When you decide to turn off your Octopus server, first take a full backup of the database and delete all the appropriate resources.
 
 ## Older versions
@@ -260,6 +291,7 @@ In our experience, most people turn off their Octopus Server in about three to s
 - Prior to version **2025.2.5601**, Config-as-Code projects were not supported by the **Export/Import Projects** feature.
 
 ## No longer offered or supported
+
 Please note that our existing [Migration API](https://octopus.com/docs/octopus-rest-api/migration-api) is **not supported** for migrations to cloud instances due to configuration differences between self-hosted and cloud installations.
 
 The legacy [Data Migration](https://octopus.com/docs/administration/data/data-migration) included with Octopus Deploy is **not supported** for migrations to cloud instances. That tool is a Windows command-line application that must be run directly on the server hosting Octopus Deploy via an RDP session. Octopus Cloud runs on our Linux Container image on a Kubernetes Cluster and therefore access to the Container is not permitted for security reasons.

--- a/src/pages/docs/octopus-cloud/permissions.md
+++ b/src/pages/docs/octopus-cloud/permissions.md
@@ -1,10 +1,11 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-09-24
+modDate: 2025-06-06
 title: Permissions
-navOrder: 20
-description: Octopus Cloud includes permissions that relate to hosting Octopus itself, and not for the configuration of your instance, as that's managed by Octopus for you.
+navTitle: Permissions
+navOrder: 100
+description: Octopus Cloud includes permissions that relate to hosting Octopus itself, and not for the configuration of your instance, as that's managed by Octopus for you
 ---
 
 Your Octopus Cloud instance includes permissions that relate to hosting Octopus itself, and not for the configuration/usability of your instance (e.g. server configuration logs), so we've introduced a new built-in team called **Octopus Managers**, think of it as a **Cloud instance** admin.

--- a/src/pages/docs/octopus-cloud/static-ip.md
+++ b/src/pages/docs/octopus-cloud/static-ip.md
@@ -1,9 +1,10 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-09-24
+modDate: 2025-06-06
 title: Static IP address
-navOrder: 10
+navTitle: Static IP address
+navOrder: 40
 description: How to find the list of static IP addresses for your Octopus Cloud instance
 ---
 
@@ -18,9 +19,9 @@ With a static IP address, you can lock down the ingress and egress communication
 The Octopus-hosted [Dynamic Workers](/docs/infrastructure/workers/dynamic-worker-pools) do not fall within the static IP range of your Octopus Cloud Server. If a known/static IP is required for your worker, please consider provisioning your own [external worker](/docs/infrastructure/workers#external-workers-external-workers).
 :::
 
-The range of IP Addresses that your Octopus Cloud Server will use is listed in the technical section of the instance details page. 
+The range of IP Addresses that your Octopus Cloud Server will use is listed in the technical section of the instance details page.
 
 1. Log in to [Octopus.com](https://octopus.com).
 1. Select your cloud instance.
 1. Click **Configuration**.
-1. Scroll down to the **Static IP addresses** section, and you will see the static IP addresses your instance can use. 
+1. Scroll down to the **Static IP addresses** section, and you will see the static IP addresses your instance can use.

--- a/src/pages/docs/octopus-cloud/task-cap.md
+++ b/src/pages/docs/octopus-cloud/task-cap.md
@@ -1,10 +1,11 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-10-13
-modDate: 2024-09-23
+modDate: 2025-06-06
 title: Octopus Cloud Task Cap
+navTitle: Task cap
 navOrder: 60
-description: How to increase the task cap on an Octopus Cloud Instance.
+description: How to increase the task cap on an Octopus Cloud Instance
 ---
 
 Every Octopus Deploy instance has set number of concurrent tasks it can process.  That number of concurrent tasks is known as the Octopus Task Cap.  
@@ -28,6 +29,7 @@ A task can be:
 The most common tasks are deployments and runbook runs.
 
 The default task cap for Octopus Cloud instances is based on the license tier:
+
 - Starter: 5
 - Professional: 5
 - Enterprise: 20
@@ -35,9 +37,11 @@ The default task cap for Octopus Cloud instances is based on the license tier:
 Self-hosted customers have more control over their task cap.  As such, every self-hosted instance starts out with a task cap of 5.  A higher task cap requires more hosting resources.  Self-hosted customers can change their instance's task cap via the Octopus Deploy UI.  That is because self-hosted customers take on the responsibility of allocating resources, and paying any additional Azure, AWS, or GCP fees.  
 
 ## Increasing the Task Cap for Octopus Cloud
-Octopus Cloud customers must reach out to sales@octopus.com to increase the task cap.  
+
+Octopus Cloud customers must [contact our Sales team](https://octopus.com/company/contact) to increase the task cap.  
 
 Octopus Cloud provides the following Task Cap options:
+
 - Starter: 5
 - Professional: 5, 10, 20
 - Enterprise: 20, 40, 80, 160
@@ -46,16 +50,18 @@ Increasing the task cap will incur a corresponding increase in platform fees.  D
 
 We assign resources to each Octopus Cloud instance based on the task cap.  Changing the task cap changes those resources.  That requires a small outage as the instance and database are reprovisioned.  We will wait until your next maintenance window to perform that reprovisioning.  You might not see a change in the task cap until the next day.
 
-**Please note:** If you need a task cap higher than 160 please reach out to sales@octopus.com to discuss your use case.  These options are meant to cover the majority of use cases.  
+**Please note:** If you need a task cap higher than 160 please [contact our Sales team](https://octopus.com/company/contact) to discuss your use case.  These options are meant to cover the majority of use cases.  
 
-**Important:** 5, 10, 20, 40, 80, and 160 are the only options we offer.  If you want an instance with a task cap above 160, again, reach out to sales@octopus.com.  There are no options between those tiers.  For example, no Octopus Cloud instance can have a task cap of 15, 34, 45, or 68.  
+**Important:** 5, 10, 20, 40, 80, and 160 are the only options we offer.  If you want an instance with a task cap above 160, again, [contact our Sales team](https://octopus.com/company/contact). There are no options between those tiers.  For example, no Octopus Cloud instance can have a task cap of 15, 34, 45, or 68.  
 
 ## How to choose a task cap
+
 We recommend task caps based upon the number and duration of deployments required for a production deployment.  Deployments and runbook runs are the most common tasks.  Deployments typically take longer than runbook runs.  Production deployments are time constrained.  They are done off-hours during an outage window.
 
 **Important:** These tables represent the _MAX_ number of deployments.  Additional tasks such as runbook runs, retention policies, or health checks can reduce the number.  Use these tables as guidelines.
 
 ### Task Cap 5
+
 | Deployment Window | 10 Minute Deployments | 15 Minute Deployments | 30 Minute Deployments |
 | ----------------- | --------------------- | --------------------- | --------------------- |
 | 2 Hours           | 60 Deployments        | 40 Deployments        | 20 Deployments        |
@@ -65,6 +71,7 @@ We recommend task caps based upon the number and duration of deployments require
 | 24 Hours          | 720 Deployments       | 480 Deployments       | 320 Deployments       |
 
 ### Task Cap 10
+
 | Deployment Window | 10 Minute Deployments | 15 Minute Deployments | 30 Minute Deployments |
 | ----------------- | --------------------- | --------------------- | --------------------- |
 | 2 Hours           | 120 Deployments       | 80 Deployments        | 40 Deployments        |
@@ -74,6 +81,7 @@ We recommend task caps based upon the number and duration of deployments require
 | 24 Hours          | 1,440 Deployments     | 960 Deployments       | 640 Deployments       |
 
 ### Task Cap 20
+
 | Deployment Window | 10 Minute Deployments | 15 Minute Deployments | 30 Minute Deployments |
 | ----------------- | --------------------- | --------------------- | --------------------- |
 | 2 Hours           | 240 Deployments       | 160 Deployments       | 80 Deployments        |
@@ -83,6 +91,7 @@ We recommend task caps based upon the number and duration of deployments require
 | 24 Hours          | 2,880 Deployments     | 1,920 Deployments     | 960 Deployments       |
 
 ### Task Cap 40
+
 | Deployment Window | 10 Minute Deployments | 15 Minute Deployments | 30 Minute Deployments |
 | ----------------- | --------------------- | --------------------- | --------------------- |
 | 2 Hours           | 480 Deployments       | 320 Deployments       | 160 Deployments       |
@@ -92,6 +101,7 @@ We recommend task caps based upon the number and duration of deployments require
 | 24 Hours          | 5,760 Deployments     | 3,840 Deployments     | 1,920 Deployments     |
 
 ### Task Cap 80
+
 | Deployment Window | 10 Minute Deployments | 15 Minute Deployments | 30 Minute Deployments |
 | ----------------- | --------------------- | --------------------- | --------------------- |
 | 2 Hours           | 960 Deployments       | 640 Deployments       | 320 Deployments       |
@@ -101,6 +111,7 @@ We recommend task caps based upon the number and duration of deployments require
 | 24 Hours          | 11,520 Deployments    | 7,680 Deployments     | 3,840 Deployments     |
 
 ### Task Cap 160
+
 | Deployment Window | 10 Minute Deployments | 15 Minute Deployments | 30 Minute Deployments |
 | ----------------- | --------------------- | --------------------- | --------------------- |
 | 2 Hours           | 1,920 Deployments     | 1,280 Deployments     | 640 Deployments       |

--- a/src/pages/docs/octopus-cloud/uptime-slo.md
+++ b/src/pages/docs/octopus-cloud/uptime-slo.md
@@ -1,10 +1,11 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-02-04
-title: Octopus Cloud Uptime SLO
-navOrder: 50
-description: The uptime SLO for Octopus Cloud instances
+modDate: 2025-06-06
+title: Uptime SLO
+navTitle: Uptime SLO
+navOrder: 70
+description: Information about Octopus Cloud's uptime SLO, including the last 12 month's historical uptime data
 ---
 
 Each Octopus Cloud customer has their own Octopus Server delivered as a highly available, scalable, secure SaaS application hosted for you. Octopus Deploy manages maintenance and resource provisioning for these hosted servers, letting our customers focus on happy deployments.  


### PR DESCRIPTION
Addressed Markdown linting errors:
- 2 char indenting
- removed trailing spaces
- blank lines around lists
- blank lines around headings
- added alt text for an images
- added a missing table column end pipe

Front matter consistency:
- removed periods from end of descriptions
- ensured all pages have navTitle
- standardised and ensured uniqueness of navOrder
- Clarified and shortened a couple of descriptions
- Reordered section child pages
- Removed extraneous Octopus Cloud from child nav titles