### PR TITLE
Adding additional information for the Octopus AI Assistant to work wi…

### DIFF
--- a/src/pages/docs/octopus-ai-assistant/index.mdx
+++ b/src/pages/docs/octopus-ai-assistant/index.mdx
@@ -94,7 +94,7 @@ For teams with specific internal processes, you can enhance any AI Assistant cap
 
 ### Using with on-premises instances
 
-For on-premises Octopus instances, ensure your server accepts HTTP requests from IP address `51.8.40.170` to enable AI Assistant functionality.
+For on-premises Octopus instances, ensure your server accepts HTTP requests from IP address `51.8.40.170` to enable AI Assistant functionality.  The DNS entry of your Octopus Server will also need to be resolvable over the Internet for the IP address to be able to communicate with it.
 
 :::div{.warning}
 It is not possible to integrate Octopus AI Assistant with an on-premises Octopus instance that cannot accept HTTP requests from this public IP address.


### PR DESCRIPTION
…th self-hosted instances

Current documentation makes it look like all you need is to allow the IP address in, but you also need the Azure Function to make a callback to the Octopus Server.  This means that the DNS entry of your self-hosted server needs to be resolvable via the Internet.