### PR TITLE
Add updated docs for octopus approvals

### DIFF
--- a/src/pages/docs/approvals/index.md
+++ b/src/pages/docs/approvals/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-04-28
+modDate: 2026-04-15
 title: Approvals
 subtitle: Defining your change approval process
 icon: fa-solid fa-square-check
@@ -14,14 +14,38 @@ hideInThisSection: true
 
 Managing deployment pipelines at scale is complex and time-consuming for DevOps teams, and it's more complicated when you add in change management. Manually filling out change requests takes time and is prone to error. It's also common to have strict change processes needing thorough reviews to get approval to ship new releases of applications. Change advisory boards can be perceived as roadblocks that slow development teams.
 
-When CI/CD systems create change requests automatically, you can work towards best practices with less friction. We want to make change management easier by helping you integrate Octopus with ServiceNow to reduce friction and simplify your development teams' lives.
+When CI/CD systems create change requests automatically, you can work towards best practices with less friction. We want to make change management easier by helping you integrate Octopus with IT service management (ITSM) systems to reduce friction and simplify your development teams' lives.
 
-Octopus Deploy includes ITSM integrations for ServiceNow and Jira Service Management that let you balance audit and compliance requirements with team productivity. 
+Octopus Deploy includes ITSM integrations for ServiceNow and Jira Service Management that let you balance audit and compliance requirements with team productivity.
+
+:::div{.hint}
+Octopus Approvals is a native, built-in approval system that works without an external ITSM tool. This feature is currently in Alpha, available to a small set of customers. If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/243-approvals-for-deployments) and we'll keep you updated.
+:::
 
 Our support focuses on:
 
-1. **Productive teams** - Automatically create change requests and associate them with Octopus deployments or runbook runs so you can work with the right stakeholders to ensure your changes are compliant and approved. Octopus can also prevent deployments and runbook runs from executing until all approvals are complete. 
+1. **Productive teams** - Automatically create change requests and associate them with Octopus deployments or runbook runs so you can work with the right stakeholders to ensure your changes are compliant and approved. Octopus can also prevent deployments and runbook runs from executing until all approvals are complete.
 2. **Compliant DevOps** - Be sure that no one is deploying unapproved changes to production. Your audits become a smooth process as you can demonstrate your company's processes are being adhered to with system reports.
+
+## Native change approvals with Octopus Approvals
+
+Octopus Approvals is a built-in change approval system that lets you gate deployments and runbook runs on sign-off from designated users or teams — no external ITSM tool required. When a controlled deployment triggers, Octopus automatically creates a change request (formatted as `OCT-{number}`) and pauses execution. Once the minimum number of approvals is reached, Octopus allows the task to proceed. If any approver rejects the request, Octopus terminates the task immediately.
+
+What's included in Octopus Approvals?
+
+- Octopus manages the full approval workflow with no external dependencies.
+- Approval policies define which users or teams can approve and how many approvals Octopus requires before proceeding.
+- Octopus creates change requests automatically at deployment time.
+- Octopus supports change windows — the task waits until an approved time period before Octopus allows execution.
+- Octopus records an audit trail of approvals and rejections in the task log.
+
+:::div{.hint}
+Octopus Feature Toggles are currently in Alpha, available to a small set of customers.
+
+If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/121-feature-toggles) and we'll keep you updated.
+:::
+
+Learn more about [Octopus Approvals](/docs/approvals/octopus-approvals).
 
 ## ServiceNow change management without friction
 
@@ -37,7 +61,7 @@ What's included in our ServiceNow support?
 - Automatically create normal and emergency change requests at execution time. Octopus pauses the execution until the appropriate approvals are complete.
 - Let Octopus do the work for you by automating the transition between stages in the change request once created, leaving a deployment or runbook run record in ServiceNow.
 - Use change templates to auto-create standard change requests to reduce manual work and control what information is populated.
-- Ensure “Change Windows” are honored on existing change requests so deployments or runbook runs won't execute until the specified time window.
+- Ensure "Change Windows" are honored on existing change requests so deployments or runbook runs won't execute until the specified time window.
 - Add work notes to change requests with information about deployment or runbook run start and finish time and whether it was successful or not.
 - Create change requests with pre-populated fields through variables.
 - View and export audit logs of controlled deployments and runbook runs for easy compliance and post-execution reconciliation.
@@ -56,9 +80,9 @@ ServiceNow integration is available to customers with an [enterprise subscriptio
 
 To build on our ITSM change management support further, we are also pleased to announce our Jira Service Management integration.
 
-The Jira Service Management integration ensures that teams using this platform can access the benefits of creating change requests automatically in Octopus. It makes it easier to manage deployment pipelines at scale, reducing the complexity of change management. Integrating Octopus with Jira Service Management reduces the need for manually filling out change requests, making it faster and less prone to error. By using Octopus to create change requests automatically, you can create best practice change management easily. 
+The Jira Service Management integration ensures that teams using this platform can access the benefits of creating change requests automatically in Octopus. It makes it easier to manage deployment pipelines at scale, reducing the complexity of change management. Integrating Octopus with Jira Service Management reduces the need for manually filling out change requests, making it faster and less prone to error. By using Octopus to create change requests automatically, you can create best practice change management easily.
 
-This new integration links Octopus deployments and runbook runs to Jira Service Management change requests and automatically creates pre-populated “Request for change” change requests. You get improved traceability out-of-the-box, and you can prove to auditors that every controlled deployment and runbook has a change request. This ensures your CI/CD and release management processes are compliant with company policies and regulations.
+This new integration links Octopus deployments and runbook runs to Jira Service Management change requests and automatically creates pre-populated "Request for change" change requests. You get improved traceability out-of-the-box, and you can prove to auditors that every controlled deployment and runbook has a change request. This ensures your CI/CD and release management processes are compliant with company policies and regulations.
 
 What's included in our Jira Service Management support?
 

--- a/src/pages/docs/approvals/index.md
+++ b/src/pages/docs/approvals/index.md
@@ -19,7 +19,7 @@ When CI/CD systems create change requests automatically, you can work towards be
 Octopus Deploy includes ITSM integrations for ServiceNow and Jira Service Management that let you balance audit and compliance requirements with team productivity.
 
 :::div{.hint}
-Octopus Approvals is a native, built-in approval system that works without an external ITSM tool. This feature is currently in Alpha, available to a small set of customers. If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/243-approvals-for-deployments) and we'll keep you updated.
+Octopus Approvals is a built-in approval system that works without an external ITSM tool. This feature is currently in Alpha, available to a small set of customers. If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/243-approvals-for-deployments) and we'll keep you updated.
 :::
 
 Our support focuses on:
@@ -27,9 +27,9 @@ Our support focuses on:
 1. **Productive teams** - Automatically create change requests and associate them with Octopus deployments or runbook runs so you can work with the right stakeholders to ensure your changes are compliant and approved. Octopus can also prevent deployments and runbook runs from executing until all approvals are complete.
 2. **Compliant DevOps** - Be sure that no one is deploying unapproved changes to production. Your audits become a smooth process as you can demonstrate your company's processes are being adhered to with system reports.
 
-## Native change approvals with Octopus Approvals
+## Built-in change management with Octopus Approvals
 
-Octopus Approvals is a built-in change approval system that lets you gate deployments and runbook runs on sign-off from designated users or teams — no external ITSM tool required. When a controlled deployment triggers, Octopus automatically creates a change request (formatted as `OCT-{number}`) and pauses execution. Once the minimum number of approvals is reached, Octopus allows the task to proceed. If any approver rejects the request, Octopus terminates the task immediately.
+Octopus Approvals is a built-in change approval system that lets you gate deployments and runbook runs on approvals from designated users or teams - no external ITSM tool required. When a controlled deployment is created, Octopus automatically creates a change request (formatted as `OCT-{number}`) and pauses execution. Once the minimum number of approvals is reached, Octopus allows the task to proceed. If any approver rejects the request, Octopus terminates the task immediately.
 
 What's included in Octopus Approvals?
 

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -41,6 +41,8 @@ Navigate to **Library ➜ Approvals ➜ Manage Approvals** and select **Add Appr
 
 ## How it works
 
+Octopus will generate a change request depending on the configured approval policies. If the required number of approvals is reached, the deployment will continue according to change windows. If the change request is rejected, the task is terminated.
+
 ### Change request creation
 
 When a deployment or runbook run triggers and it is in scope for an approval policy, Octopus automatically creates a change request with a unique reference number in the format `OCT-{number}` (for example, `OCT-42`). Octopus immediately pauses execution and displays the change request status in the task log.

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -27,23 +27,17 @@ Once Octopus Approvals is enabled, navigate to **Library ➜ Approvals ➜ Manag
 
 Navigate to **Library ➜ Approvals ➜ Manage Approvals** and select **Add Approval Policy**. Each policy includes the following settings:
 
-**Name**
-A short, memorable, unique name for this approval policy.
+- **Name**: A short, memorable, unique name for this approval policy.
+- **Description**: An optional description for this approval policy.
+- **Scope**: The projects and environments that this approval policy should apply to. Octopus will require approvals for deployments and runbook runs that match the selected project and environment combination.
 
-**Description**
-An optional description for this approval policy.
+  You can scope the approval policy by project and environment tags or individual project and environments.
 
-**Scope**
-The projects and environments that this approval policy should apply to. Octopus will require approvals for deployments and runbook runs that match the selected project and environment combination.
+- **Approvers**: Select the Octopus teams or individual users who are authorized to approve change requests under this policy. Any member of an approving team counts toward the minimum approvers total.
 
-You can scope the approval policy by project and environment tags or individual project and environments.
-**Approvers**
-Select the Octopus teams or individual users who are authorized to approve change requests under this policy. Any member of an approving team counts toward the minimum approvers total.
+  Octopus can optionally block the deployment creator from approving their own change request. Enable **Block approvals by the deployment creator** to enforce this separation of duties.
 
-Octopus can optionally block the deployment creator from approving their own change request. Enable **Block approvals by the deployment creator** to enforce this separation of duties.
-
-**Minimum approvers required**
-The number of approvals Octopus requires before allowing execution to proceed. If any approver rejects the change request before this threshold is reached, Octopus immediately terminates the task.
+- **Minimum approvers required** The number of approvals Octopus requires before allowing execution to proceed. If any approver rejects the change request before this threshold is reached, Octopus immediately terminates the task.
 
 ## How it works
 
@@ -72,9 +66,9 @@ Octopus surfaces change requests in several places so approvers can act on them 
 
 Navigate to **Library ➜ Approvals** for a complete list of all change requests. The list is divided into three tabs:
 
-- **Needs Approval** — change requests that are still pending the required number of approvals.
-- **Completed** — change requests that have been approved or rejected.
-- **All** — all change requests regardless of state.
+- **Needs Approval**: Change requests that are still pending the required number of approvals.
+- **Completed**: Change requests that have been approved or rejected.
+- **All**: All change requests regardless of state.
 
 Each row shows the **Change Request** number (as a link). Select the change request link to open the **Review change request** page, where you can see the full approval details and submit your approval or rejection.
 

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -1,0 +1,100 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2026-04-15
+modDate: 2026-04-15
+title: Octopus Approvals
+description: Octopus Approvals is a built-in change approval system that gates deployments and runbook runs on sign-off from designated users or teams, without requiring an external ITSM tool.
+navOrder: 5
+---
+
+:::div{.hint}
+Octopus Approvals is currently in Alpha, available to a small set of customers. If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/243-approvals-for-deployments) and we'll keep you updated.
+:::
+
+## Overview
+
+Octopus Approvals is a built-in change approval system for Octopus Deploy. Octopus blocks deployments and runbook runs until designated approvers sign off directly within Octopus. This means you don't need any external ITSM tools to manage your changes.
+
+When a controlled deployment or runbook run triggers, Octopus automatically creates a change request (with the format `OCT-{number}`) and pauses execution. Designated users or team members can then approve or reject the request. Once the minimum number of approvals is reached, Octopus allows execution to proceed. If any approver rejects the request, Octopus terminates the task.
+
+## Getting started
+
+Enable Octopus Approvals on your Octopus instance by navigating to **Configuration ➜ Settings ➜ Octopus Approvals** and tick **Is Enabled** and save. `
+
+Once Octopus Approvals is enabled, navigate to **Library ➜ Approvals ➜ Manage Approvals** to create your first approval policy, then configure scope to apply it to the relevant projects and environments.
+
+## Configuring an approval policy
+
+Navigate to **Library ➜ Approvals ➜ Manage Approvals** and select **Add Approval Policy**. Each policy includes the following settings:
+
+**Name**
+A short, memorable, unique name for this approval policy.
+
+**Description**
+An optional description for this approval policy.
+
+**Scope**
+The projects and environments that this approval policy should apply to. Octopus will require approvals for deployments and runbook runs that match the selected project and environment combination.
+
+You can scope the approval policy by project and environment tags or individual project and environments.
+**Approvers**
+Select the Octopus teams or individual users who are authorized to approve change requests under this policy. Any member of an approving team counts toward the minimum approvers total.
+
+Octopus can optionally block the deployment creator from approving their own change request. Enable **Block approvals by the deployment creator** to enforce this separation of duties.
+
+**Minimum approvers required**
+The number of approvals Octopus requires before allowing execution to proceed. If any approver rejects the change request before this threshold is reached, Octopus immediately terminates the task.
+
+## How it works
+
+### Change request creation
+
+When a deployment or runbook run triggers and it is in scope for an approval policy, Octopus automatically creates a change request with a unique reference number in the format `OCT-{number}` (for example, `OCT-42`). Octopus immediately pauses execution and displays the change request status in the task log.
+
+If multiple approval policies match, the policies are merged to a resultant policy.
+
+- Approvers are merged as a union of the approvers from each policy that has a matching scope.
+- The minimum approvers required will be equal to the highest value from all approval policy with matching scope.
+
+### Change windows
+
+Octopus supports change windows. Change windows are scheduled time periods during which a deployment is allowed to run. If a change request is approved but the change window has not yet opened, Octopus keeps execution paused. If the change window closes before the deployment runs (whether the request is approved or still pending), Octopus terminates the task.
+
+### Rejection
+
+If any designated approver rejects the change request, Octopus immediately terminates the task. You cannot retry a rejected task; you must trigger a new deployment or runbook run, which will create a fresh change request.
+
+## Reviewing change requests
+
+Octopus surfaces change requests in several places so approvers can act on them without leaving their current context.
+
+### Approvals
+
+Navigate to **Library ➜ Approvals** for a complete list of all change requests. The list is divided into three tabs:
+
+- **Needs Approval** — change requests that are still pending the required number of approvals.
+- **Completed** — change requests that have been approved or rejected.
+- **All** — all change requests regardless of state.
+
+Each row shows the **Change Request** number (as a link). Select the change request link to open the **Review change request** page, where you can see the full approval details and submit your approval or rejection.
+
+### Tasks Page
+
+Navigate to **Tasks** and select the **Needs Approval** tab for a filtered view of all tasks currently waiting on an approval. If the task is waiting for an Octopus Approval, the row will have button to review the change request associated with this task.
+
+Select **Review** to open the drawer to view the change request details and submit your approval or rejection.
+
+### Deployment or Runbook Run Page
+
+When viewing a deployment or runbook run is blocked on an Octopus Approval, a warning callout appears at the top of the task page:
+
+> **Approval needed to continue this deployment**
+> This deployment is blocked by change request OCT-n and requires approval from N approvers.
+
+Select **Review** to open the drawer to view the change request details and submit your approval or rejection.
+
+### Release Page
+
+When viewing a release, under **Progression** you will see a list of deployments to the environments in your lifecycle and lifecycle phases. If a deployment to an environment is blocked on a Octopus Approval, the environment will have a button to review the change request associated with this task.
+
+Select **Review** to open the drawer to view the change request details and submit your approval or rejection.

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -19,7 +19,7 @@ When a controlled deployment or runbook run triggers, Octopus automatically crea
 
 ## Getting started
 
-Enable Octopus Approvals on your Octopus instance by navigating to **Configuration ➜ Settings ➜ Octopus Approvals** and tick **Is Enabled** and save. `
+Enable Octopus Approvals on your Octopus instance by navigating to **Configuration ➜ Settings ➜ Octopus Approvals** and tick **Is Enabled** and save.
 
 Once Octopus Approvals is enabled, navigate to **Library ➜ Approvals ➜ Manage Approvals** to create your first approval policy, then configure scope to apply it to the relevant projects and environments.
 
@@ -50,7 +50,7 @@ When a deployment or runbook run triggers and it is in scope for an approval pol
 If multiple approval policies match, the policies are merged to a resultant policy.
 
 - Approvers are merged as a union of the approvers from each policy that has a matching scope.
-- The minimum approvers required will be equal to the highest value from all approval policy with matching scope.
+- The minimum approvers required will be equal to the highest value from all approval policies with matching scope.
 
 ### Change windows
 
@@ -58,7 +58,7 @@ Octopus supports change windows. Change windows are scheduled time periods durin
 
 ### Rejection
 
-If any designated approver rejects the change request, Octopus immediately terminates the task. You cannot retry a rejected task; you must trigger a new deployment or runbook run, which will create a fresh change request.
+If any designated approver rejects the change request, Octopus immediately terminates the task. You cannot retry a rejected task; you must trigger a deployment of a new release or runbook run, which will create a fresh change request.
 
 ## Reviewing change requests
 
@@ -76,13 +76,13 @@ Each row shows the **Change Request** number (as a link). Select the change requ
 
 ### Tasks Page
 
-Navigate to **Tasks** and select the **Needs Approval** tab for a filtered view of all tasks currently waiting on an approval. If the task is waiting for an Octopus Approval, the row will have button to review the change request associated with this task.
+Navigate to **Tasks** and select the **Needs Approval** tab for a filtered view of all tasks currently waiting on an approval. If the task is waiting for an Octopus Approval, the row will have a button to review the change request associated with this task.
 
 Select **Review** to open the drawer to view the change request details and submit your approval or rejection.
 
 ### Deployment or Runbook Run Page
 
-When viewing a deployment or runbook run is blocked on an Octopus Approval, a warning callout appears at the top of the task page:
+When a deployment or runbook run is blocked on an Octopus Approval, a warning callout appears at the top of the task page:
 
 > **Approval needed to continue this deployment**
 > This deployment is blocked by change request OCT-n and requires approval from N approvers.
@@ -91,6 +91,6 @@ Select **Review** to open the drawer to view the change request details and subm
 
 ### Release Page
 
-When viewing a release, under **Progression** you will see a list of deployments to the environments in your lifecycle and lifecycle phases. If a deployment to an environment is blocked on a Octopus Approval, the environment will have a button to review the change request associated with this task.
+When viewing a release, under **Progression** you will see a list of deployments to the environments in your lifecycle and lifecycle phases. If a deployment to an environment is blocked on an Octopus Approval, the environment will have a button to review the change request associated with this task.
 
 Select **Review** to open the drawer to view the change request details and submit your approval or rejection.

--- a/src/pages/docs/installation/load-balancers/aws-load-balancers.mdx
+++ b/src/pages/docs/installation/load-balancers/aws-load-balancers.mdx
@@ -27,7 +27,7 @@ gRPC traffic can be routed with either the Application Load Balancer which provi
 
 If you choose to use the Application Load Balancer you might come across certain errors like the following from our gRPC clients(Kubernetes Monitor/Argo CD Gateway)
 
-```golang
+```go
 stream terminated by RST_STREAM with error code: PROTOCOL_ERROR
 ```
 

--- a/src/pages/docs/kubernetes/live-object-status/index.md
+++ b/src/pages/docs/kubernetes/live-object-status/index.md
@@ -42,48 +42,48 @@ Octopus display individual status at an object level as well as summarized statu
 
 The application health status is a roll-up of the health of all objects:
 
-| Label       |                    Status Icon                                                       | Description                                                                  |
-| :---------- | :----------------------------------------------------------------------------------: | :--------------------------------------------------------------------------  |
-| Progressing |   <i class="fa-solid fa-circle-notch blue"></i>                                      | Objects in your application are currently in a progressing state             |
-| Healthy     |      <i class="fa-solid fa-heart green"></i>                                         | The objects in your cluster match what was specified in the last deployment  |
-| Unknown     |     <i class="fa-solid fa-question grey"></i>                                        | We're having trouble getting live status updates for this application        |
-| Degraded    |    <i class="fa-solid fa-heart-crack red"></i>                                       | Your objects experienced errors after the deployment completed               |
-| Missing     |       <i class="fa-solid fa-ghost grey"></i>                                         | Objects in your application are currently in a missing state                 |
-| Unavailable | <i class="fa-solid fa-circle-exclamation red"></i>                                   | Application live status is unavailable because your last deployment failed   |
-| Waiting     |     <i class="fa-solid fa-hourglass blue"></i>                                       | Application live status will be available once the deployment completes      |
-| Stale       | <img src="/docs/img/bolt-slash.svg" alt="stale icon" width="16px" height="16px">.    | Status information is stale. No data has been received in the last 10 minutes|
+| Label       |                                    Status Icon                                    | Description                                                                   |
+| :---------- | :-------------------------------------------------------------------------------: | :---------------------------------------------------------------------------- |
+| Progressing |                   <i class="fa-solid fa-circle-notch blue"></i>                   | Objects in your application are currently in a progressing state              |
+| Healthy     |                      <i class="fa-solid fa-heart green"></i>                      | The objects in your cluster match what was specified in the last deployment   |
+| Unknown     |                     <i class="fa-solid fa-question grey"></i>                     | We're having trouble getting live status updates for this application         |
+| Degraded    |                    <i class="fa-solid fa-heart-crack red"></i>                    | Your objects experienced errors after the deployment completed                |
+| Missing     |                      <i class="fa-solid fa-ghost grey"></i>                       | Objects in your application are currently in a missing state                  |
+| Unavailable |                <i class="fa-solid fa-circle-exclamation red"></i>                 | Application live status is unavailable because your last deployment failed    |
+| Waiting     |                    <i class="fa-solid fa-hourglass blue"></i>                     | Application live status will be available once the deployment completes       |
+| Stale       | <img src="/docs/img/bolt-slash.svg" alt="stale icon" width="16px" height="16px">. | Status information is stale. No data has been received in the last 10 minutes |
 
 ### Application Sync Status
 
 Sync Status tracks whether the changes Octopus deployed still matches the resources in the cluster.
 
-| Label       |                    Status Icon                     | Description                                                                 |
-| :---------- | :------------------------------------------------: |:----------------------------------------------------------------------------|
-| In Sync     |      <i class="fa-solid fa-check green"></i>       | The objects on your cluster match what you last deployed                    |
-| Out of Sync |    <i class="fa-solid fa-arrow-up orange"></i>     | The objects on your cluster no longer match what you last deployed          |
-| Unknown     |     <i class="fa-solid fa-question grey"></i>      | We’re having trouble getting sync status updates for this application       |
-| Unavailable | <i class="fa-solid fa-circle-exclamation red"></i> | Application sync status is unavailable because your last deployment failed  |
-| Waiting     |     <i class="fa-solid fa-hourglass blue"></i>     | Application sync status will be available once the deployment completes     |
+| Label       |                    Status Icon                     | Description                                                                |
+| :---------- | :------------------------------------------------: | :------------------------------------------------------------------------- |
+| In Sync     |      <i class="fa-solid fa-check green"></i>       | The objects on your cluster match what you last deployed                   |
+| Out of Sync |    <i class="fa-solid fa-arrow-up orange"></i>     | The objects on your cluster no longer match what you last deployed         |
+| Unknown     |     <i class="fa-solid fa-question grey"></i>      | We’re having trouble getting sync status updates for this application      |
+| Unavailable | <i class="fa-solid fa-circle-exclamation red"></i> | Application sync status is unavailable because your last deployment failed |
+| Waiting     |     <i class="fa-solid fa-hourglass blue"></i>     | Application sync status will be available once the deployment completes    |
 
 ### Object Health Status
 
-| Label       |                  Status Icon                                                      | Description                                                                    |
-| :---------- | :-------------------------------------------------------------------------------: |:-------------------------------------------------------------------------------|
-| Progressing | <i class="fa-solid fa-circle-notch blue"></i>                                     | Object is attempting to reach the desired state                                |
-| Healthy     |    <i class="fa-solid fa-heart green"></i>                                        | Object is in sync and reporting that it is running as expected                 |
-| Unknown     |   <i class="fa-solid fa-question grey"></i>                                       | We don't have information about the live status of this object                 |
-| Degraded    |  <i class="fa-solid fa-heart-crack red"></i>                                      | Object has run into a problem, check the logs or events to find out more       |
-| Missing     |    <i class="fa-solid fa-ghost grey"></i>                                         | Object is missing from the cluster                                             |
-| Suspended   |    <i class="fa-solid fa-pause grey"></i>                                         | Job is not currently running                                                   |
-| Stale       | <img src="/docs/img/bolt-slash.svg" alt="stale icon" width="16px" height="16px">  | Status information is stale. No data has been received in the last 10 minutes  |
+| Label       |                                   Status Icon                                    | Description                                                                   |
+| :---------- | :------------------------------------------------------------------------------: | :---------------------------------------------------------------------------- |
+| Progressing |                  <i class="fa-solid fa-circle-notch blue"></i>                   | Object is attempting to reach the desired state                               |
+| Healthy     |                     <i class="fa-solid fa-heart green"></i>                      | Object is in sync and reporting that it is running as expected                |
+| Unknown     |                    <i class="fa-solid fa-question grey"></i>                     | We don't have information about the live status of this object                |
+| Degraded    |                   <i class="fa-solid fa-heart-crack red"></i>                    | Object has run into a problem, check the logs or events to find out more      |
+| Missing     |                      <i class="fa-solid fa-ghost grey"></i>                      | Object is missing from the cluster                                            |
+| Suspended   |                      <i class="fa-solid fa-pause grey"></i>                      | Job is not currently running                                                  |
+| Stale       | <img src="/docs/img/bolt-slash.svg" alt="stale icon" width="16px" height="16px"> | Status information is stale. No data has been received in the last 10 minutes |
 
 ### Object Sync Status
 
-| Label       |                  Status Icon                  | Description                                                      |
-| :---------- | :-------------------------------------------: |:-----------------------------------------------------------------|
-| In Sync     |    <i class="fa-solid fa-check green"></i>    | Object manifest matches what was applied                         |
-| Out of Sync |  <i class="fa-solid fa-arrow-up orange"></i>  | Object manifest is not the same as what was applied              |
-| Unknown     |   <i class="fa-solid fa-question grey"></i>   | We don't have information about the live status of this object   |
+| Label       |                 Status Icon                 | Description                                                    |
+| :---------- | :-----------------------------------------: | :------------------------------------------------------------- |
+| In Sync     |   <i class="fa-solid fa-check green"></i>   | Object manifest matches what was applied                       |
+| Out of Sync | <i class="fa-solid fa-arrow-up orange"></i> | Object manifest is not the same as what was applied            |
+| Unknown     |  <i class="fa-solid fa-question grey"></i>  | We don't have information about the live status of this object |
 
 Take a look at our [troubleshooting guide](/docs/kubernetes/live-object-status/troubleshooting) for details on why you may see some object statuses
 
@@ -174,7 +174,7 @@ report_kubernetes_manifest_file "$ManifestFilePath"
 
 #### Powershell
 
-```pwsh
+```powershell
 $manifest = @"
 apiVersion: v1
 kind: Namespace
@@ -187,7 +187,7 @@ labels:
 Report-KubernetesManifest -manifest $manifest
 ```
 
-```pwsh
+```powershell
 Report-KubernetesManifestFile -path $ManifestFilePath
 ```
 


### PR DESCRIPTION
In [#project-octopus-approvals](https://octopusdeploy.slack.com/archives/C09N04XSR7F), we have created a built-in change request management system in Octopus. This PR updates the documentation to include Octopus Approvals, with messaging to customers that this feature is in closed alpha stage.