### PR TITLE
Update signing key document

### DIFF
--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -22,7 +22,8 @@ When externally hosting public keys, they will be available for download as a zi
 
 ### Rotating externally hosted keys
 
-Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. The user will then need to upload the contents of this file to their chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. After it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
+Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. You will then need to upload the contents of this file to your chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. After it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
 
 :::div{.info}
 The new key set will include your previous active key. This ensures that all OIDC services continue to function while the key rotation is underway. Octopus Deploy will start signing tokens with the new key only after validating that the new key is available at the issuer URL.
+:::

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -13,12 +13,15 @@ Octopus uses a Signing Key to sign the generated authorization request tokens us
 Depending on your security requirements, your public keys can either be hosted by your Octopus Deploy instance or delegated to a 3rd party.
 
 ### Internally hosted
+
 When using internally hosted public keys, your Octopus Deploy instance will host and manage them. Octopus Deploy will automatically rotate and revoke the keys according to your preferences. Any tokens Octopus Deploy creates will include the current public address of your Octopus Deploy instance as the issuer. It is important to ensure your Octopus Deploy instance can be accessed at this address.
 
 ## Externally hosted
+
 When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the `OIDC Issuer URL`. When Octopus Deploy creates a token, the issuer will point to the `OIDC Issuer URL`. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
-### Rotating externally  hosted keys
+## Rotating externally hosted keys
+
 Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. The user will then need to upload the contents of this file to their chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. Once it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
 
 :::div{.info}

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-11-01
-modDate: 2023-11-01
+modDate: 2026-04-15
 title: Signing Keys
 description: Signing keys used for OpenID Connect authentication
 navOrder: 40
@@ -10,16 +10,16 @@ hideInThisSection: true
 
 Octopus uses a Signing Key to sign the generated authorization request tokens used in the authentication flow for OpenID Connect. The public signing key is used by the resource server to validate the token supplied by Octopus.
 
-The signing keys by default have a 90-day expiry and will be rotated when they expire.
+Depending on your security requirements, your public keys can either be hosted by your Octopus Deploy instance or delegated to a 3rd party.
 
-:::div{.warning}
-Since OpenID Connect authentication is still an EAP feature, there is no User Interface to manage or view the Signing Keys.
+### Internally hosted
+When using internally hosted public keys, your Octopus Deploy instance will host and manage them. Octopus Deploy will automatically rotate and revoke the keys according to your preferences. Any tokens Octopus Deploy creates will include the current public address of your Octopus Deploy instance as the issuer. It is important to ensure your Octopus Deploy instance can be accessed at this address.
 
-The following API endpoints can be used to manage the Signing Keys:
+## Externally hosted
+When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the `OIDC Issuer URL`. When Octopus Deploy creates a token, the issuer will point to the `OIDC Issuer URL`. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
-List all keys: `GET` `/api/signingkeys/v1`
+### Rotating externally  hosted keys
+Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. The user will then need to upload the contents of this file to their chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. Once it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
 
-Rotate the active key: `POST` `/api/signingkeys/rotate/v1`
-
-Revoke a signing key: `POST` `/api/signingkeys/{id}/revoke/v1`
-:::
+:::div{.info}
+The new key set will include your previous active key. This ensures that all OIDC services continue to function while the key rotation is underway. Octopus Deploy will start signing tokens with the new key only after validating that the new key is available at the issuer URL.

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -8,9 +8,9 @@ navOrder: 40
 hideInThisSection: true
 ---
 
-Octopus uses a Signing Key to sign the generated authorization request tokens used in the authentication flow for OpenID Connect. The public signing key is used by the resource server to validate the token supplied by Octopus.
+Octopus uses a signing key to sign the generated authorization request tokens used in the authentication flow for OpenID Connect. The public signing key is used by the resource server to validate the token supplied by Octopus.
 
-Depending on your security requirements, your public keys can either be hosted by your Octopus Deploy instance or delegated to a 3rd party.
+Depending on your security requirements, your public keys can either be hosted by your Octopus Deploy instance or delegated to a third party.
 
 ## Internally hosted
 
@@ -22,7 +22,7 @@ When externally hosting public keys, they will be available for download as a zi
 
 ### Rotating externally hosted keys
 
-Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. The user will then need to upload the contents of this file to their chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. Once it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
+Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. The user will then need to upload the contents of this file to their chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. After it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
 
 :::div{.info}
 The new key set will include your previous active key. This ensures that all OIDC services continue to function while the key rotation is underway. Octopus Deploy will start signing tokens with the new key only after validating that the new key is available at the issuer URL.

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -14,15 +14,15 @@ Depending on your security requirements, your public keys can either be hosted b
 
 ## Internally hosted
 
-When using internally hosted public keys, your Octopus Deploy instance will host and manage them. Octopus Deploy will automatically rotate and revoke the keys according to your preferences. Any tokens Octopus Deploy creates will include the current public address of your Octopus Deploy instance as the issuer. It is important to ensure your Octopus Deploy instance can be accessed at this address.
+When using internally hosted public keys, your Octopus Deploy instance will host and manage them. Octopus Deploy will automatically rotate and revoke the keys according to your preferences. Any tokens Octopus Deploy creates will include the current public address of your Octopus Deploy instance as the issuer. Ensure your Octopus Deploy instance is accessible at this address.
 
 ## Externally hosted
 
-When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the `OIDC Issuer URL`. When Octopus Deploy creates a token, the issuer will point to the `OIDC Issuer URL`. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
+When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the **OIDC Issuer URL**. When Octopus Deploy creates a token, the issuer will point to the **OIDC Issuer URL**. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
 ### Rotating externally hosted keys
 
-Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. You will then need to upload the contents of this file to your chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. After it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
+Externally hosted public keys must be manually rotated. Upon clicking **Rotate**, a new set of keys will be downloaded as a zip file. You will then need to upload the contents of this file to your chosen hosting provider. Octopus Deploy will poll the provided **OIDC Issuer URL** for the new keys. After it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
 
 :::div{.info}
 The new key set will include your previous active key. This ensures that all OIDC services continue to function while the key rotation is underway. Octopus Deploy will start signing tokens with the new key only after validating that the new key is available at the issuer URL.

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -12,7 +12,7 @@ Octopus uses a Signing Key to sign the generated authorization request tokens us
 
 Depending on your security requirements, your public keys can either be hosted by your Octopus Deploy instance or delegated to a 3rd party.
 
-### Internally hosted
+## Internally hosted
 
 When using internally hosted public keys, your Octopus Deploy instance will host and manage them. Octopus Deploy will automatically rotate and revoke the keys according to your preferences. Any tokens Octopus Deploy creates will include the current public address of your Octopus Deploy instance as the issuer. It is important to ensure your Octopus Deploy instance can be accessed at this address.
 
@@ -20,7 +20,7 @@ When using internally hosted public keys, your Octopus Deploy instance will host
 
 When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the `OIDC Issuer URL`. When Octopus Deploy creates a token, the issuer will point to the `OIDC Issuer URL`. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
-## Rotating externally hosted keys
+### Rotating externally hosted keys
 
 Externally hosted public keys must be manually rotated. Upon clicking `Rotate`, a new set of keys will be downloaded as a zip file. The user will then need to upload the contents of this file to their chosen hosting provider. Octopus Deploy will poll the provided `OIDC Issuer URL` for the new keys. Once it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.
 

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -27,3 +27,5 @@ Externally hosted public keys must be manually rotated. Upon clicking **Rotate**
 :::div{.info}
 The new key set will include your previous active key. This ensures that all OIDC services continue to function while the key rotation is underway. Octopus Deploy will start signing tokens with the new key only after validating that the new key is available at the issuer URL.
 :::
+
+Support for manually managing signing keys has been added in **2026.2** and later.

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -20,7 +20,7 @@ When using internally hosted public keys, your Octopus Deploy instance will host
 
 When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the **OIDC Issuer URL**. When Octopus Deploy creates a token, the issuer will point to the **OIDC Issuer URL**. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
-:::div{.info}
+:::div{.hint}
 If the OIDC issuer URL is specified in Octopus Deploy's settings it will be used as the issuer when performing the OIDC authentication regardless of if Internal or External hosting in selected.
 :::
 

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -20,7 +20,7 @@ When using internally hosted public keys, your Octopus Deploy instance will host
 
 When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the **OIDC Issuer URL**. When Octopus Deploy creates a token, the issuer will point to the **OIDC Issuer URL**. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
-:::div{.warn}
+:::div{.info}
 If the OIDC issuer URL is specified in Octopus Deploy's settings it will be used as the issuer when performing the OIDC authentication regardless of if Internal or External hosting in selected.
 :::
 

--- a/src/pages/docs/infrastructure/signing-keys/index.md
+++ b/src/pages/docs/infrastructure/signing-keys/index.md
@@ -20,6 +20,10 @@ When using internally hosted public keys, your Octopus Deploy instance will host
 
 When externally hosting public keys, they will be available for download as a zip file. The contents of this zip file can then be hosted on any hosting provider that publicly serves HTTPS. The location where the files are hosted must be provided as the **OIDC Issuer URL**. When Octopus Deploy creates a token, the issuer will point to the **OIDC Issuer URL**. While the location specified by the issuer URL must be publicly available, the Octopus Deploy instance can be isolated from public access.
 
+:::div{.warn}
+If the OIDC issuer URL is specified in Octopus Deploy's settings it will be used as the issuer when performing the OIDC authentication regardless of if Internal or External hosting in selected.
+:::
+
 ### Rotating externally hosted keys
 
 Externally hosted public keys must be manually rotated. Upon clicking **Rotate**, a new set of keys will be downloaded as a zip file. You will then need to upload the contents of this file to your chosen hosting provider. Octopus Deploy will poll the provided **OIDC Issuer URL** for the new keys. After it successfully validates that the new keys are available at the issuer URL, it will start using the new signing key.


### PR DESCRIPTION
# Context 🌆 
We have updated Octopus Deploy to support externally hosting OIDC public keys. This allows customers who want to keep their Octopus Deploy instance on the public internet to still use OIDC.  This PR updates our documentation to reflect the change

# Details 🔍 
I have provided a quick summary of the benefits/trade-offs of internal and external hosting of the OIDC keys. I have also provided a summary of the external key rotation procedure.

I removed the warning block because all the functions it described are now accessible via the portal. Or have I missed something?

> [!WARNING]
This should only be merged after the GitHub App self-hosted feature toggle is enabled.

<img width="835" height="1107" alt="chrome_no3MdgdXQ3" src="https://github.com/user-attachments/assets/452bfa89-ef59-4d63-adb1-331c90fe28c9" />

This PR contributes to DEVEX-13