### PR TITLE
Add callout for runbook triggers and pre-release package versions

### DIFF
--- a/src/pages/docs/runbooks/config-as-code-runbooks.md
+++ b/src/pages/docs/runbooks/config-as-code-runbooks.md
@@ -82,6 +82,10 @@ The information that was previously found on the **Snapshot** page is still avai
 
 [Runbook triggers](/docs/runbooks/scheduled-runbook-trigger) will always run CaC Runbooks from the latest commit on your default branch, just as non-CaC runbook triggers will only run published runbooks.
 
+:::{.hint}
+If you have steps that use packages in your runbook process we only support getting latest non-prerelease versions. To use prerelease packages you would need to hard-code the version on individual steps.
+:::
+
 ## Custom automated scripts
 
 If you use automated scripts that run runbooks via the Octopus Server API and you convert your runbooks to Config As Code the URL for the runbook will change to include a branch reference (e.g. `refs/heads/main`) as a result you need to update your scripts to include the branch reference where the runbook is stored. 

--- a/src/pages/docs/runbooks/scheduled-runbook-trigger/index.md
+++ b/src/pages/docs/runbooks/scheduled-runbook-trigger/index.md
@@ -34,6 +34,10 @@ Scheduled runbook triggers provide a way to configure your runbooks to run on a 
 
 If you are using [tenants](/docs/tenants) you can select the tenants that the runbook will run against. For each tenant, the published runbook will run against the tenant's environment. 
 
+:::{.hint}
+If you have steps that use packages in your runbook process we only support getting latest non-prerelease versions. To use prerelease packages you would need to hard-code the version on individual steps.
+:::
+
 6. Save the trigger.
 
 :::div{.hint}


### PR DESCRIPTION
Scheduled triggers for git runbooks only support finding non-prerelease package versions so I'm adding a callout to our docs to make it clear that runbook triggers won't find prerelease packages and that you'd have to hard-code the version if you want to use them.

[sc-124157]