### PR TITLE
Update MCP server configuration examples to use environment variables

### DIFF
--- a/src/pages/docs/octopus-ai/mcp/index.mdx
+++ b/src/pages/docs/octopus-ai/mcp/index.mdx
@@ -44,14 +44,19 @@ Full example configuration (for Claude Desktop, Claude Code, and Cursor):
 {
   "mcpServers": {
     "octopusdeploy": {
+      "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@octopusdeploy/mcp-server", "--api-key", "YOUR_API_KEY", "--server-url", "https://your-octopus.com"]
+      "args": ["-y", "@octopusdeploy/mcp-server"],
+      "env": {
+        "OCTOPUS_SERVER_URL": "https://your-octopus.com",
+        "OCTOPUS_API_KEY": "YOUR_API_KEY"
+      }
     }
   }
 }
 ```
 
-The Octopus MCP Server is typically configured within your AI Client of choice. 
+The Octopus MCP Server is typically configured within your AI Client of choice.
 
 It is packaged as an npm package and executed via Node's `npx` command. Your configuration will include the command invocation `npx`, and a set of arguments that supply the Octopus MCP Server package and provide the Octopus Server URL and API key required, if they are not available as environment variables.
 
@@ -69,7 +74,8 @@ OCTOPUS_SERVER_URL=https://your-octopus.com
 
 Or with configuration supplied via the command line:
 ```bash
-npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com --api-key YOUR_API_KEY
+OCTOPUS_API_KEY=API-KEY \
+npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com
 ```
 
 For detailed documentation visit [the official Github repo](https://github.com/OctopusDeploy/mcp-server).

--- a/src/pages/docs/octopus-ai/mcp/index.mdx
+++ b/src/pages/docs/octopus-ai/mcp/index.mdx
@@ -9,7 +9,7 @@ description: An overview of the the Octopus MCP server, allowing AI clients to l
 navOrder: 2
 ---
 
-### Octopus MCP Server
+## Octopus MCP Server
 
 The Octopus MCP ([Model Context Protocol](https://modelcontextprotocol.io/)) server represents a significant leap forward in AI integration capabilities. Built on Anthropic's open standard for connecting AI assistants to external data sources and tools, the MCP server enables AI assistants like Claude to interact directly with your Octopus Deploy infrastructure.
 
@@ -33,6 +33,7 @@ To learn more, read our [Octopus REST API](/docs/octopus-rest-api) documentation
 ## 🚀 Installation
 
 ### Requirements
+
 - Node.js >= v20.0.0
 - Octopus Deploy instance that can be accessed by the MCP server via HTTPS
 - Octopus Deploy API Key
@@ -40,6 +41,7 @@ To learn more, read our [Octopus REST API](/docs/octopus-rest-api) documentation
 ### Configuration
 
 Full example configuration (for Claude Desktop, Claude Code, and Cursor):
+
 ```json
 {
   "mcpServers": {
@@ -67,12 +69,14 @@ npx -y @octopusdeploy/mcp-server
 ```
 
 With configuration provided via environment variables:
+
 ```bash
 OCTOPUS_API_KEY=API-KEY
 OCTOPUS_SERVER_URL=https://your-octopus.com
 ```
 
 Or with configuration supplied via the command line:
+
 ```bash
 OCTOPUS_API_KEY=API-KEY \
 npx -y @octopusdeploy/mcp-server --server-url https://your-octopus.com


### PR DESCRIPTION
Updates the Octopus MCP server docs to show environment variable-based configuration as the primary approach for supplying `OCTOPUS_API_KEY` and `OCTOPUS_SERVER_URL`, rather than passing them as command line arguments.

The full JSON config block now uses `env` fields, and the accompanying bash examples are updated to match. This aligns with the documentation in [the official Github repo](https://github.com/OctopusDeploy/mcp-server)