### PR TITLE
Fix release custom fields link in ephemeral environments docs

### DIFF
--- a/src/pages/docs/projects/ephemeral-environments/index.md
+++ b/src/pages/docs/projects/ephemeral-environments/index.md
@@ -58,7 +58,7 @@ Enter a template and click Next.
 
 #### Custom Fields
 
-Releases support Custom Fields which can be used to configure the name of an ephemeral environment. See [Using custom fields in releases](/docs/releases#custom-fields) for more information.
+Releases support Custom Fields which can be used to configure the name of an ephemeral environment. See [Using custom fields in releases](/docs/releases/creating-a-release#custom-fields) for more information.
 
 :::div{.hint}
 Remember that custom fields referenced in your Environment Name Template must be provided with any release that you use to create an ephemeral environment.


### PR DESCRIPTION
The link in the ephemeral environments page on how to use custom fields in releases is pointing at https://octopus.com/docs/releases#custom-fields when it should be pointing at https://octopus.com/docs/releases/creating-a-release#custom-fields. This just fixes that up.

[sc-124306]