### PR TITLE
ArgoCD: Add warnings to indicate github alone is supported

### DIFF
--- a/src/pages/docs/argo-cd/resources/index.md
+++ b/src/pages/docs/argo-cd/resources/index.md
@@ -20,20 +20,24 @@ There are a number of use cases which Octopus _cannot_ support due to data acces
     * If your application specifies a constant `TargetRevision`, Octopus will treat it as a branch - and fail to push back to your repository.
 * Octopus cannot update the content of Helm Sources as they typically references a chart from a Helm Repository or OCI feed which is static content.
     * However, if your application is represented as a helm chart _in a directory_, Octopus can interact with the directory content via the applications repository
+* Octopus can create PRs for github based repositories only - support for other platforms is coming in later builds.
+
 
 ## Update Argo Manifest Step
-| Argo Source Type   | Repository Content | Behavior                                                                                  |
-|--------------------|--------------------|-------------------------------------------------------------------------------------------|
-| Directory          | Kubernetes Yaml    | &#x2705; Will successfully inject Octopus variables to the yaml                           |
-| Directory          | Kubernetes Yaml    | &#x2705; Will successfully inject Octopus variables to the yaml                           |
-| Directory          | Helm Chart         | &#x2705; Will successfully inject variables to any file in the repository's path          |     
-| Multiple Directory | *                  | &#x1F7E1; Will write the _same_ content to both sources, in respective paths              |
-| Helm               | Helm Chart         | &#x274C; Not currently supported - work coming to update *referenced* `values.yaml` files |
+| Argo Source Type | Repository Content | Behavior                                                                                  |
+|------------------|--------------------|-------------------------------------------------------------------------------------------|
+| Directory        | Kubernetes Yaml    | &#x2705; Will successfully inject Octopus variables to the yaml                           |
+| Directory        | Kubernetes Yaml    | &#x2705; Will successfully inject Octopus variables to the yaml                           |
+| Directory        | Helm Chart         | &#x2705; Will successfully inject variables to any file in the repository's path          |
+ | Directory | Kustomize |  &#x2705; Will successfully inject variables to any file in the repository's path |
+| Multiple Source  | Any                | &#x274C; Not currently supported - work coming to update specifically referenced sources  |
+| Helm             | Helm Chart         | &#x274C; Not currently supported - work coming to update *referenced* `values.yaml` files |
 
 ## Update Argo Image Tags
-| Argo Source Type     | Repository Content                 | Behavior                                                                                                     |
-|----------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| Directory            | Kubernetes Yaml                    | &#x2705; Will update image-tag fields without requiring additional annotations                               |
-| Directory            | Helm Chart w/values.yaml           | &#x2705; Will update image-tag fields, will require helm-annotations to identify image-fields in values file |
-| Multiple Directories | Helm Char w/referenced values.yaml | &#x2705; Will update image-tag fields, will require multiple helm annotations                                |
+| Argo Source Type     | Repository Content                 | Behavior                                                                                                 |
+|----------------------|------------------------------------|----------------------------------------------------------------------------------------------------------|
+| Directory            | Kubernetes Yaml                    | &#x2705; Will update image-tag fields without requiring additional annotations                           |
+| Directory | Kustomize | &#x2705; Will replace image tag values in the kustomize file |
+| Directory            | Helm Chart w/internal values.yaml  | &#x2705; Will update image-tag fields, requires helm-annotations to identify image-fields in values file |
+| Multiple Directories | Helm Char w/referenced values.yaml | &#x2705; Will update image-tag fields, requires multiple helm annotations                                |
 

--- a/src/pages/docs/argo-cd/resources/index.md
+++ b/src/pages/docs/argo-cd/resources/index.md
@@ -20,7 +20,7 @@ There are a number of use cases which Octopus _cannot_ support due to data acces
     * If your application specifies a constant `TargetRevision`, Octopus will treat it as a branch - and fail to push back to your repository.
 * Octopus cannot update the content of Helm Sources as they typically references a chart from a Helm Repository or OCI feed which is static content.
     * However, if your application is represented as a helm chart _in a directory_, Octopus can interact with the directory content via the applications repository
-* Octopus can create PRs for github based repositories only - support for other platforms is coming in later builds.
+* Octopus can currently only create Pull Requests for GitHub-based repositories. Please [let us know](https://oc.to/roadmap-argo-cd) which other providers you would like to see supported.
 
 
 ## Update Argo Manifest Step

--- a/src/pages/docs/argo-cd/steps/update-application-image-tags.md
+++ b/src/pages/docs/argo-cd/steps/update-application-image-tags.md
@@ -41,10 +41,10 @@ The output section allows you to configure how changes are to be merged into you
 2. Commit message allows you to specify the summary, and description of the change. The description will be automatically populated if left empty.
    * The content here will be reused for Pull Request messages if you have selected for the change to merge via Pull Request
 3. Git Commit Method specifies _how_ changes are merged - merging directly into the repo, or going via a PR.
-   * A third option exists whereby you can specify which environments should use PRs, with all others falling back to a direct commit
+   * A third option exists whereby you can specify which environments should use Pull Requests, with all others falling back to a direct commit
    * This is useful if your Production environment requires PRs, but early environments do not.
 :::div{.warning}
-At this time, PRs can only be created for GitHub based repositories, work is coming to support other platforms.
+Currently, Pull Requests can only be created for GitHub-based repositories. Please [let us know](https://oc.to/roadmap-argo-cd) which other providers you would like to see supported.
 :::
 
 ## Creating and Deploying a Release

--- a/src/pages/docs/argo-cd/steps/update-application-image-tags.md
+++ b/src/pages/docs/argo-cd/steps/update-application-image-tags.md
@@ -29,7 +29,7 @@ This step will execute on a worker of your choosing - if required it can run wit
 
 ### Inputs
 
-2. Specify the Container Images which are to be updated  in your Argo Application.
+1. Specify the Container Images which are to be updated  in your Argo Application.
 `Note`: These packages can then be used in an [external feed trigger](/docs/projects/project-triggers/external-feed-triggers), such that your cluster is automatically updated when new image versions become available.
 
 
@@ -43,6 +43,9 @@ The output section allows you to configure how changes are to be merged into you
 3. Git Commit Method specifies _how_ changes are merged - merging directly into the repo, or going via a PR.
    * A third option exists whereby you can specify which environments should use PRs, with all others falling back to a direct commit
    * This is useful if your Production environment requires PRs, but early environments do not.
+:::div{.info}
+At this time, PRs can only be created for GitHub based repositories, work is coming to support other platforms.
+:::
 
 ## Creating and Deploying a Release
 :::div{.info}

--- a/src/pages/docs/argo-cd/steps/update-application-image-tags.md
+++ b/src/pages/docs/argo-cd/steps/update-application-image-tags.md
@@ -43,7 +43,7 @@ The output section allows you to configure how changes are to be merged into you
 3. Git Commit Method specifies _how_ changes are merged - merging directly into the repo, or going via a PR.
    * A third option exists whereby you can specify which environments should use PRs, with all others falling back to a direct commit
    * This is useful if your Production environment requires PRs, but early environments do not.
-:::div{.info}
+:::div{.warning}
 At this time, PRs can only be created for GitHub based repositories, work is coming to support other platforms.
 :::
 

--- a/src/pages/docs/argo-cd/steps/update-application-manifests.md
+++ b/src/pages/docs/argo-cd/steps/update-application-manifests.md
@@ -41,10 +41,11 @@ The output section allows you to configure how changes are to be merged into you
 2. Commit message allows you to specify the summary, and description of the change. The description will be automatically populated if left empty.
     * The content here will be reused for Pull Request messages if you have selected for the change to merge via Pull Request
 3. Git Commit Method specifies _how_ changes are merged - merging directly into the repo, or going via a PR.
-    * A third option exists whereby you can specify which environments should use PRs, with all others falling back to a direct commit
+    * A third option exists whereby you can specify which environments should use Pull Requests, with all others falling back to a direct commit
     * This is useful if your Production environment requires PRs, but early environments do not.
+
 :::div{.warning}
-   At this time, PRs can only be created for GitHub based repositories, work is coming to support other platforms.
+      Currently, Pull Requests can only be created for GitHub-based repositories. Please [let us know](https://oc.to/roadmap-argo-cd) which other providers you would like to see supported.
 :::
 
 4. Purge Output Folder allows you to clear the `Path` directory of the Argo CD Application's repository prior to adding newly templated files.

--- a/src/pages/docs/argo-cd/steps/update-application-manifests.md
+++ b/src/pages/docs/argo-cd/steps/update-application-manifests.md
@@ -17,21 +17,16 @@ how it executes.
 Add the `Update Argo CD Application Manifests` step to the project, and provide it a name.
 
 ## Provide the required configuration
-
-
 1. Specify an execution location
-
-This step will execute on a worker of your choosing - if required it can run within a container on the worker, though this should not be necessary.
-
+  * This step will execute on a worker of your choosing, if required it can run within a container on the worker, though this should not be necessary.
 ### Inputs
 1. Specify the set of input template files which can be sourced from either:
-* A git repository (requires URL, credentials and branch-name), or a
-* Package from a configured feed (eg a zip file, nuget package etc)
-
-2Specify the "Input Path"
-* A subfolder (or file) within the previously specified repository/package which contains the template files to be used
-  * If the string entered is a directory, all files (recursively) within that directory are considered templates
-  * If the string entered is a single file - only that file will be considered a template.
+   * A git repository (requires URL, credentials and branch-name), or a
+   * Package from a configured feed (eg a zip file, nuget package etc)
+2. Specify the "Input Path"
+   * A subfolder (or file) within the previously specified repository/package which contains the template files to be used
+   * If the string entered is a directory, all files (recursively) within that directory are considered templates
+   * If the string entered is a single file - only that file will be considered a template.
 :::div{.info}
 A single file will be copied into the _root_ directory of the Path defined in the mapped Argo CD Application.
 When a directory is specified, the structure below the specified path is maintained when moving files into the Argo CD Application's repository.
@@ -48,13 +43,12 @@ The output section allows you to configure how changes are to be merged into you
 3. Git Commit Method specifies _how_ changes are merged - merging directly into the repo, or going via a PR.
     * A third option exists whereby you can specify which environments should use PRs, with all others falling back to a direct commit
     * This is useful if your Production environment requires PRs, but early environments do not.
-:::div{.info}
+:::div{.warning}
    At this time, PRs can only be created for GitHub based repositories, work is coming to support other platforms.
 :::
 
 4. Purge Output Folder allows you to clear the `Path` directory of the Argo CD Application's repository prior to adding newly templated files.
     * This can be useful when resources have been removed from your input-templates, but also need to be removed from the target repository.
-
 
 
 ## Creating and Deploying a Release

--- a/src/pages/docs/argo-cd/steps/update-application-manifests.md
+++ b/src/pages/docs/argo-cd/steps/update-application-manifests.md
@@ -24,11 +24,11 @@ Add the `Update Argo CD Application Manifests` step to the project, and provide 
 This step will execute on a worker of your choosing - if required it can run within a container on the worker, though this should not be necessary.
 
 ### Inputs
-2. Specify the set of input template files which can be sourced from either:
+1. Specify the set of input template files which can be sourced from either:
 * A git repository (requires URL, credentials and branch-name), or a
 * Package from a configured feed (eg a zip file, nuget package etc)
 
-3. Specify the "Input Path"
+2Specify the "Input Path"
 * A subfolder (or file) within the previously specified repository/package which contains the template files to be used
   * If the string entered is a directory, all files (recursively) within that directory are considered templates
   * If the string entered is a single file - only that file will be considered a template.
@@ -36,7 +36,7 @@ This step will execute on a worker of your choosing - if required it can run wit
 A single file will be copied into the _root_ directory of the Path defined in the mapped Argo CD Application.
 When a directory is specified, the structure below the specified path is maintained when moving files into the Argo CD Application's repository.
 :::
-4. Container Images can be defined (but are optional) - these are included to allow External Feed Triggers to be attached to the project.
+3. Container Images can be defined (but are optional) - these are included to allow External Feed Triggers to be attached to the project.
 
 ### Outputs
 The output section allows you to configure how changes are to be merged into your repository.
@@ -48,8 +48,14 @@ The output section allows you to configure how changes are to be merged into you
 3. Git Commit Method specifies _how_ changes are merged - merging directly into the repo, or going via a PR.
     * A third option exists whereby you can specify which environments should use PRs, with all others falling back to a direct commit
     * This is useful if your Production environment requires PRs, but early environments do not.
+:::div{.info}
+   At this time, PRs can only be created for GitHub based repositories, work is coming to support other platforms.
+:::
+
 4. Purge Output Folder allows you to clear the `Path` directory of the Argo CD Application's repository prior to adding newly templated files.
     * This can be useful when resources have been removed from your input-templates, but also need to be removed from the target repository.
+
+
 
 ## Creating and Deploying a Release
 :::div{.info}


### PR DESCRIPTION
Added to the supported-use cases, and also as a warning to the 2 step pages.