### PR TITLE
Update Feature Toggles status from Alpha to Preview

### DIFF
--- a/src/pages/docs/feature-toggles/index.md
+++ b/src/pages/docs/feature-toggles/index.md
@@ -13,9 +13,7 @@ navOrder: 95
 Octopus Feature Toggles support toggling features on or off in real-time, without redeploying, and progressively releasing changes to subsets of your users.
 
 :::div{.hint}
-Octopus Feature Toggles are currently in Preview, available to a small set of customers.
-
-If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/121-feature-toggles) and we'll keep you updated.
+Octopus Feature Flags are now available to Octopus Cloud customers as a Private Preview. To get access, [register your interest](https://survey.octopus.com/t/piv3LpVWWmus).
 :::
 
 ## Usage

--- a/src/pages/docs/feature-toggles/index.md
+++ b/src/pages/docs/feature-toggles/index.md
@@ -13,7 +13,7 @@ navOrder: 95
 Octopus Feature Toggles support toggling features on or off in real-time, without redeploying, and progressively releasing changes to subsets of your users.
 
 :::div{.hint}
-Octopus Feature Toggles are currently in Alpha, available to a small set of customers.
+Octopus Feature Toggles are currently in Preview, available to a small set of customers.
 
 If you are interested in this feature please register your interest on the [roadmap card](https://roadmap.octopus.com/c/121-feature-toggles) and we'll keep you updated.
 :::

--- a/src/pages/docs/feature-toggles/index.md
+++ b/src/pages/docs/feature-toggles/index.md
@@ -13,7 +13,7 @@ navOrder: 95
 Octopus Feature Toggles support toggling features on or off in real-time, without redeploying, and progressively releasing changes to subsets of your users.
 
 :::div{.hint}
-Octopus Feature Flags are now available to Octopus Cloud customers as a Private Preview. To get access, [register your interest](https://survey.octopus.com/t/piv3LpVWWmus).
+Octopus Feature Toggles are now available to Octopus Cloud customers as a Private Preview. To get access, [register your interest](https://survey.octopus.com/t/piv3LpVWWmus).
 :::
 
 ## Usage


### PR DESCRIPTION
Updates the feature toggles page to say that we are now in preview with a link to the preview signup form.

<img width="866" height="680" alt="image" src="https://github.com/user-attachments/assets/4b70aa59-48b2-4051-a21d-f40c0d74310a" />

This still says "feature toggles", there is a separate PR to update everything to feature flag at once (https://github.com/OctopusDeploy/docs/pull/3192). This one will merge first, so I'll update this in that one once this merges.

Wording is copied directly from the accompanying blog post (except the toggles bit).

Part of DEVEX-319