### PR TITLE
Add anchor link to Installation section in Kubernetes Live Object Status troubleshooting

### DIFF
--- a/src/pages/docs/kubernetes/live-object-status/troubleshooting/index.md
+++ b/src/pages/docs/kubernetes/live-object-status/troubleshooting/index.md
@@ -11,7 +11,7 @@ navOrder: 70
 
 This page will help you diagnose and solve issues with Kubernetes Live Object Status.
 
-## Installation
+## Installation \{#installation}
 
 ### The Kubernetes monitor can't connect gRPC port 8443
 


### PR DESCRIPTION
Adding an anchor link to existing docs on troubleshooting KLOS. Will be using this anchor for a short link.