### PR TITLE
Adding deprecations notice for SHA1 Tentacle changes to 2025.3 release

### DIFF
--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -23,6 +23,16 @@ Deprecations are subject to change in detail or time frame. If you need help ass
 
 ## Planned Deprecations
 
+## Deprecations for 2025.3
+
+### Removing support on Linux self-hosted and Cloud for SHA-1 certificates in Octopus Tentacles
+
+Starting in Octopus 2025.3, Tentacle instances using SHA‑1 certificates will no longer be supported. SHA‑1 is an outdated hashing algorithm with known security weaknesses, and modern security standards recommend stronger alternatives such as SHA‑256.
+
+If any of your deployment targets are running Tentacles with SHA‑1 certificates, they will be unable to connect to your Octopus Server after upgrading to 2025.3. We recommend updating your Tentacle certificates to SHA‑256 before upgrading.
+
+For background, migration guidance, and a detailed timeline, please see our blog post: [Removing support for SHA‑1 certificates in Octopus Tentacles](https://octopus.com/blog/removing-sha1-tentacles).
+
 ## Deprecations for 2025.2
 
 ### Defaulting C# scripting to dotnet-script

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-06-10
+modDate: 2025-10-02
 title: Deprecations
 description: Upcoming and past deprecations by version for Octopus Server
 navOrder: 300


### PR DESCRIPTION
Following our blog post on [Removing support for SHA-1 certificates in Octopus Tentacles
](https://octopus.com/blog/removing-sha1-tentacles) and the now closed issue on [Removing support on Linux self-hosted and Cloud for SHA-1 certificates in Octopus Tentacles](https://github.com/OctopusDeploy/Issues/issues/9508), we're adding a section to the deprecations page for the appropriate release.

This follows an internal support thread from an earlier discussion with Simon: https://octopusdeploy.slack.com/archives/C08AH85QTN3/p1754783324066279?thread_ts=1752220740.422009&cid=C08AH85QTN3