### PR TITLE
Add information to GitHub Connections for allow lists

### DIFF
--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -81,7 +81,7 @@ Whenever possible, Octopus uses a token scoped down to minimal permissions in ac
 
 ## Allow List
 
-The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list either enable "Enable IP allow list configuration for installed GitHub Apps" in the "Authentication security" section, or manually add the IP Address "172.182.208.68" to your allow list.
+The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list manually add the IP Address `172.182.208.68`. Due to a limitation in the way that GitHub supports inheritance of IP addresses when performing actions on behalf of a user, the IP address for the GitHub App needs to be configured manually and cannot be inherited from the app settings. For more information please refer to [GitHub's Documentation](https://docs.github.com/en/enterprise-cloud@latest/apps/maintaining-github-apps/managing-allowed-ip-addresses-for-a-github-app#about-ip-address-allow-lists-for-github-apps)
 
 :::div{.hint}
 **Note:**

--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2024-03-14
-modDate: 2024-11-07
+modDate: 2026-04-13
 title: GitHub integration 
 description: Octopus Deploy GitHub integration
 icon: fa-brands fa-github
@@ -79,6 +79,10 @@ There are specific GitHub permissions that the Octopus GitHub App requests in or
 
 Whenever possible, Octopus uses a token scoped down to minimal permissions in accordance with the principle of least privilege.
 
+## Allow List
+
+The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list either enable "Enable IP allow list configuration for installed GitHub Apps" in the "Authenication security" section, or manually add the IP Address "172.182.208.68" to your allow list.
+
 ## More information on installing and authorizing the Octopus GitHub App
 
 You install the Octopus GitHub App on an account (organization or user) to give the repositories or other content within that account. Authorizing gives the Octopus GitHub App permission to act on your behalf in any account that has the app installed.
@@ -89,9 +93,6 @@ Installing and authorizing are both GitHub concepts. If you want to find out mor
 - [Installing GitHub apps documentation](https://docs.github.com/en/apps/using-github-apps/installing-a-github-app-from-a-third-party)
 - [Authorizing GitHub apps documentation](https://docs.github.com/en/apps/using-github-apps/authorizing-github-apps)
 
-## Known limitations
-
-- Connecting to GitHub organizations with IP allow lists enabled is not currently supported with Octopus GitHub App Connections.
 
 ## Older versions
 

--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -85,9 +85,8 @@ The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list 
 
 :::div{.hint}
 **Note:**
-In order to use Octopus Deploy with GitHub allow lists, the IP address of your Octopus Deploy instance and any workers that require GitHub access will also need to be added. If you are using a Octopus Cloud instance of Octopus Deploy you can obtain your [staitc IP](/docs/octopus-cloud/static-ip) via the Control Center.
+In order to use Octopus Deploy with GitHub allow lists, the IP address of your Octopus Deploy instance and any workers that require GitHub access will also need to be added. If you are using a Octopus Cloud instance of Octopus Deploy you can obtain your [static IP](/docs/octopus-cloud/static-ip) via the Control Center.
 :::
-
 
 ## More information on installing and authorizing the Octopus GitHub App
 

--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -79,14 +79,16 @@ There are specific GitHub permissions that the Octopus GitHub App requests in or
 
 Whenever possible, Octopus uses a token scoped down to minimal permissions in accordance with the principle of least privilege.
 
-## Allow List
+## GitHub Allow List
 
-The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list manually add the IP Address `172.182.208.68`. Due to a limitation in the way that GitHub supports inheritance of IP addresses when performing actions on behalf of a user, the IP address for the GitHub App needs to be configured manually and cannot be inherited from the app settings. For more information please refer to [GitHub's Documentation](https://docs.github.com/en/enterprise-cloud@latest/apps/maintaining-github-apps/managing-allowed-ip-addresses-for-a-github-app#about-ip-address-allow-lists-for-github-apps)
+The Octopus Deploy GitHub App can be used with the GitHub's allow list feature. To include the app in your allow list manually add the IP Address `172.182.208.68`. Information about adding IP addresses to GitHub's allow list can be found in [GitHub's Documentation](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#adding-an-allowed-ip-address) 
 
 :::div{.hint}
 **Note:**
 In order to use Octopus Deploy with GitHub allow lists, the IP address of your Octopus Deploy instance and any workers that require GitHub access will also need to be added. If you are using a Octopus Cloud instance of Octopus Deploy you can obtain your [static IP](/docs/octopus-cloud/static-ip) via the Control Center.
 :::
+
+Due to a limitation in the way that GitHub supports inheritance of IP addresses when performing actions on behalf of a user, the IP address for the GitHub App needs to be configured manually and cannot be inherited from the app settings. For more information please refer to [GitHub's Documentation](https://docs.github.com/en/enterprise-cloud@latest/apps/maintaining-github-apps/managing-allowed-ip-addresses-for-a-github-app#about-ip-address-allow-lists-for-github-apps)
 
 ## More information on installing and authorizing the Octopus GitHub App
 

--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -83,6 +83,12 @@ Whenever possible, Octopus uses a token scoped down to minimal permissions in ac
 
 The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list either enable "Enable IP allow list configuration for installed GitHub Apps" in the "Authentication security" section, or manually add the IP Address "172.182.208.68" to your allow list.
 
+:::div{.hint}
+**Note:**
+In order to use Octopus Deploy with GitHub allow lists, the IP address of your Octopus Deploy instance and any workers that require GitHub access will also need to be added. If you are using a Octopus Cloud instance of Octopus Deploy you can obtain your [staitc IP](/docs/octopus-cloud/static-ip) via the Control Center.
+:::
+
+
 ## More information on installing and authorizing the Octopus GitHub App
 
 You install the Octopus GitHub App on an account (organization or user) to give the repositories or other content within that account. Authorizing gives the Octopus GitHub App permission to act on your behalf in any account that has the app installed.

--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -81,7 +81,7 @@ Whenever possible, Octopus uses a token scoped down to minimal permissions in ac
 
 ## GitHub Allow List
 
-The Octopus Deploy GitHub App can be used with the GitHub's allow list feature. To include the app in your allow list manually add the IP Address `172.182.208.68`. Information about adding IP addresses to GitHub's allow list can be found in [GitHub's Documentation](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#adding-an-allowed-ip-address) 
+The Octopus Deploy GitHub App can be used with the GitHub's allow list feature. To include the app in your allow list manually add the IP Address `172.182.208.68`. Information about adding IP addresses to GitHub's allow list can be found in [GitHub's Documentation](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#adding-an-allowed-ip-address)
 
 :::div{.hint}
 **Note:**

--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -81,7 +81,7 @@ Whenever possible, Octopus uses a token scoped down to minimal permissions in ac
 
 ## Allow List
 
-The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list either enable "Enable IP allow list configuration for installed GitHub Apps" in the "Authenication security" section, or manually add the IP Address "172.182.208.68" to your allow list.
+The Octopus Deploy GitHub App can be used with the GitHub Enterprise allow list feature. To include the app in your allow list either enable "Enable IP allow list configuration for installed GitHub Apps" in the "Authentication security" section, or manually add the IP Address "172.182.208.68" to your allow list.
 
 ## More information on installing and authorizing the Octopus GitHub App
 
@@ -92,7 +92,6 @@ Installing and authorizing are both GitHub concepts. If you want to find out mor
 - [GitHub Apps documentation](https://docs.github.com/en/apps/using-github-apps/about-using-github-apps)
 - [Installing GitHub apps documentation](https://docs.github.com/en/apps/using-github-apps/installing-a-github-app-from-a-third-party)
 - [Authorizing GitHub apps documentation](https://docs.github.com/en/apps/using-github-apps/authorizing-github-apps)
-
 
 ## Older versions
 


### PR DESCRIPTION
# Context 🌇 
We have updated the GitHub App so that all traffic from the App to GitHub now passes through a known IP. This allows customers using GitHub Enterprise to enable allow lists and, by adding this IP, still use the GitHub App to manage connections to their repositories.

<img width="850" height="444" alt="chrome_5NfT9Nqo0H" src="https://github.com/user-attachments/assets/3144a691-5a94-443e-9f0e-207d003f45d9" />


This PR will closes devex-5
