### PR TITLE
Update Uptime SLO stats for September 2025

### DIFF
--- a/src/pages/docs/octopus-cloud/uptime-slo.md
+++ b/src/pages/docs/octopus-cloud/uptime-slo.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-09-05
+modDate: 2025-10-03
 title: Uptime SLO
 navTitle: Uptime SLO
 navOrder: 70
@@ -26,6 +26,7 @@ We list our achieved uptime percentage and weekly unplanned downtime duration. W
 
 | Month  | Uptime % | Weekly unplanned downtime | Uptime % incl. planned maintenance | Weekly downtime incl. planned maintenance |
 | :----- | ------: | ------: | ------: | ------: |
+| September 2025 | 99.9989% | 7s | 99.8722% | 777s |
 | August 2025 | 99.9989% | 7s | 99.9281% | 441s |
 | July 2025 | 99.9992% | 7s | 99.9207% | 483s |
 | June 2025 | 99.9974% | 21s | 99.9307% | 420s |
@@ -37,8 +38,6 @@ We list our achieved uptime percentage and weekly unplanned downtime duration. W
 | December 2024 | 100% | 0s | 99.9666% | 203s |
 | November 2024 | 100% | 0s | 99.8895% | 672s |
 | October 2024 | 99.9973% | 21s | 99.917% | 504s |
-| September 2024 | 99.9977% | 14s | 99.9165% | 511s |
-| August 2024 | 99.9955% | 28s | 99.8978% | 623s |
 
 ### How we calculate uptime
 


### PR DESCRIPTION
Add uptime statistics for September 2025 and removed August and September 2024 to list only the past 12 months as per

> This table lists Octopus Cloud's monthly uptime statistics for the last 12 months.

[sc-120729]