### PR TITLE
Add troubleshooting docs for runbook migrations to cac

### DIFF
--- a/src/pages/docs/runbooks/config-as-code-runbooks.md
+++ b/src/pages/docs/runbooks/config-as-code-runbooks.md
@@ -34,6 +34,21 @@ You can migrate an existing version controlled project to use CaC Runbooks by cl
 
 Once that's done, you should see a branch selector at the top of the **Runbooks** page, and a new 'runbooks/' directory in your repository alongside your existing OCL files. (See the '.octopus/ directory' of your repository project repository.) 
 
+### Troubleshooting
+
+**Slug related errors during migration**
+
+Published runbook snapshots must have unique step slugs. Step slugs were added to Octopus in 2022. If you published snapshots before this feature was added, those snapshots may contain empty or duplicate slugs.
+To identify and fix these issues:
+
+1. Use these scripts to check for problematic slugs in your runbooks:
+- [Check for blank slugs in runbook snapshots](https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/REST/PowerShell/Runbooks/CheckForBlankSlugsInFrozenSnapshots.ps1)
+- [Check for duplicate slugs in runbook snapshots](https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/REST/PowerShell/Runbooks/CheckForDuplicateSlugs.ps1)
+
+2. For any affected runbooks, ensure all steps have unique slugs
+3. Publish new snapshots of the affected runbooks
+4. Retry the runbook migration
+
 ## Drafts vs branches
 
 One of the exciting things about CaC is that it allows you to edit your runbooks over as many branches as you would like, creating as many copies of each runbook as you have branches. This means that we no longer need 'draft' runbooks. 


### PR DESCRIPTION
Customer ran into issues migrating their runbooks due to duplicate/empty slugs in their runbook snapshots. This was likely due to them having published runbooks from before slugs were introduced.

This was not able to be fixed in code as duplicate slugs meant that we could not determine the `processOrder`.

Added docs to help troubleshoot slug related errors during runbook migrations. Included 2 scripts from support that help identify the problematic runbook steps.

[sc-120525]