### PR TITLE
Show actual server url example in sample github actions workflow

### DIFF
--- a/src/pages/docs/packaging-applications/build-servers/github-actions.mdx
+++ b/src/pages/docs/packaging-applications/build-servers/github-actions.mdx
@@ -66,7 +66,7 @@ jobs:
     - name: Login to Octopus Deploy 🐙
       uses: OctopusDeploy/login@v1
       with: 
-        server: ${{ secrets.SERVER }}
+        server: https://acme.octopus.app 
         service_account_id: a1a1a1a1-b2b2-c3c3-d4d4-e5e5e5e5e5e5
     
     # Action to Create a Release


### PR DESCRIPTION
Added an actual server url instead of a secret reference. Hopefully more helpful!