### PR TITLE
Document K8s orphan-resource tracking

### DIFF
--- a/src/pages/docs/kubernetes/live-object-status/index.md
+++ b/src/pages/docs/kubernetes/live-object-status/index.md
@@ -96,13 +96,13 @@ Orphaned objects:
 
 - keep their existing Health Status, so Octopus continues tracking them while they remain in your cluster
 - have **Orphaned** as their Sync Status (shown with the link-slash icon in the table above)
-- are summarised by a total-orphans count shown on the project's Live Status page
+- are summarized by a total-orphans count shown on the project's Live Status page
 - can be narrowed to by using the Live Status table's filter and selecting **Orphaned**
 
 The orphan state clears automatically on the next deployment that re-adds the resource. If you remove an orphaned object from your cluster directly (for example with `kubectl delete` or by uninstalling its Helm release), the Kubernetes monitor detects the removal and Octopus stops tracking the resource, so the orphan entry disappears from the Live Status table without any manual intervention.
 
 :::div{.info}
-Orphaned-resource tracking requires every Kubernetes monitor in the application instance to be on agent version 2.38.3 or later (v2) / 3.0.1 or later (v3). On clusters with any older agent, the resource is silently removed from the Live Status table when it is dropped from a deployment, matching the previous behaviour.
+Orphaned-resource tracking requires every Kubernetes monitor in the application instance to be on agent version 2.38.3 or later (v2) / 3.0.1 or later (v3). On clusters with any older agent, the resource is silently removed from the Live Status table when it is dropped from a deployment, matching the previous behavior.
 :::
 
 ### Detailed object information

--- a/src/pages/docs/kubernetes/live-object-status/index.md
+++ b/src/pages/docs/kubernetes/live-object-status/index.md
@@ -90,7 +90,7 @@ Take a look at our [troubleshooting guide](/docs/kubernetes/live-object-status/t
 
 ### Orphaned objects
 
-When you deploy a project that no longer includes a resource that was deployed in a previous release (for example, a Helm chart drops a sub-resource, or you remove a step from the deployment process), Octopus marks the dropped resource as **Orphaned** in the Live Status table.
+When you deploy a project that no longer includes a resource that was deployed in a previous release (for example, you remove a resource from a YAML manifest or remove a step from the deployment process), Octopus marks the dropped resource as **Orphaned** in the Live Status table.
 
 Orphaned objects:
 
@@ -99,7 +99,7 @@ Orphaned objects:
 - are summarized by a total-orphans count shown on the project's Live Status page
 - can be narrowed to by using the Live Status table's filter and selecting **Orphaned**
 
-The orphan state clears automatically on the next deployment that re-adds the resource. If you remove an orphaned object from your cluster directly (for example with `kubectl delete` or by uninstalling its Helm release), the Kubernetes monitor detects the removal and Octopus stops tracking the resource, so the orphan entry disappears from the Live Status table without any manual intervention.
+The orphan state clears automatically on the next deployment that re-adds the resource. If you remove an orphaned object from your cluster directly (for example with `kubectl delete`), the Kubernetes monitor detects the removal and Octopus stops tracking the resource, so the orphan entry disappears from the Live Status table without any manual intervention.
 
 :::div{.info}
 Orphaned-resource tracking requires every Kubernetes monitor in the application instance to be on agent version 2.38.3 or later (v2) / 3.0.1 or later (v3). On clusters with any older agent, the resource is silently removed from the Live Status table when it is dropped from a deployment, matching the previous behavior.

--- a/src/pages/docs/kubernetes/live-object-status/index.md
+++ b/src/pages/docs/kubernetes/live-object-status/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-03-28
-modDate: 2026-03-19
+modDate: 2026-05-24
 navSection: Live Object Status
 title: Kubernetes Live Object Status
 navTitle: Overview
@@ -79,13 +79,31 @@ Sync Status tracks whether the changes Octopus deployed still matches the resour
 
 ### Object Sync Status
 
-| Label       |                 Status Icon                 | Description                                                    |
-| :---------- | :-----------------------------------------: | :------------------------------------------------------------- |
-| In Sync     |   <i class="fa-solid fa-check green"></i>   | Object manifest matches what was applied                       |
-| Out of Sync | <i class="fa-solid fa-arrow-up orange"></i> | Object manifest is not the same as what was applied            |
-| Unknown     |  <i class="fa-solid fa-question grey"></i>  | We don't have information about the live status of this object |
+| Label       |                  Status Icon                  | Description                                                                                      |
+| :---------- | :-------------------------------------------: | :----------------------------------------------------------------------------------------------- |
+| In Sync     |    <i class="fa-solid fa-check green"></i>    | Object manifest matches what was applied                                                         |
+| Out of Sync |  <i class="fa-solid fa-arrow-up orange"></i>  | Object manifest is not the same as what was applied                                              |
+| Unknown     |   <i class="fa-solid fa-question grey"></i>   | We don't have information about the live status of this object                                   |
+| Orphaned    | <i class="fa-solid fa-link-slash orange"></i> | Object was deployed in a previous release but is no longer part of the latest deployment process |
 
 Take a look at our [troubleshooting guide](/docs/kubernetes/live-object-status/troubleshooting) for details on why you may see some object statuses
+
+### Orphaned objects
+
+When you deploy a project that no longer includes a resource that was deployed in a previous release (for example, a Helm chart drops a sub-resource, or you remove a step from the deployment process), Octopus marks the dropped resource as **Orphaned** in the Live Status table.
+
+Orphaned objects:
+
+- keep their existing Health Status, so Octopus continues tracking them while they remain in your cluster
+- have **Orphaned** as their Sync Status (shown with the link-slash icon in the table above)
+- are summarised by a total-orphans count shown on the project's Live Status page
+- can be narrowed to by using the Live Status table's filter and selecting **Orphaned**
+
+The orphan state clears automatically on the next deployment that re-adds the resource. If you remove an orphaned object from your cluster directly (for example with `kubectl delete` or by uninstalling its Helm release), the Kubernetes monitor detects the removal and Octopus stops tracking the resource, so the orphan entry disappears from the Live Status table without any manual intervention.
+
+:::div{.info}
+Orphaned-resource tracking requires every Kubernetes monitor in the application instance to be on agent version 2.38.3 or later (v2) / 3.0.1 or later (v3). On clusters with any older agent, the resource is silently removed from the Live Status table when it is dropped from a deployment, matching the previous behaviour.
+:::
 
 ### Detailed object information
 

--- a/src/pages/docs/kubernetes/targets/kubernetes-agent/kubernetes-monitor.md
+++ b/src/pages/docs/kubernetes/targets/kubernetes-agent/kubernetes-monitor.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-03-28
-modDate: 2025-03-28
+modDate: 2026-05-24
 title: Kubernetes Monitor
 description: How to manage the Kubernetes monitor component
 navOrder: 25
@@ -14,6 +14,8 @@ The Kubernetes monitor is a component that runs alongside Tentacle in the cluste
 The Kubernetes monitor communicates with Octopus Server over gRPC on a new port (8443) to send back object information to Octopus Deploy. Communications are initiated by the Kubernetes monitor, so no endpoints on the Kubernetes cluster need to be exposed.
 
 The monitor process uses the [Argo project gitops engine project](https://github.com/argoproj/gitops-engine) to internally keep track of the resources running on your cluster and react to changes as they occur.
+
+Newer versions of the Kubernetes monitor (2.38.3 or later for v2, 3.0.1 or later for v3) also surface resources that were previously deployed but are no longer part of the latest deployment process. See [Orphaned objects](/docs/kubernetes/live-object-status#orphaned-objects) for details.
 
 ## Required Kubernetes permissions
 


### PR DESCRIPTION
## Summary

Documents the K8s Orphan Resource Pruning observability work that lands with OctopusDeploy/OctopusDeploy#42986.

## Changes

- **`kubernetes/live-object-status/index.md`**
  - Adds `Orphaned` row to the Object Sync Status table (with the link-slash icon to match the UI).
  - Adds a new **Orphaned objects** section describing: when a resource becomes orphaned, what users see (orphan sync status, total-count label, filter via the regular Live Status filter), reactivation behaviour, and the out-of-band cleanup path (kubectl delete / Helm uninstall is detected by the monitor and clears the entry automatically).
  - Adds an info box noting the agent-version requirement (v2 >= 2.38.3 / v3 >= 3.0.1).
- **`kubernetes/targets/kubernetes-agent/kubernetes-monitor.md`**
  - One-line note in *How it works* pointing readers to the new Orphaned objects section.

## Out of scope

- Deletion behaviour for orphaned resources (separate milestone, not yet shipped, intentionally not mentioned).
- A 'what's new' / changelog entry (this repo doesn't have a product-changelog surface).