### PR TITLE
Clarify docs for self hosted hosting keys

### DIFF
--- a/src/pages/docs/projects/version-control/github/index.md
+++ b/src/pages/docs/projects/version-control/github/index.md
@@ -26,6 +26,11 @@ You install the Octopus GitHub App on an account (organization or user) to give 
 
 Selecting authorize will take you to GitHub to complete the installation and authorization process.
 
+:::div{.info}
+**Note:**
+For self-hosted instances, the public [signing key](/docs/infrastructure/signing-keys) must be set up and accessible on the internet before authorizing the app.
+:::
+
 If you are authorizing the app for a self-hosted instance, you will be required to copy an access code over to your octopus instance.
 
 #### More information on installing and authorizing the Octopus GitHub App


### PR DESCRIPTION
# Background

Update the docs to clarify to self hosted customers that signing keys should be hosted externally before they authorize

# Before

<img width="913" height="629" alt="Screenshot 2026-05-22 142128" src="https://github.com/user-attachments/assets/9d798fa9-5477-41c3-8457-eb511d2ad273" />

# After

<img width="1083" height="752" alt="Screenshot 2026-05-22 102353" src="https://github.com/user-attachments/assets/e09188bd-f172-45e1-a47d-431ba9737489" />
