### PR TITLE
Small note about required OpenSSL support for linux targets

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
@@ -17,7 +17,7 @@ When connecting to a target over SSH, the Octopus Server connects then executes 
 
 For example, with targets on a Mac the default $PATH variable may be missing `/usr/sbin`. This can be added in the `.bashrc` script with the line:
 
-```
+```bash
 PATH=$PATH:/usr/sbin
 ```
 
@@ -36,6 +36,7 @@ Since it is self-contained, .NET Core does not need to be installed on the targe
 Git-based steps (steps that clone or fetch from a git repository as part of a deployment or runbook) require OpenSSL **1.1** or **3** on the host. SSH targets running with other OpenSSL versions will fail when running these steps.
 
 ## Python
+
 Octopus can execute Python scripts on SSH targets provided the following criteria are met:
 
 - Python is version 3.4+

--- a/src/pages/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
+++ b/src/pages/docs/infrastructure/deployment-targets/linux/ssh-requirements.md
@@ -31,6 +31,10 @@ See the Bash Reference Manual, section [6.2 Bash Startup Files](http://www.gnu.o
 
 Since it is self-contained, .NET Core does not need to be installed on the target server. However, there are still some [pre-requisite dependencies](https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#dependencies) required for .NET Core itself that must be installed.
 
+## Git-based steps
+
+Git-based steps (steps that clone or fetch from a git repository as part of a deployment or runbook) require OpenSSL **1.1** or **3** on the host. SSH targets running with other OpenSSL versions will fail when running these steps.
+
 ## Python
 Octopus can execute Python scripts on SSH targets provided the following criteria are met:
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -22,6 +22,10 @@ Before you can configure a Linux Tentacle, the Linux server must meet the [requi
 
 Linux Tentacle is a .NET application distributed as a [self-contained deployment](https://docs.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained). On most Linux distributions it will *just work*, but be aware that [you will need to install some prerequisites](https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#dependencies).
 
+### Git-based steps \{#git-based-steps}
+
+Git-based steps (steps that clone or fetch from a git repository as part of a deployment or runbook) require OpenSSL **1.1** or **3** on the host. Tentacles running with other OpenSSL versions will fail when running these steps.
+
 ## Known limitations
 
 Support for F# scripts are only available with **Mono 4** and above. While they require mono installed, they will still execute with the self-contained Calamari.

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -52,7 +52,6 @@ The latest release of Linux Tentacle is available for download from:
 Many of the steps described below require elevated permissions, or must be run as a super user using `sudo`.
 :::
 
-
 ### Installing Tentacle
 
 <details data-group="deployment-targets-tentacle-linux">
@@ -129,7 +128,7 @@ The installer script does not make any adjustments to firewalls. Be sure to chec
 
 Start the Tentacle interactively by running:
 
-```
+```bash
 /opt/octopus/tentacle/Tentacle run --instance <instance name>
 ```
 
@@ -137,7 +136,7 @@ Start the Tentacle interactively by running:
 
 Tentacle has command line options for configuring a systemd service:
 
-```
+```bash
 Usage: Tentacle service [<options>]
 
 Where [<options>] is any of:
@@ -165,7 +164,7 @@ Or one of the common options:
 
 To install and start Tentacle as a service, use the `Tentacle service` command:
 
-```
+```bash
  /opt/octopus/tentacle/Tentacle service --install --start
 ```
 
@@ -174,7 +173,8 @@ To install and start Tentacle as a service, use the `Tentacle service` command:
 To manually configure a systemd service, use the following sample unit file:
 
 1. Create a systemd **Unit file** to run Tentacle.
-   ```
+
+   ```bash
    [Unit]
    Description=Octopus Tentacle Server
    After=network.target
@@ -190,18 +190,21 @@ To manually configure a systemd service, use the following sample unit file:
    ```
 
 2. Copy the unit file to `/etc/systemd/system` and give it permissions
-   ```
+
+   ```bash
    sudo cp tentacle.service /etc/systemd/system/tentacle.service
    sudo chmod 644 /etc/systemd/system/tentacle.service
    ```
 
 3. Start the Tentacle service
-   ```
+
+   ```bash
    sudo systemctl start tentacle
    ```
 
 4. Use the `enable` command to ensure that the service start whenever the system boots.
-   ```
+
+   ```bash
    sudo systemctl enable tentacle
    ```
 
@@ -219,21 +222,22 @@ The upgrade is attempted in the following order:
 
 To uninstall (delete) a Tentacle instance run the `service --stop --uninstall` and then `delete-instance` commands first:
 
-```
+```bash
 /opt/octopus/tentacle/Tentacle service --instance <instance name> --stop --uninstall
 /opt/octopus/tentacle/Tentacle delete-instance --instance <instance name>
 ```
 
 The `service --stop --uninstall` command on the Tentacle will run the following commands to manage the systemd **Unit file**:
 
-```
+```bash
 sudo systemctl stop tentacle
 sudo systemctl disable tentacle
 sudo rm /etc/systemd/system/tentacle.service
 ```
 
 Then the working folders and logs can be deleted if they are no longer needed, depending on where you installed them, for instance:
-```
+
+```bash
 # default locations:
 # - installed directory:
 cd /opt/octopus/tentacle
@@ -251,13 +255,16 @@ The following bash scripts install, configure and register Linux Tentacle for us
 
 :::div{.hint}
 **Note:**
+
 - Many of the steps described below require elevated permissions, or must be run as a super user using `sudo`.
 - By default, when registering Linux Targets or Workers, the scripts below assume Octopus will communicate with the target or worker using the server hostname (from the `$HOSTNAME` variable). To provide a different address, consider looking up the hostname/IP address. For example:
 
-      ```bash
-      publicIp=$(curl -s https://ifconfig.info)
-      ```
-      You can specify the address when using the [register-with](/docs/octopus-rest-api/tentacle.exe-command-line/register-with) command by providing the value to the `--publicHostName` parameter.
+```bash
+publicIp=$(curl -s https://ifconfig.info)
+```
+
+You can specify the address when using the [register-with](/docs/octopus-rest-api/tentacle.exe-command-line/register-with) command by providing the value to the `--publicHostName` parameter.
+
 :::
 
 <QuickstartDebian />


### PR DESCRIPTION
When [this Calamari PR](https://github.com/OctopusDeploy/Calamari/pull/1917) goes out, there is a requirement that linux targets have OpenSSL 1.1 or OpenSSL 3 installed if a step is run that performs git operations on the target.

This doesn't include loading scripts from a git repository, that is done server side, this is only a concern when cloning or commiting back to git on the target itself.