### PR TITLE
Fixed callouts for package versions in CaC runbooks as they were incorrectly formatted

### DIFF
--- a/src/pages/docs/runbooks/config-as-code-runbooks.md
+++ b/src/pages/docs/runbooks/config-as-code-runbooks.md
@@ -82,7 +82,7 @@ The information that was previously found on the **Snapshot** page is still avai
 
 [Runbook triggers](/docs/runbooks/scheduled-runbook-trigger) will always run CaC Runbooks from the latest commit on your default branch, just as non-CaC runbook triggers will only run published runbooks.
 
-:::{.hint}
+:::div{.hint}
 If you have steps that use packages in your runbook process we only support getting latest non-prerelease versions. To use prerelease packages you would need to hard-code the version on individual steps.
 :::
 

--- a/src/pages/docs/runbooks/scheduled-runbook-trigger/index.md
+++ b/src/pages/docs/runbooks/scheduled-runbook-trigger/index.md
@@ -34,7 +34,7 @@ Scheduled runbook triggers provide a way to configure your runbooks to run on a 
 
 If you are using [tenants](/docs/tenants) you can select the tenants that the runbook will run against. For each tenant, the published runbook will run against the tenant's environment. 
 
-:::{.hint}
+:::div{.hint}
 If you have steps that use packages in your runbook process we only support getting latest non-prerelease versions. To use prerelease packages you would need to hard-code the version on individual steps.
 :::
 


### PR DESCRIPTION
### Before

<img width="807" height="223" alt="image" src="https://github.com/user-attachments/assets/972761ea-eec5-4ced-a2a1-75de84115ad3" />

### After

<img width="874" height="307" alt="image" src="https://github.com/user-attachments/assets/7ece173c-cf69-415e-a280-c7fc2fae5594" />
