### PR TITLE
Update cli commands

### DIFF
--- a/src/pages/docs/administration/reporting/report-on-deployments-using-excel.md
+++ b/src/pages/docs/administration/reporting/report-on-deployments-using-excel.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-06-25
+modDate: 2025-09-01
 title: Report on deployments using Excel and XML
 icon: fa-solid fa-file-excel
 description: How to report on deployments using Excel and XML
@@ -20,37 +20,25 @@ At a high-level, the steps are:
 ![](/docs/administration/reporting/images/3278122.png)
 :::
 
-## Export all deployments to an XML file
+## Export all deployments using the XML feed
 
 Before we can report on the data using Excel, we need to export it in a format that Excel can import. The easiest way to do this is using an XML file.
 
-As of 2.5.10, the Octopus CLI can be used to export deployments to an XML file. The command looks like this:
+Octopus exposes data on deployments through the `/api/reporting/deployments/xml` endpoint. You can use our [Octopus API clients](/docs/octopus-rest-api/getting-started#api-clients) to download the XML file.
 
-```bash
-octo dump-deployments --server https://your-octopus-url --apiKey API-YOUR-KEY --filePath=Deployments.xml
-```
-
-:::div{.success}
-Learn more about [how to create an API key](/docs/octopus-rest-api/how-to-create-an-api-key/), and [how to use the Octopus CLI](/docs/octopus-rest-api/octopus-cli)
-:::
-
-The output will appear as follows:
+<details data-group="administration-reporting-report-on-deployments-using-excel-client">
+<summary>PowerShell</summary>
 
 ```powershell
-octo dump-deployments --server https://samples.octopus.app --apiKey API-GUEST --filepath C:\Development\Deployments.xml
-Octopus Deploy Command Line Tool, version 7.3.2
+$octopusURL = "https://your-octopus-url"
+$octopusAPIKey = "API-YOUR-KEY"
+$header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 
-Detected automation environment: "NoneOrUnknown"
-Space name unspecified, process will run in the default space context
-Handshaking with Octopus Server: https://samples.octopus.app
-Handshake successful. Octopus version: 2020.2.9; API version: 3.0.0
-Authenticated as: Guest
-Listing projects, project groups and environments
-Dumping deployments...
-Wrote 30 of 72 deployments...
-Wrote 60 of 72 deployments...
-Wrote 72 of 72 deployments...
+Invoke-RestMethod -Method Get -Uri "$octopusURL/api/reporting/deployments/xml" -Headers $header -OutFile "deployments.xml"
+
 ```
+
+</details>
 
 The command will produce an XML file with contents similar to the following:
 
@@ -82,12 +70,13 @@ This file is now ready to be imported into Excel.
 Now that we have an XML file containing our deployments, we can import it into Microsoft Excel. In this example we are using Excel 2013.
 
 1. Open Microsoft Excel, and create a new, blank workbook.
-2. On the **Data** ribbon tab, click **From Other Sources**, then choose **From XML Data Import**. 
+2. On the **Data** ribbon tab, click **From Other Sources**, then choose **From XML Data Import**.
 
    ![](/docs/administration/reporting/images/3278132.png)
+
 3. Excel will prompt you that the XML file does not refer to a schema, and that one will be created. Click **OK**.
 4. Excel will ask you where to create a table. Choose the location in your workbook to put the new table, or just click **OK**.
-5. You should now have a table that lists each of the deployments you have performed with Octopus, along with the name of the environment, project and the date of the deployment. 
+5. You should now have a table that lists each of the deployments you have performed with Octopus, along with the name of the environment, project and the date of the deployment.
 
    ![](/docs/administration/reporting/images/3278131.png)
 
@@ -95,7 +84,7 @@ Now that we have an XML file containing our deployments, we can import it into M
 
 It's easy to turn the table of deployments into a pivot table for reporting.
 
-1. Select any cell in the table, then from the **Insert** ribbon tab, click **PivotTable**. 
+1. Select any cell in the table, then from the **Insert** ribbon tab, click **PivotTable**.
 
    ![](/docs/administration/reporting/images/3278130.png)
 
@@ -156,8 +145,8 @@ There are two major limits to this approach to be aware of:
 
 1. As you have seen, only a small amount of data is available for use for reporting.
 2. If you use [retention policies](/docs/administration/retention-policies), releases and deployments that have been deleted by the retention policy will also not be available for reporting.
-:::
+   :::
 
 ## Learn more
 
-- [Reporting blog posts](https://octopus.com/blog/tag/reporting).
+- [Reporting blog posts](https://octopus.com/blog/tag/reporting/1).

--- a/src/pages/docs/deployments/azure/service-fabric/packaging.md
+++ b/src/pages/docs/deployments/azure/service-fabric/packaging.md
@@ -81,7 +81,7 @@ Whichever option from above that you select, the objective is to get the `Publis
 <summary>PowerShell</summary>
 
 ```powershell
-octo pack --id=MyFabricApplication --version=VERSION --format=Zip --outFolder=OUTPUT --basePath=MyFabricApplication\pkg\Release
+octopus package zip create --id MyFabricApplication --version VERSION --base-path MyFabricApplication\pkg\Release --out-folder OUTPUT --include '**'
 ```
 
 </details>
@@ -89,7 +89,7 @@ octo pack --id=MyFabricApplication --version=VERSION --format=Zip --outFolder=OU
 <summary>Bash</summary>
 
 ```bash
-octo pack --id=MyFabricApplication --version=VERSION --format=Zip --outFolder=OUTPUT --basePath=MyFabricApplication/pkg/Release
+octopus package zip create --id MyFabricApplication --version VERSION --base-path MyFabricApplication/pkg/Release --out-folder OUTPUT --include '**'
 ```
 
 </details>

--- a/src/pages/docs/deployments/azure/service-fabric/packaging.md
+++ b/src/pages/docs/deployments/azure/service-fabric/packaging.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-09-03
 title: Packaging a Service Fabric application
 description: Learn how to package a Service Fabric application so it can be deployed from Octopus.
 navOrder: 10

--- a/src/pages/docs/deployments/dotnet/netcore-webapp.md
+++ b/src/pages/docs/deployments/dotnet/netcore-webapp.md
@@ -24,7 +24,7 @@ When your application has been published you need to package it:
 
 ```powershell
 # Package the folder into a ZIP
-octo pack --id MyApp.Web --version 1.0.0 --basePath published-app
+octopus package zip create --id 'MyApp.Web' --version '1.0.0' --base-path 'published-app'
 ```
 
 For more information about packaging applications see [Creating packages using the Octopus CLI](/docs/packaging-applications/create-packages/octopus-cli).

--- a/src/pages/docs/deployments/dotnet/netcore-webapp.md
+++ b/src/pages/docs/deployments/dotnet/netcore-webapp.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-09-03
 title: ASP.NET Core webapp
 description: This guide covers everything you need to perform your first ASP.NET Core webapp deployment.
 navOrder: 0

--- a/src/pages/docs/deployments/nginx/create-and-push-asp.net-core-project.md
+++ b/src/pages/docs/deployments/nginx/create-and-push-asp.net-core-project.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-09-03
 title: Create and push an ASP.NET Core project
 description: This guide describes how to package and publish an ASP.NET Core project to Octopus from your development workstation.
 navOrder: 1

--- a/src/pages/docs/deployments/nginx/create-and-push-asp.net-core-project.md
+++ b/src/pages/docs/deployments/nginx/create-and-push-asp.net-core-project.md
@@ -27,7 +27,7 @@ We've crafted and packaged v1.0.0 of this sample application for you to try out 
 dotnet publish source/NginxSampleWebApp --output published-app --configuration Release
 
 # Package the folder into a ZIP
-octo pack --id NginxSampleWebApp --version 1.0.0 --basePath published-app
+octopus package zip create --id NginxSampleWebApp --version 1.0.0 --base-path published-app
 ```
 
 :::div{.hint}

--- a/src/pages/docs/deployments/patterns/elastic-and-transient-environments/immutable-infrastructure.md
+++ b/src/pages/docs/deployments/patterns/elastic-and-transient-environments/immutable-infrastructure.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-06-27
+modDate: 2025-09-03
 title: Immutable Infrastructure
 description: This guide covers deploying to immutable infrastructure where a new version of the infrastructure is provisioned and the old infrastructure is terminated.
 navOrder: 4

--- a/src/pages/docs/deployments/patterns/elastic-and-transient-environments/immutable-infrastructure.md
+++ b/src/pages/docs/deployments/patterns/elastic-and-transient-environments/immutable-infrastructure.md
@@ -88,10 +88,23 @@ We are almost there! Next we need to bump the version of **Hello World** and aut
 
 Octopus will automatically deploy the current successful deployment for a project. That means if you deploy release 1.0.0 and then create release 1.0.1, the version 1.0.0 will continue to be deployed until 1.0.1 has been manually deployed.  This is not ideal for immutable infrastructure, because we do not want to deploy 1.0.1 to our old infrastructure, so we have no way to indicate to Octopus that it should start deploying release 1.0.1.  Enter auto deploy overrides. By creating both a new release and an auto deploy override when our infrastructure is provisioned, we can indicate to Octopus that the new release should be deployed to the new infrastructure.
 
-1. Create an auto deploy override using the Octopus CLI:
+1. Create an auto deploy override using the Octopus C# Client:
 
 ```powershell
-octo create-autodeployoverride --project "Hello World" --environment $environment --version $version --server $octopusURI --apiKey $apiKey
+Add-Type -Path 'Octopus.Client.dll'
+
+$octopusURI = 'https://your-octopus-url'
+$apiKey = 'API-YOUR-KEY'
+
+$endpoint = New-Object Octopus.Client.OctopusServerEndpoint $octopusURI, $apiKey
+$repository = New-Object Octopus.Client.OctopusRepository $endpoint
+
+$project = $repository.Projects.Get("Projects-1")
+$environment = $repository.Environments.Get("Environments-1")
+$release = $repository.Releases.Get("Releases-1")
+
+$project.AddAutoDeployReleaseOverride($environment, $release)
+$repository.Projects.Modify($project)
 ```
 
 ## Magic {#ImmutableInfrastructure-Magic}
@@ -105,15 +118,23 @@ $octopusURI = "https://your-octopus-url"
 $apiKey = "API-YOUR-KEY"
 
 $endpoint = New-Object Octopus.Client.OctopusServerEndpoint $octopusURI, $apiKey
+octopus login --server $octopusURI --api-key $apiKey
 $repository = New-Object Octopus.Client.OctopusRepository $endpoint
 
-octo create-release --project "Hello World Infrastructure"  --packageversion "1.0.0.0" --deployto "Development" --server $octopusURI --apiKey $apiKey
-octo create-release --project "Hello World" --server $octopusURI --apiKey $apiKey
+octopus release create --project "Hello World Infrastructure" --package-version "1.0.0.0"
+$infraProject = $repository.Projects.FindByName("Hello World Infrastructure")
+$infraRelease = $repository.Projects.GetReleases($project).Items | Select-Object -first 1
+octopus release deploy --project 'Hello World Infrastructure' --version $infraRelease.Version --environment 'Development' --no-prompt
+
+octopus release create --project "Hello World"
 
 $project = $repository.Projects.FindByName("Hello World")
 $release = $repository.Projects.GetReleases($project).Items | Select-Object -first 1
+$environment = $repository.Environments.FindByName("Development")
+$project.AddAutoDeployReleaseOverride($environment, $release)
 
-octo create-autodeployoverride --project "Hello World" --environment "Development" --version $release.Version --server $octopusURI --apiKey $apiKey
+$project.AddAutoDeployReleaseOverride($environment, $release)
+$repository.Projects.Modify($project)
 
 ```
 

--- a/src/pages/docs/deployments/patterns/elastic-and-transient-environments/keeping-deployment-targets-up-to-date.md
+++ b/src/pages/docs/deployments/patterns/elastic-and-transient-environments/keeping-deployment-targets-up-to-date.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-04-28
+modDate: 2025-09-03
 title: Keeping deployment targets up to date
 description: Octopus can ensure that deployment targets are kept up to date with the relevant releases. This can be useful when deploying to transient targets or when new deployment targets are added to an environment.
 navOrder: 2

--- a/src/pages/docs/deployments/patterns/elastic-and-transient-environments/keeping-deployment-targets-up-to-date.md
+++ b/src/pages/docs/deployments/patterns/elastic-and-transient-environments/keeping-deployment-targets-up-to-date.md
@@ -62,13 +62,6 @@ To test the trigger, we will disable a deployment target, deploy to that target'
 
 Automatic deployments attempts to calculate the release to use for a project and environment (using the *current* and *successful* release that has been deployed, as shown in your Project Overview dashboard). In some cases the calculated release may not be the release that should be automatically deployed, or Octopus may not be able to find a deployment for an environment (maybe you have a release, but have not yet deployed it anywhere). It is possible to explicitly set the release that should be automatically deployed by overriding the automatic-deployment-release. Overrides can be configured using the [Octopus CLI](/docs/octopus-rest-api/octopus-cli/) or through [Octopus.Client](/docs/octopus-rest-api/octopus.client). Overrides define a release for a project when deploying to an environment (this can, for example, be useful for cloud-testing-automation when standing up new cloud infrastructure). For multi-tenanted deployments, overrides may be configured for each environment/tenant combination.
 
-**Octopus CLI**
-
-```bash
-octo create-autodeployoverride --server https://your-octopus-url --apiKey API-YOUR-KEY --project HelloWorld --environment Test -version 1.3.0
-octo delete-autodeployoverride --server https://your-octopus-url --apiKey API-YOUR-KEY --project HelloWorld --environment Test
-```
-
 **Octopus.Client**
 
 ```powershell

--- a/src/pages/docs/packaging-applications/package-repositories/built-in-repository/index.md
+++ b/src/pages/docs/packaging-applications/package-repositories/built-in-repository/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2025-09-03
 title: Built-in Octopus repository
 description: Using the Octopus built-in repository.
 navOrder: 10

--- a/src/pages/docs/packaging-applications/package-repositories/built-in-repository/index.md
+++ b/src/pages/docs/packaging-applications/package-repositories/built-in-repository/index.md
@@ -11,15 +11,15 @@ Your Octopus Server comes with a built-in repository which is the best choice fo
 
 The built-in feed can only be consumed by Octopus. Octopus Server provides a write-only repository; intended for hosting deployment packages only. Packages that are pushed to the Octopus Server can't be consumed by other NuGet clients like Visual Studio. If you need a NuGet feed for sharing libraries between your development projects, a separate NuGet repository is required. See [package repositories](/docs/packaging-applications/package-repositories).
 
-## Pushing packages to the built-in repository {#pushing-packages-to-the-built-in-repository}
+## Uploading packages to the built-in repository {#pushing-packages-to-the-built-in-repository}
 
 It is possible to manually upload a package file from your local machine via the Octopus Web Portal by navigating to **Library ➜ Packages** and clicking the **Upload Package** button.
 
-However, we recommend using a [build server](/docs/packaging-applications/build-servers) to build, test, package and automatically push your release packages into the Octopus Deploy built-in repository.
+However, we recommend using a [build server](/docs/packaging-applications/build-servers) to build, test, package and automatically upload your release packages into the Octopus Deploy built-in repository.
 
-In most cases you simply provide the build server with the URL to your Octopus Server and an [Octopus API key](/docs/octopus-rest-api/how-to-create-an-api-key) with the required permissions  (see [security considerations](/docs/packaging-applications/package-repositories/built-in-repository/#security-considerations)).
+In most cases you simply provide the build server with the URL to your Octopus Server and an [Octopus API key](/docs/octopus-rest-api/how-to-create-an-api-key) with the required permissions (see [security considerations](/docs/packaging-applications/package-repositories/built-in-repository/#security-considerations)).
 
-In addition to manually uploading packages or using your build server, you can add, upload, and push packages to the built-in feed in the following ways:
+In addition to manually uploading packages or using your build server, you can add, upload packages to the built-in feed in the following ways:
 
 - [Using the Octopus CLI](#UsingOctopusCli).
 - [Using the Octopus API (HTTP POST)](#UsingTheOctopusAPI(HttpPost)).
@@ -34,13 +34,13 @@ To push packages using these methods, you will need:
 
 ## Using the Octopus CLI {#UsingOctopusCli}
 
-You can push one or more packages using the [Octopus CLI](/docs/packaging-applications/create-packages/octopus-cli), the command-line tool for Octopus Deploy. The example below will push `MyApp.Website.1.1.0.zip` and `MyApp.Database.1.1.0.zip` to the built-in repository, automatically replacing existing packages if there are conflicts.
+You can upload one or more packages using the [Octopus CLI](/docs/packaging-applications/create-packages/octopus-cli), the command-line tool for Octopus Deploy. The example below will upload `MyApp.Website.1.1.0.zip` and `MyApp.Database.1.1.0.zip` to the built-in repository, automatically replacing existing packages if there are conflicts.
 
 <details data-group="packaging-built-in-repository">
 <summary>PowerShell</summary>
 
 ```powershell
-C:\> octo push --package MyApp.Website.1.1.0.zip --package MyApp.Database.1.1.0.zip --replace-existing --server https://my.octopus.url --apiKey API-XXXXXXXXXXXXXXXX
+C:\> octopus package upload --package MyApp.Website.1.1.0.zip --package MyApp.Database.1.1.0.zip --overwrite-mode overwrite
 ```
 
 </details>
@@ -48,7 +48,7 @@ C:\> octo push --package MyApp.Website.1.1.0.zip --package MyApp.Database.1.1.0.
 <summary>Bash</summary>
 
 ```bash
-$ octo push --package MyApp.Website.1.1.0.zip --package MyApp.Database.1.1.0.zip --replace-existing --server https://my.octopus.url --apiKey API-XXXXXXXXXXXXXXXX
+$ octopus package upload --package MyApp.Website.1.1.0.zip --package MyApp.Database.1.1.0.zip --overwrite-mode overwrite
 ```
 
 </details>

--- a/src/pages/docs/projects/variables/prompted-variables.md
+++ b/src/pages/docs/projects/variables/prompted-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-29
+modDate: 2025-09-03
 title: Prompted variables
 icon: fa-solid fa-terminal
 description: Prompted variables allow you to prompt a user to enter a value rather than storing it in Octopus.

--- a/src/pages/docs/projects/variables/prompted-variables.md
+++ b/src/pages/docs/projects/variables/prompted-variables.md
@@ -47,10 +47,10 @@ When deploying (not creating a release), you'll be prompted to provide a value f
 
 These variables will be ordered alphabetically by label (or name, if the variable label is not provided).
 
-A value can also be passed to a prompted variable when using the Octopus CLI through the `--variable` parameter of the [Deploy-Release](/docs/octopus-rest-api/octopus-cli/deploy-release/) command, or the [Create-Release](/docs/octopus-rest-api/octopus-cli/create-release) command when also deploying the release with the `--deployto` parameter.
+A value can also be passed to a prompted variable when using the Octopus CLI through the `--variable` parameter of the [octopus release deploy](/docs/octopus-rest-api/cli/octopus-release-deploy) command.
 
-```bash
-octo deploy-release ... --variable "Missile launch code:LAUNCH123" --variable "Variable 2:Some value"
+```bash;
+octopus release deploy ... --variable "Missile launch code:LAUNCH123" --variable "Variable 2:Some value"
 ```
 
 :::div{.hint}

--- a/src/pages/docs/projects/version-control/creating-release-from-a-build-server-plug-in.mdx
+++ b/src/pages/docs/projects/version-control/creating-release-from-a-build-server-plug-in.mdx
@@ -1,12 +1,19 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-10-04
+modDate: 2025-09-03
 title: Creating releases from a build server plugin on a version-controlled project
 description: Examples of how to ensure that the right branch is used to create the release when using a build server plugin.
 navOrder: 45 
 icon: fa-brands fa-git-alt
 ---
+
+:::div{.hint}
+Creating releases for version controlled projects using Octopus Deploy GitHub App authentication is not yet supported in some build server integrations. (Bamboo, BitBucket Pipelines, Jenkins, TeamCity)
+
+Consider using git credentials for version controlled projects that are integrating with these build servers.
+:::
+
 import BuildServerPluginVersionControlFields from 'src/shared-content/projects/version-control/build-server-plugin-version-control-fields.include.md';
 
 <BuildServerPluginVersionControlFields />

--- a/src/pages/docs/releases/creating-a-release.md
+++ b/src/pages/docs/releases/creating-a-release.md
@@ -43,10 +43,10 @@ Deployments scheduled for the future can be viewed under the Project Overview pa
 
 ### Schedule deployments with the Octopus CLI
 
-For everyone using the [Octopus CLI](/docs/octopus-rest-api/octopus-cli), you can use the following option:
+For everyone using the [Octopus CLI](/docs/octopus-rest-api/cli), you can use the following option:
 
 ```powershell
-octo deploy-release --deployAt="2014-07-12 17:54:00 +11:00" --project=HelloWorld --releaseNumber=1.0.0 --deployto=Production --server=https://your-octopus-url --apiKey=API-YOUR-KEY
+octopus release deploy --deploy-at "2014-07-12 17:54:00 +11:00" --project HelloWorld -- version 1.0.0 --environment Production
 ```
 
 ### Exclude steps from releases

--- a/src/pages/docs/releases/creating-a-release.md
+++ b/src/pages/docs/releases/creating-a-release.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2024-04-29
-modDate: 2024-06-25
+modDate: 2025-09-03
 title: Creating a release
 description: Learn how to create a release in Octopus Deploy  
 navOrder: 2

--- a/src/pages/docs/tenants/tenant-tags.md
+++ b/src/pages/docs/tenants/tenant-tags.md
@@ -108,7 +108,7 @@ Consider an example deploying a release to the tenants tagged with the **Alpha**
 
 ```powershell
 # Deploys My Project 1.0.1 to all tenants tagged as in the Alpha ring
-./octo deploy-release --server=http://octopus.company.com --apiKey=API-1234567890123456 --project="My Project" --version="1.0.1" --tenantTag="Release ring/Alpha"
+octopus release deploy --project "My Project" --version "1.0.1" --tenant-tag "Release ring/Alpha"
 ```
 
 Some places you can use tags are:

--- a/src/pages/docs/tenants/tenant-tags.md
+++ b/src/pages/docs/tenants/tenant-tags.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-02-18
+modDate: 2025-09-03
 title: Tenant tags
 icon: fa-solid fa-tags
 description: Tenant Tags help you to classify your tenants with custom tags so you can tailor your tenanted deployments accordingly.


### PR DESCRIPTION
# Background

The old Octo Command Line tool is deprecated. The documentation still refers to the old CLI in a few areas, which may be confusing for users.

# Result
This PR updates the documentation to remove references to the old CLI.
[sc-118974]

Updated sections
- Data export
- Deployments - packaging
- Deployments - auto deploy overrides
- Creating releases
- Build server integrations

# Reviewing the PR

- Try running locally and check
- Grammar and spelling