### PR TITLE
Add GH Workflows for Deploy instance

### DIFF
--- a/.github/workflows/branch-validation-full.yml
+++ b/.github/workflows/branch-validation-full.yml
@@ -1,123 +1,16 @@
-name: Deploy to Channel Full Refresh
+name: Pull Request build and deploy
 
 on:
   workflow_dispatch:
-
-# Allow this job to clone the repo and create a page deployment
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  branch_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-
-    env:
-      SHOULD_DEPLOY: ${{ secrets.OCTOPUSSERVERURL != '' || '' }}
-      OCTOPUS_URL: ${{ secrets.OCTOPUSSERVERURL }}
-      OCTOPUS_API_KEY: ${{ secrets.OCTOPUSSERVERAPIKEY }}
-      OCTOPUS_SPACE: "DevOps Microsite"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: PNPM and Playwright install
-        run: |
-          echo; echo "cd to workspace"
-          cd $GITHUB_WORKSPACE
-          echo; echo "listing"
-          ls
-          echo; echo "NPM install"
-          pnpm install
-
-      - name: Astro build and test
-        run: |
-          export NODE_OPTIONS=--max_old_space_size=4096
-          pnpm dev:img
-          pnpm test
-          pnpm crawl
-
-      - name: Set Version
-        run: |
-          echo "PACKAGE_VERSION=$(date +'%Y.%m.%d').$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
-
-      - name: Check output
-        run: |
-          echo; echo "cd to workspace"
-          cd $GITHUB_WORKSPACE
-          echo; echo "listing"
-          ls
-
-      - name: Create a Zip package 🐙
-        id: package
-        uses: OctopusDeploy/create-zip-package-action@v3
-        with:
-          package_id: 'DocsMicrosite'
-          version: "${{ env.PACKAGE_VERSION }}-pullrequest.full"
-          base_path: "./dist"
-          output_folder: "./artifacts"
-          files: |
-            **/*.*
-
-      - name: Push a package to Octopus Deploy 🐙
-        uses: OctopusDeploy/push-package-action@v3.0.2
-        if: ${{ env.SHOULD_DEPLOY }}
-        with:
-          packages: ${{ steps.package.outputs.package_file_path }}
-
-      - name: Let people download package
-        uses: actions/upload-artifact@v4
-        if: ${{ ! env.SHOULD_DEPLOY }}
-        with:
-          name: docs-microsite
-          path: ${{ steps.package.outputs.package_file_path }}
-
-      - name: Push build information to Octopus Deploy 🐙
-        uses: OctopusDeploy/push-build-information-action@v3
-        if: ${{ env.SHOULD_DEPLOY }}
-        with:
-          version: "${{ env.PACKAGE_VERSION }}-pullrequest.full"
-          packages: ${{ steps.package.outputs.package_file_path }}
-
-      - name: Create a release in Octopus Deploy 🐙
-        id: "create_release"
-        uses: OctopusDeploy/create-release-action@v3
-        if: ${{ env.SHOULD_DEPLOY }}
-        with:
-          project: "Docs Microsite"
-          package_version: "${{ env.PACKAGE_VERSION }}-pullrequest.full"
-          git_ref: ${{ github.ref }}
+  branch_validation:
+    uses: OctopusDeploy/microsite-deployment/.github/workflows/microsite-deployment-branch.yml@main
+    with:
+      octopus_project_name: "Docs Microsite"
+      package_id: "DocsMicrosite"
+      node_version: '20'
+    secrets: inherit

--- a/.github/workflows/build-astro-full.yml
+++ b/.github/workflows/build-astro-full.yml
@@ -1,123 +1,15 @@
-name: Deploy Full Refresh
+name: Build and deploy
 
 on:
   workflow_dispatch:
-  
-# Allow this job to clone the repo and create a page deployment
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  push:
+    branches: [ main ]
 
 jobs:
-  build_and_deploy:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-
-    env:
-      SHOULD_DEPLOY: ${{ secrets.OCTOPUSSERVERURL != '' || '' }}
-      OCTOPUS_URL: ${{ secrets.OCTOPUSSERVERURL }}
-      OCTOPUS_API_KEY: ${{ secrets.OCTOPUSSERVERAPIKEY }}
-      OCTOPUS_SPACE: "DevOps Microsite"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.13.1
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: PNPM and Playwright install
-        run: |
-          echo; echo "cd to workspace"
-          cd $GITHUB_WORKSPACE
-          echo; echo "listing"
-          ls
-          echo; echo "PNPM install"
-          pnpm install
-
-      - name: Astro build and test
-        run: |
-          export NODE_OPTIONS=--max_old_space_size=4096
-          pnpm dev:img
-          pnpm test
-          pnpm crawl
-
-      - name: Set Version
-        run: |
-          echo "PACKAGE_VERSION=$(date +'%Y.%m.%d').$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
-
-      - name: Check output
-        run: |
-          echo; echo "cd to workspace"
-          cd $GITHUB_WORKSPACE
-          echo; echo "listing"
-          ls
-
-      - name: Create a Zip package 🐙
-        id: package
-        uses: OctopusDeploy/create-zip-package-action@v3
-        with:
-          package_id: 'DocsMicrosite'
-          version: "${{ env.PACKAGE_VERSION }}-full"
-          base_path: "./dist"
-          output_folder: "./artifacts"
-          files: |
-            **/*.*
-
-      - name: Push a package to Octopus Deploy 🐙
-        uses: OctopusDeploy/push-package-action@v3.0.2
-        if: ${{ env.SHOULD_DEPLOY }}
-        with:
-          packages: ${{ steps.package.outputs.package_file_path }}
-
-      - name: Let people download package
-        uses: actions/upload-artifact@v4
-        if: ${{ ! env.SHOULD_DEPLOY }}
-        with:
-          name: docs-microsite
-          path: ${{ steps.package.outputs.package_file_path }}
-
-      - name: Push build information to Octopus Deploy 🐙
-        uses: OctopusDeploy/push-build-information-action@v3
-        if: ${{ env.SHOULD_DEPLOY }}
-        with:
-          version: "${{ env.PACKAGE_VERSION }}-full"
-          packages: ${{ steps.package.outputs.package_file_path }}
-
-      - name: Create a release in Octopus Deploy 🐙
-        id: "create_release"
-        uses: OctopusDeploy/create-release-action@v3
-        if: ${{ env.SHOULD_DEPLOY }}
-        with:
-          project: "Docs Microsite"
-          package_version: "${{ env.PACKAGE_VERSION }}-full"
-          git_ref: ${{ github.ref }}
+  branch_validation:
+    uses: OctopusDeploy/microsite-deployment/.github/workflows/microsite-deployment-full.yml@main
+    with:
+      octopus_project_name: 'Docs Microsite'
+      package_id: 'DocsMicrosite'
+      node_version: '20'
+    secrets: inherit

--- a/.octopus/deploy-instance/deployment_settings.ocl
+++ b/.octopus/deploy-instance/deployment_settings.ocl
@@ -6,5 +6,8 @@ connectivity_policy {
 }
 
 versioning_strategy {
-    template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.LastMinor}.#{Octopus.Version.NextPatch}"
+    donor_package {
+        package = "microsite-package"
+        step = "run-a-process-template-upload-site-to-azure-blob"
+    }
 }


### PR DESCRIPTION
This PR changes 2 unused workflows, to now call a reusable workflow designed for microsites.

The workflows will:
- On PR, run a build, push to the deploy instance, and create an ephemeral environment
- On main, run a build, push to the deploy instance, and create a release for production

The PR also includes a small change to the Octopus project configuration, so releases in Octopus are named based off the version included in the package being deployed.