### PR TITLE
Update dynamic worker docs

### DIFF
--- a/src/pages/docs/octopus-cloud/dynamic-worker.md
+++ b/src/pages/docs/octopus-cloud/dynamic-worker.md
@@ -34,7 +34,7 @@ Self-hosted Octopus Server customers have access to a third type of worker, know
 
 Dynamic workers are isolated virtual machines, hosted and created on-demand by Octopus to run your deployments and runbook steps. Dynamic workers are provided as part of your Octopus Cloud subscription.
 
-Customers may choose between Windows and Ubuntu virtual machine images for their dynamic workers. Octopus provides a [dynamic worker pool](/docs/infrastructure/workers/dynamic-worker-pools) of these virtual machines from which, as required, your Octopus Cloud will lease a freshly provisioned dynamic worker VM. Leases are held for a maximum of 72 hours.
+Customers may choose between Windows and Ubuntu virtual machine images for their dynamic workers. Octopus provides a [dynamic worker pool](/docs/infrastructure/workers/dynamic-worker-pools) of each type of these virtual machines from which, as required, your Octopus Cloud will lease a freshly provisioned dynamic worker VM. Leases are held for a maximum of 72 hours. Customers can lease one dynamic worker VM from each pool concurrently.
 
 ## Limitations of dynamic workers
 

--- a/src/pages/docs/octopus-cloud/dynamic-worker.md
+++ b/src/pages/docs/octopus-cloud/dynamic-worker.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-03-07
-modDate: 2025-06-06
+modDate: 2025-08-08
 title: Dynamic workers
 navTitle: Dynamic workers
 navOrder: 50

--- a/src/pages/docs/octopus-cloud/dynamic-worker.md
+++ b/src/pages/docs/octopus-cloud/dynamic-worker.md
@@ -34,7 +34,7 @@ Self-hosted Octopus Server customers have access to a third type of worker, know
 
 Dynamic workers are isolated virtual machines, hosted and created on-demand by Octopus to run your deployments and runbook steps. Dynamic workers are provided as part of your Octopus Cloud subscription.
 
-Customers may choose between Windows and Ubuntu virtual machine images for their dynamic workers. Octopus provides a [dynamic worker pool](/docs/infrastructure/workers/dynamic-worker-pools) of each type of these virtual machines from which, as required, your Octopus Cloud will lease a freshly provisioned dynamic worker VM. Leases are held for a maximum of 72 hours. Customers can lease one dynamic worker VM from each pool concurrently.
+Customers may choose between Windows and Ubuntu virtual machine images for their dynamic workers. Octopus provides a [dynamic worker pool](/docs/infrastructure/workers/dynamic-worker-pools) of these virtual machine image types from which, as required, your Octopus Cloud will lease a freshly provisioned dynamic worker VM. Leases are held for a maximum of 72 hours. Customers can lease one dynamic worker VM from each pool concurrently.
 
 ## Limitations of dynamic workers
 


### PR DESCRIPTION
Make it more explicit that customers can lease one VM of each type, and can do so concurrently.