### PR TITLE
Update links in deployment targets documentation

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/index.mdx
@@ -37,5 +37,5 @@ Deployments to Kubernetes clusters are performed by a lightweight agent that run
 You select the target type when you add it to Octopus. Based on the type, you'll be prompted to set up the appropriate connection using a simple form.
 
 ## Learn more
-- How Octopus counts deployment targets
-- Adding deployment targets
+- [How Octopus counts deployment targets](/docs/infrastructure/deployment-targets/how-octopus-counts-deployment-targets)
+- [Adding deployment targets](/docs/getting-started/first-deployment/add-deployment-targets)


### PR DESCRIPTION
There are Learn More bullet points in the Deployment Targets help page without associated links. This PR links to sensible pages explaining those topics.