### PR TITLE
fix: Octopus Approvals page has incorrect information

### DIFF
--- a/src/pages/docs/approvals/index.md
+++ b/src/pages/docs/approvals/index.md
@@ -42,7 +42,7 @@ What's included in Octopus Approvals?
 :::div{.hint}
 Octopus Approvals is currently in Alpha, available to a small set of customers.
 
-If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/121-feature-toggles) and we'll keep you updated.
+If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/243-approvals-for-deployments) and we'll keep you updated.
 :::
 
 Learn more about [Octopus Approvals](/docs/approvals/octopus-approvals).

--- a/src/pages/docs/approvals/index.md
+++ b/src/pages/docs/approvals/index.md
@@ -40,7 +40,7 @@ What's included in Octopus Approvals?
 - Octopus records an audit trail of approvals and rejections in the task log.
 
 :::div{.hint}
-Octopus Feature Toggles are currently in Alpha, available to a small set of customers.
+Octopus Approvals is currently in Alpha, available to a small set of customers.
 
 If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/121-feature-toggles) and we'll keep you updated.
 :::

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -66,7 +66,7 @@ Octopus surfaces change requests in several places so approvers can act on them 
 
 ### Approvals
 
-Navigate to **Library ➜ Approvals** for a complete list of all change requests. The list is divided into three tabs:
+Navigate to **Deploy ➜ Manage ➜ Approvals** for a complete list of all change requests. The list is divided into three tabs:
 
 - **Needs Approval**: Change requests that are still pending the required number of approvals.
 - **Completed**: Change requests that have been approved or rejected.

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -21,11 +21,11 @@ When a controlled deployment or runbook run triggers, Octopus automatically crea
 
 Enable Octopus Approvals on your Octopus instance by navigating to **Configuration ➜ Settings ➜ Octopus Approvals** and tick **Is Enabled** and save.
 
-Once Octopus Approvals is enabled, navigate to **Deploy ➜ Manage ➜ Approvals ➜ Manage Approvals** to create your first approval policy, then configure scope to apply it to the relevant projects and environments.
+Once Octopus Approvals is enabled, navigate to **Deploy ➜ Manage ➜ Approvals ➜ Manage** to create your first approval policy, then configure scope to apply it to the relevant projects and environments.
 
 ## Configuring an approval policy
 
-Navigate to **Deploy ➜ Manage ➜ Approvals ➜ Manage Approvals** and select **Add Approval Policy**. Each policy includes the following settings:
+Navigate to **Deploy ➜ Manage ➜ Approvals ➜ Manage** and select **Add Approval Policy**. Each policy includes the following settings:
 
 - **Name**: A short, memorable, unique name for this approval policy.
 - **Description**: An optional description for this approval policy.

--- a/src/pages/docs/approvals/octopus-approvals/index.md
+++ b/src/pages/docs/approvals/octopus-approvals/index.md
@@ -21,11 +21,11 @@ When a controlled deployment or runbook run triggers, Octopus automatically crea
 
 Enable Octopus Approvals on your Octopus instance by navigating to **Configuration ➜ Settings ➜ Octopus Approvals** and tick **Is Enabled** and save.
 
-Once Octopus Approvals is enabled, navigate to **Library ➜ Approvals ➜ Manage Approvals** to create your first approval policy, then configure scope to apply it to the relevant projects and environments.
+Once Octopus Approvals is enabled, navigate to **Deploy ➜ Manage ➜ Approvals ➜ Manage Approvals** to create your first approval policy, then configure scope to apply it to the relevant projects and environments.
 
 ## Configuring an approval policy
 
-Navigate to **Library ➜ Approvals ➜ Manage Approvals** and select **Add Approval Policy**. Each policy includes the following settings:
+Navigate to **Deploy ➜ Manage ➜ Approvals ➜ Manage Approvals** and select **Add Approval Policy**. Each policy includes the following settings:
 
 - **Name**: A short, memorable, unique name for this approval policy.
 - **Description**: An optional description for this approval policy.


### PR DESCRIPTION
Fix:
- Octopus approvals callout references "Octopus Feature Toggles"
- Instructions for using approvals references "Library"

Woops 😅 