### PR TITLE
Document Tentacle script abandonment

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment.md
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment.md
@@ -1,0 +1,98 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2026-05-27
+modDate: 2026-05-27
+title: Tentacle script abandonment
+description: How Octopus Tentacle abandons a deployment script when it can't run normally on the target, what you'll see when it happens, and what to do about the underlying cause.
+navOrder: 58
+---
+
+Octopus Tentacle can abandon a deployment script when the script can't run normally on the target. Abandonment releases the Tentacle's per-target mutex so the next deployment in the queue can start, even though the script's underlying process may still be running on the target.
+
+This page covers when abandonment fires, what you'll see when it does, why these failures happen, and what to do about the underlying cause.
+
+## How abandonment works
+
+When Tentacle abandons a script:
+
+- The Tentacle's per-target mutex is released. The next deployment in the queue for that target can start immediately.
+- The Tentacle-side runtime locks holding state for the script are dropped.
+- The abandonment is logged in the server-side task log and in the Tentacle log.
+
+What abandonment does **not** do:
+
+- It does not kill the script's underlying process on the target. If your script was performing an operation that could leave the target in an inconsistent state (a database migration, a file system change, and so on), inspect the target and clean up manually.
+- It does not introduce a new task status. Depending on which trigger fired, the task is marked as `Failed` (PowerShell startup detection) or `Cancelled` (cancellation timeout). Check the task log to know which path your task took.
+
+The Tentacle itself stays healthy after abandoning a script. It doesn't need to be restarted.
+
+## When abandonment fires
+
+Tentacle abandons a script in response to one of two triggers.
+
+### PowerShell startup detection
+
+Scope: Windows Tentacles running `powershell.exe`. Linux `pwsh` is not currently supported.
+
+When Tentacle launches `powershell.exe` to run your script, the PowerShell process can sometimes start but never actually begin executing the script body. This typically happens when antivirus or endpoint-protection software hooks into PowerShell startup and the script content never reaches the runtime.
+
+If `powershell.exe` doesn't reach the first instruction of your script in 5 minutes, Tentacle marks the task as `Failed` with exit code `-47` and prevents the script body from running, even if PowerShell wakes up later. Tentacle records a log line like:
+
+```
+PowerShell startup detection: PowerShell did not start within 5 minutes for task <task ID>
+```
+
+Version requirements:
+
+- Octopus Server `2026.2.5952` or later
+- Tentacle `9.1.3801` or later
+
+### Cancellation timeout
+
+Scope: any script on Tentacle. Both Windows and Linux Tentacles. SSH targets and the Kubernetes agent are not in scope.
+
+If you cancel a deployment from the Octopus Web Portal and the cancellation can't take effect on the Tentacle in 2 minutes, Octopus tells the Tentacle to abandon the script. The task is marked as `Cancelled`.
+
+The server-side task log records:
+
+```
+Cancellation hasn't taken effect on Tentacle after 2 minutes. Abandoning the script so this target can accept new deployments.
+Tentacle abandoned the script.
+```
+
+If the script had already completed by the time abandonment was attempted, the second line reads:
+
+```
+Script had already completed before abandon was needed.
+```
+
+Tentacle's own log also records:
+
+```
+Tentacle has abandoned this script. The underlying script process may still be running on this host.
+```
+
+If your cancellation succeeded cleanly, no abandonment runs and the task is marked `Cancelled` without these messages. Check your task log to know which path your cancellation took.
+
+Version requirements:
+
+- Octopus Server version supporting cancellation timeout abandonment (to be confirmed when the work ships)
+- Tentacle version that publishes `AbandonScript` on `IScriptServiceV2` (to be confirmed when the work ships)
+
+## Why these failures happen
+
+The conditions that lead to abandonment are usually on the target machine, not in Octopus.
+
+Antivirus and endpoint-protection software (CrowdStrike, Rapid7, and similar) can hook into `powershell.exe` at process startup. When two agents race for the same kernel locks, the process can fail to begin executing the script body. The same agents can hold file locks on the Tentacle's working directories (`Output.log`, `stdout.txt`), blocking the script from making progress or a cancellation from being processed.
+
+For a worked example with stack traces and a detailed analysis of a CrowdStrike + Rapid7 deadlock on a customer's target, see [OctopusTentacle issue #1208](https://github.com/OctopusDeploy/OctopusTentacle/issues/1208).
+
+Multiple security agents installed on the same host are the most common pattern. The fix is on the target machine.
+
+## What to do about it
+
+Both abandonment triggers are mitigation, not a fix. The underlying problem is on the target machine, and you're best placed to fix it. Three steps, in order:
+
+1. **Configure your antivirus or endpoint-protection software to exclude Tentacle's working directories.** Specifically `<Tentacle Home>\Tools` and `<Tentacle Home>\Work`. The full exclusion list and additional directories you can include if you're still seeing issues are documented in [Troubleshooting failed or hanging tasks: Antivirus software](/docs/support/troubleshooting-failed-or-hanging-tasks#anti-virus-software).
+2. **Keep target-side security tooling updated.** Known interactions between specific CrowdStrike and Rapid7 versions cause the deadlock; vendor updates have addressed similar issues before.
+3. **If abandonment fires on the same target more than occasionally,** contact support and include a process dump from the target during the next occurrence. This helps support identify which agent is interfering. You can identify how often abandonment is firing on a specific target by searching your task logs for the messages above across recent deployments to that target.

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment.md
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment.md
@@ -7,7 +7,7 @@ description: How Octopus Tentacle abandons a deployment script when it can't run
 navOrder: 58
 ---
 
-Octopus Tentacle can abandon a deployment script when the script can't run normally on the target. Abandonment releases the Tentacle's per-target mutex so the next deployment in the queue can start, even though the script's underlying process may still be running on the target.
+Octopus Tentacle can abandon a deployment script when the script can't run normally on the target. Abandonment releases the Tentacle's [per-target mutex](/docs/administration/managing-infrastructure/run-multiple-processes-on-a-target-simultaneously) so the Tentacle can begin executing the next script it has for that target, even though the abandoned script's underlying process may still be running on the target.
 
 This page covers when abandonment fires, what you'll see when it does, why these failures happen, and what to do about the underlying cause.
 
@@ -15,8 +15,7 @@ This page covers when abandonment fires, what you'll see when it does, why these
 
 When Tentacle abandons a script:
 
-- The Tentacle's per-target mutex is released. The next deployment in the queue for that target can start immediately.
-- The Tentacle-side runtime locks holding state for the script are dropped.
+- The Tentacle's [per-target mutex](/docs/administration/managing-infrastructure/run-multiple-processes-on-a-target-simultaneously) is released. The Tentacle can begin executing the next script it has for that target.
 - The abandonment is logged in the server-side task log and in the Tentacle log.
 
 What abandonment does **not** do:
@@ -32,20 +31,17 @@ Tentacle abandons a script in response to one of two triggers.
 
 ### PowerShell startup detection
 
-Scope: Windows Tentacles running `powershell.exe`. Linux `pwsh` is not currently supported.
+We've only observed this class of script-startup failure with PowerShell, so the detection is currently scoped to `powershell.exe` on Windows Tentacles. Bash on Linux Tentacles isn't covered.
 
 When Tentacle launches `powershell.exe` to run your script, the PowerShell process can sometimes start but never actually begin executing the script body. This typically happens when antivirus or endpoint-protection software hooks into PowerShell startup and the script content never reaches the runtime.
 
 If `powershell.exe` doesn't reach the first instruction of your script in 5 minutes, Tentacle marks the task as `Failed` with exit code `-47` and prevents the script body from running, even if PowerShell wakes up later. Tentacle records a log line like:
 
-```
+```text
 PowerShell startup detection: PowerShell did not start within 5 minutes for task <task ID>
 ```
 
-Version requirements:
-
-- Octopus Server `2026.2.5952` or later
-- Tentacle `9.1.3801` or later
+PowerShell startup detection requires Octopus Server `2026.2.5952` or later and Tentacle `9.1.3801` or later.
 
 ### Cancellation timeout
 
@@ -53,31 +49,27 @@ Scope: any script on Tentacle. Both Windows and Linux Tentacles. SSH targets and
 
 If you cancel a deployment from the Octopus Web Portal and the cancellation can't take effect on the Tentacle in 2 minutes, Octopus tells the Tentacle to abandon the script. The task is marked as `Cancelled`.
 
-The server-side task log records:
+The server-side task log records one of two lines, depending on what Tentacle reports back:
 
-```
-Cancellation hasn't taken effect on Tentacle after 2 minutes. Abandoning the script so this target can accept new deployments.
+```text
 Tentacle abandoned the script.
 ```
 
-If the script had already completed by the time abandonment was attempted, the second line reads:
+Or, if the script had already completed by the time abandonment was attempted:
 
-```
+```text
 Script had already completed before abandon was needed.
 ```
 
 Tentacle's own log also records:
 
-```
+```text
 Tentacle has abandoned this script. The underlying script process may still be running on this host.
 ```
 
 If your cancellation succeeded cleanly, no abandonment runs and the task is marked `Cancelled` without these messages. Check your task log to know which path your cancellation took.
 
-Version requirements:
-
-- Octopus Server version supporting cancellation timeout abandonment (to be confirmed when the work ships)
-- Tentacle version that publishes `AbandonScript` on `IScriptServiceV2` (to be confirmed when the work ships)
+Cancellation timeout abandonment requires a specific Octopus Server version and Tentacle version. Both are to be confirmed when the work ships.
 
 ## Why these failures happen
 
@@ -87,12 +79,12 @@ Antivirus and endpoint-protection software (CrowdStrike, Rapid7, and similar) ca
 
 For a worked example with stack traces and a detailed analysis of a CrowdStrike + Rapid7 deadlock on a customer's target, see [OctopusTentacle issue #1208](https://github.com/OctopusDeploy/OctopusTentacle/issues/1208).
 
-Multiple security agents installed on the same host are the most common pattern. The fix is on the target machine.
+Multiple security agents installed on the same host are the most common pattern. Octopus can't reach inside that interaction to fix it. The fix lives in your target-side antivirus configuration.
 
 ## What to do about it
 
 Both abandonment triggers are mitigation, not a fix. The underlying problem is on the target machine, and you're best placed to fix it. Three steps, in order:
 
 1. **Configure your antivirus or endpoint-protection software to exclude Tentacle's working directories.** Specifically `<Tentacle Home>\Tools` and `<Tentacle Home>\Work`. The full exclusion list and additional directories you can include if you're still seeing issues are documented in [Troubleshooting failed or hanging tasks: Antivirus software](/docs/support/troubleshooting-failed-or-hanging-tasks#anti-virus-software).
-2. **Keep target-side security tooling updated.** Known interactions between specific CrowdStrike and Rapid7 versions cause the deadlock; vendor updates have addressed similar issues before.
+2. **Keep target-side security tooling updated.** Specific versions of certain endpoint-protection agents are known to cause this. Check your vendor's release notes.
 3. **If abandonment fires on the same target more than occasionally,** contact support and include a process dump from the target during the next occurrence. This helps support identify which agent is interfering. You can identify how often abandonment is firing on a specific target by searching your task logs for the messages above across recent deployments to that target.

--- a/src/pages/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/src/pages/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -63,9 +63,9 @@ In some instances, Octopus will automatically trigger the failure of a task that
 
 This is generally indicative of an internal error in Octopus. In Octopus Cloud we actively monitor for these issues, but please reach out to support for further assistance, especially if the problem persists.
 
-### Tentacle script abandonment
+### Automatic recovery for hanging tasks
 
-If your task ends in `Cancelled` or `Failed` and your Tentacle has logged that the script was abandoned, see [Tentacle script abandonment](/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment) for the full explanation and what to do next.
+Octopus Tentacle can automatically recover from many hanging-task scenarios by abandoning the affected script and releasing the per-target mutex. See [Tentacle script abandonment](/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment) for what triggers this, what you'll see in the task log, and what to do about the underlying cause.
 
 ### Antivirus software {#anti-virus-software}
 

--- a/src/pages/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/src/pages/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -63,69 +63,9 @@ In some instances, Octopus will automatically trigger the failure of a task that
 
 This is generally indicative of an internal error in Octopus. In Octopus Cloud we actively monitor for these issues, but please reach out to support for further assistance, especially if the problem persists.
 
-### Recovering from stuck PowerShell scripts on Tentacle
+### Tentacle script abandonment
 
-PowerShell scripts on a Tentacle target can sometimes fail to run normally because of interference from antivirus or endpoint-protection software on the target. Without help, this used to leave the target's deployment queue blocked: you'd have to remote into the target and end the process, or restart the Tentacle service, before the next deployment could run.
-
-Octopus now has two automatic recoveries that keep the queue moving while you investigate the underlying interference. Both are mitigation, not a fix. The underlying problem is on the target machine, and you'll still want to configure your antivirus software ([see the antivirus section below](#anti-virus-software)) so the interference stops happening.
-
-#### Detecting scripts that never start
-
-When Tentacle launches `powershell.exe` to run your script, the PowerShell process can sometimes start but never actually begin executing the script body. This typically happens when endpoint-protection software hooks into PowerShell startup and the script content never reaches the runtime.
-
-If `powershell.exe` doesn't reach the first instruction of your script in 5 minutes, Tentacle marks the task as failed with exit code `-47` and prevents the script body from ever running, even if PowerShell wakes up later. Tentacle records a log line like:
-
-```
-PowerShell startup detection: PowerShell did not start within 5 minutes for task <task ID>
-```
-
-The mutex protecting the target is released as part of normal task cleanup, so the next deployment to that machine can begin straight away. The Tentacle itself stays healthy and doesn't need to be restarted.
-
-This recovery is supported on Windows Tentacles running `powershell.exe`. Linux `pwsh` is not currently covered.
-
-#### Releasing the target when cancellation can't take effect
-
-If you cancel a deployment from the Octopus Web Portal and the cancellation can't take effect on the Tentacle in 2 minutes, Octopus tells the Tentacle to abandon the script and accept new work. This means:
-
-- The script's underlying process may still be running on the target. Octopus does not kill it. If your script was performing an operation that could leave the target in an inconsistent state (a database migration, a file system change, and so on), inspect the target and clean up manually.
-- The Tentacle releases its mutex and immediately accepts the next deployment in the queue.
-- The task is marked as Cancelled.
-
-When abandonment runs, you'll see this in the task log:
-
-```
-Cancellation hasn't taken effect on Tentacle after 2 minutes. Abandoning the script so this target can accept new deployments.
-Tentacle abandoned the script.
-```
-
-Tentacle's own log will also record:
-
-```
-Tentacle has abandoned this script. The underlying script process may still be running on this host.
-```
-
-If your cancellation succeeded cleanly, no abandonment runs and the task is marked Cancelled without these messages. Check your task log to know which path your cancellation took.
-
-#### Version requirements
-
-The automatic recoveries described above are available from:
-
-- Octopus Server `2026.2.5952` or later
-- Tentacle `9.1.3801` or later for the script-startup detection
-- Tentacle version supporting the cancellation abandon to be confirmed when the work ships
-
-If either component is on an older version, your deployments use the previous behavior, where a stuck script may require you to remote into the target and end the process manually or restart the Tentacle service.
-
-#### What to do if automatic recovery fires regularly
-
-If you see automatic recovery firing on the same target more than occasionally, that target has an environmental problem worth investigating directly. Common causes:
-
-- Antivirus or endpoint-protection software (CrowdStrike, Rapid7, and similar) hooking into PowerShell startup or holding file locks on the Tentacle's working directories.
-- Multiple security agents installed on the same host, contending for the same kernel locks.
-
-The first step is to configure your antivirus or endpoint-protection software per the [antivirus section below](#anti-virus-software). You can identify how often automatic recovery is firing on a specific target by searching your task logs for the messages above across recent deployments to that target.
-
-If the recoveries keep firing after exclusions are in place, contact support and include a process dump from the target during the next occurrence. This helps us identify which agent is interfering.
+If your task ends in `Cancelled` or `Failed` and your Tentacle has logged that the script was abandoned, see [Tentacle script abandonment](/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment) for the full explanation and what to do next.
 
 ### Antivirus software {#anti-virus-software}
 

--- a/src/pages/docs/support/troubleshooting-failed-or-hanging-tasks.md
+++ b/src/pages/docs/support/troubleshooting-failed-or-hanging-tasks.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-01-13
+modDate: 2026-05-26
 title: Troubleshooting failed or hanging tasks
 description: A guide for troubleshooting tasks that fail unexpectedly or are unresponsive
 navOrder: 8
@@ -62,6 +62,70 @@ In some instances, Octopus will automatically trigger the failure of a task that
 - The overall task will be marked as failed
 
 This is generally indicative of an internal error in Octopus. In Octopus Cloud we actively monitor for these issues, but please reach out to support for further assistance, especially if the problem persists.
+
+### Recovering from stuck PowerShell scripts on Tentacle
+
+PowerShell scripts on a Tentacle target can sometimes fail to run normally because of interference from antivirus or endpoint-protection software on the target. Without help, this used to leave the target's deployment queue blocked: you'd have to remote into the target and end the process, or restart the Tentacle service, before the next deployment could run.
+
+Octopus now has two automatic recoveries that keep the queue moving while you investigate the underlying interference. Both are mitigation, not a fix. The underlying problem is on the target machine, and you'll still want to configure your antivirus software ([see the antivirus section below](#anti-virus-software)) so the interference stops happening.
+
+#### Detecting scripts that never start
+
+When Tentacle launches `powershell.exe` to run your script, the PowerShell process can sometimes start but never actually begin executing the script body. This typically happens when endpoint-protection software hooks into PowerShell startup and the script content never reaches the runtime.
+
+If `powershell.exe` doesn't reach the first instruction of your script in 5 minutes, Tentacle marks the task as failed with exit code `-47` and prevents the script body from ever running, even if PowerShell wakes up later. Tentacle records a log line like:
+
+```
+PowerShell startup detection: PowerShell did not start within 5 minutes for task <task ID>
+```
+
+The mutex protecting the target is released as part of normal task cleanup, so the next deployment to that machine can begin straight away. The Tentacle itself stays healthy and doesn't need to be restarted.
+
+This recovery is supported on Windows Tentacles running `powershell.exe`. Linux `pwsh` is not currently covered.
+
+#### Releasing the target when cancellation can't take effect
+
+If you cancel a deployment from the Octopus Web Portal and the cancellation can't take effect on the Tentacle in 2 minutes, Octopus tells the Tentacle to abandon the script and accept new work. This means:
+
+- The script's underlying process may still be running on the target. Octopus does not kill it. If your script was performing an operation that could leave the target in an inconsistent state (a database migration, a file system change, and so on), inspect the target and clean up manually.
+- The Tentacle releases its mutex and immediately accepts the next deployment in the queue.
+- The task is marked as Cancelled.
+
+When abandonment runs, you'll see this in the task log:
+
+```
+Cancellation hasn't taken effect on Tentacle after 2 minutes. Abandoning the script so this target can accept new deployments.
+Tentacle abandoned the script.
+```
+
+Tentacle's own log will also record:
+
+```
+Tentacle has abandoned this script. The underlying script process may still be running on this host.
+```
+
+If your cancellation succeeded cleanly, no abandonment runs and the task is marked Cancelled without these messages. Check your task log to know which path your cancellation took.
+
+#### Version requirements
+
+The automatic recoveries described above are available from:
+
+- Octopus Server `2026.2.5952` or later
+- Tentacle `9.1.3801` or later for the script-startup detection
+- Tentacle version supporting the cancellation abandon to be confirmed when the work ships
+
+If either component is on an older version, your deployments use the previous behavior, where a stuck script may require you to remote into the target and end the process manually or restart the Tentacle service.
+
+#### What to do if automatic recovery fires regularly
+
+If you see automatic recovery firing on the same target more than occasionally, that target has an environmental problem worth investigating directly. Common causes:
+
+- Antivirus or endpoint-protection software (CrowdStrike, Rapid7, and similar) hooking into PowerShell startup or holding file locks on the Tentacle's working directories.
+- Multiple security agents installed on the same host, contending for the same kernel locks.
+
+The first step is to configure your antivirus or endpoint-protection software per the [antivirus section below](#anti-virus-software). You can identify how often automatic recovery is firing on a specific target by searching your task logs for the messages above across recent deployments to that target.
+
+If the recoveries keep firing after exclusions are in place, contact support and include a process dump from the target during the next occurrence. This helps us identify which agent is interfering.
 
 ### Antivirus software {#anti-virus-software}
 


### PR DESCRIPTION
## Summary

Adds a new standalone page at `src/pages/docs/infrastructure/deployment-targets/tentacle/tentacle-script-abandonment.md` covering **Tentacle script abandonment**, the product behaviour that lets Tentacle abandon a deployment script when it can't run normally, releasing the per-target mutex so the next deployment in the queue can start.

The page covers both triggers under one product term:

- **PowerShell startup detection** (EFT-365, shipped April 2026). Fires when `powershell.exe` doesn't start executing the script body within 5 minutes. Task ends `Failed` with exit code `-47`. Windows + PowerShell only.
- **Cancellation timeout** (EFT-3295, in flight). Fires when a cancellation hasn't taken effect on the Tentacle within 2 minutes. Task ends `Cancelled`. Any script on Tentacle (Windows or Linux); SSH and Kubernetes agent not in scope.

The page also covers why these failures happen (target-side antivirus/EDR interference) with a link to [`OctopusTentacle#1208`](https://github.com/OctopusDeploy/OctopusTentacle/issues/1208) for the stack traces and CrowdStrike + Rapid7 deadlock analysis, and what customers should do about it (whitelist Tentacle paths, cross-linked to the existing antivirus section on the troubleshooting page).

The existing `Troubleshooting failed or hanging tasks` page gets a short cross-link pointer to the new page.

## Test plan

- [ ] Spell check passes
- [ ] Astro build doesn't break links
- [ ] Cross-link to `#anti-virus-software` on the troubleshooting page resolves (anchor exists on the existing page)
- [ ] navOrder `58` slots the new page between `agent-vs-agentless` (55) and `troubleshooting-tentacles` (60) in the Tentacle sidebar

## Open questions for review

@lucyjspence @LukeButters, three things in the new page worth a second eye on:

1. **EFT-365 startup-detection timeout = 5 minutes.** PR #1200 lists 5 min as the default. Clare quoted 13 min in her May 18 email to Philips. Is the actual rolled-out value 5, or did the rollout configure 13?
2. **Cancellation timeout version requirements.** Placeholder text reads "to be confirmed when the work ships". After EFT-3295 lands and we know the Tentacle version that publishes `AbandonScript` on `IScriptServiceV2`, update before merging.
3. **PowerShell startup detection scope.** Is Linux `pwsh` support on a roadmap, or does this stay Windows + `powershell.exe` only indefinitely? Affects whether to soften that paragraph or leave it firm.

## Reducing risk

- Honest framing throughout: both triggers are mitigation, not cure. The page says explicitly that the underlying problem is on the target machine and the customer still needs to whitelist antivirus paths.
- The abandonment subsections explicitly tell the customer the runaway process may still be running on the target.
- Don't-oversell: no claims of robustness, no marketing language.

Refs: EFT-365, EFT-3295

_[JIM_BOT.EXE v2.13]_
