### PR TITLE
Octopus AI Assistant getting started docs

### DIFF
--- a/src/pages/docs/octopus-ai-assistant/cookbook/index.md
+++ b/src/pages/docs/octopus-ai-assistant/cookbook/index.md
@@ -6,7 +6,7 @@ title: Octopus AI Assistant Cookbook
 navTitle: Overview
 navSection: Cookbook
 description: A collection of prompt-based automation examples for Octopus Deploy
-navOrder: 1
+navOrder: 4
 ---
 
 This cookbook includes ready-to-use prompts that help automate and optimize your work with Octopus Deploy.

--- a/src/pages/docs/octopus-ai-assistant/getting-started.md
+++ b/src/pages/docs/octopus-ai-assistant/getting-started.md
@@ -1,0 +1,27 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2025-08-01
+modDate: 2025-08-01
+title: Getting started
+description: 
+navOrder: 3
+---
+
+## Prerequisites
+
+- An Octopus instance (cloud or on-premises with [public accessibility](#using-with-on-premises-instances))
+- A Chromium-based browser (Chrome, Brave, Edge, etc.) that supports Chrome Web Store extensions
+
+## Installation
+
+1. Install the [Octopus AI Assistant Chrome extension](https://oc.to/install-ai-assistant)
+2. Navigate to your Octopus Deploy instance. You will see a new icon in the bottom right corner of your Chrome browser
+3. Click the AI Assistant icon in your browser to start using the assistant
+
+## Using with on-premises instances
+
+For on-premises Octopus instances, ensure your server accepts HTTP requests from IP address `51.8.40.170` to enable AI Assistant functionality.  The DNS entry of your Octopus Server will also need to be resolvable over the Internet for the IP address to be able to communicate with it.
+
+:::div{.warning}
+It is not possible to integrate Octopus AI Assistant with an on-premises Octopus instance that cannot accept HTTP requests from this public IP address.
+:::

--- a/src/pages/docs/octopus-ai-assistant/index.mdx
+++ b/src/pages/docs/octopus-ai-assistant/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-04-04
-modDate: 2025-07-14
+modDate: 2025-08-01
 title: Octopus AI Assistant
 navTitle: Overview
 navSection: Octopus AI Assistant
@@ -16,6 +16,8 @@ The Octopus AI Assistant Alpha is a feature released to an audience who has opte
 :::
 
 ![Octopus AI Assistant Screenshot](/docs/octopus-ai-assistant/octopus-ai-assistant.png)
+
+To begin, see our [Getting Started](/docs/octopus-ai-assistant/getting-started) guide for setup instructions.
 
 ## Core capabilities
 
@@ -78,27 +80,6 @@ Example prompts:
 ## Custom prompts for organizational needs
 
 For teams with specific internal processes, you can enhance any AI Assistant capability with [custom prompts](/docs/octopus-ai-assistant/custom-prompts) that embed your organization's knowledge, procedures, and support channels directly into the AI responses.
-
-## Getting started
-
-### Prerequisites
-
-- An Octopus instance (cloud or on-premises with [public accessibility](#using-with-on-premises-instances))
-- A Chromium-based browser (Chrome, Brave, Edge, etc.) that supports Chrome Web Store extensions
-
-### Installation
-
-1. Install the [Octopus AI Assistant Chrome extension](https://oc.to/install-ai-assistant)
-2. Navigate to your Octopus Deploy instance. You will see a new icon in the top right corner of your Chrome browser
-3. Click the AI Assistant icon in your browser to start using the assistant
-
-### Using with on-premises instances
-
-For on-premises Octopus instances, ensure your server accepts HTTP requests from IP address `51.8.40.170` to enable AI Assistant functionality.  The DNS entry of your Octopus Server will also need to be resolvable over the Internet for the IP address to be able to communicate with it.
-
-:::div{.warning}
-It is not possible to integrate Octopus AI Assistant with an on-premises Octopus instance that cannot accept HTTP requests from this public IP address.
-:::
 
 ## We want your feedback
 


### PR DESCRIPTION
Move getting started instructions to its own page.
Link to it from the overview page.
Change order of cookbook so getting started appears directly under overview