### PR TITLE
Add missing vars for argocd instances tf

### DIFF
--- a/src/pages/docs/argo-cd/instances/terraform-bootstrap.md
+++ b/src/pages/docs/argo-cd/instances/terraform-bootstrap.md
@@ -148,6 +148,16 @@ variable "gateway_namespace" {
   type        = string
   default     = "octopus-argocd-gateway"
 }
+
+variable "gateway_name" {
+  description = "Name of the Argo CD Gateway"
+  type        = string
+}
+
+variable "gateway_chart_version" {
+  description = "Helm chart version for the Argo CD Gateway"
+  type        = string
+}
 ```
 
 ## Argo CD


### PR DESCRIPTION
Ran this terraform recently - these variables can be used if using the helm chart for the argo cd gateway, and are already included in the tfvars, just needed to be mapped using the `variables.tf`. 