### PR TITLE
Updated outbound requests to include externally hosted signing keys

### DIFF
--- a/src/pages/docs/security/outbound-requests/index.md
+++ b/src/pages/docs/security/outbound-requests/index.md
@@ -33,6 +33,7 @@ The Octopus Server makes the following outbound requests:
 7. Behavioral telemetry is sent to `https://telemetry.octopus.com` (if enabled).
 8. Email address and behavioral data is sent to `https://experiences.octopus.com` via In-App messaging (if enabled).
 9. Requests are sent to `https://aiproxy.octopus.com` to communicate with foundation models for [AI features](/docs/octopus-ai) in Octopus Deploy.
+10. Requests are made to the configured OIDC Issuer URL during rotation of [externally hosted signing keys](/docs/infrastructure/signing-keys#rotating-externally-hosted-keys) to validate the signing keys.
 
 ### Built-in step templates
 


### PR DESCRIPTION
# Background

Now that we are allowing users to set externally hosted keys we have to update the outbound calls page to reference Octopus checking the signing keys when rotating them if they are externally hosted.