### PR TITLE
Update docs for Project Templates Public Preview

### DIFF
--- a/src/pages/docs/platform-hub/templates/parameters.md
+++ b/src/pages/docs/platform-hub/templates/parameters.md
@@ -39,7 +39,7 @@ Templates can manage the following as parameters:
 - Worker Pool
 - Package
 - Project
-- A previous step name
+- A previous step name (process templates only)
 
 To create a parameter, navigate to **Parameters** on a template and add a new parameter.
 

--- a/src/pages/docs/platform-hub/templates/parameters.md
+++ b/src/pages/docs/platform-hub/templates/parameters.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-05
-modDate: 2026-03-06
+modDate: 2026-05-28
 title: Template parameters
 subtitle: A reference for parameters in Platform Hub templates
 icon: fa-solid fa-layer-group
@@ -41,7 +41,7 @@ Templates can manage the following as parameters:
 - Project
 - A previous step name
 
-To create a parameter, navigate to the **Parameters** tab on a template and add a new parameter.
+To create a parameter, navigate to **Parameters** on a template and add a new parameter.
 
 ## Parameter values
 
@@ -57,10 +57,10 @@ You can set an optional default value for these parameters:
 - Generic OIDC Account
 - Google Cloud Account
 - Username Password Account
+- Certificate
 
 You cannot set a default value for these parameters, they must be set inside a project:
 
-- Certificate
 - Worker Pool
 - Package
 - A previous step name
@@ -81,5 +81,5 @@ Some parameter behavior differs between template types.
 :::
 
 :::div{.hint}
-**Project templates** do not support parameter scoping or sensitive parameter values in the Alpha release. The following parameter types are not available for project templates: Multi-line text, Dropdown, Checkbox, and Sensitive/password box. For more information, see [Project template parameters](/docs/platform-hub/templates/project-templates#parameters).
+**Project templates** don't yet support parameter scoping or sensitive parameter values. For more information, see [Project template parameters](/docs/platform-hub/templates/project-templates#parameters).
 :::

--- a/src/pages/docs/platform-hub/templates/process-templates/best-practices.md
+++ b/src/pages/docs/platform-hub/templates/process-templates/best-practices.md
@@ -5,7 +5,7 @@ modDate: 2025-09-11
 title: Process Templates best practices
 subtitle: Best practices for creating process templates within Platform Hub
 icon: fa-solid fa-lock
-navTitle: Best Practices
+navTitle: Best practices
 navSection: Process Templates
 description: Best practices for creating process templates within Platform Hub
 navOrder: 160

--- a/src/pages/docs/platform-hub/templates/project-templates/best-practices.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/best-practices.md
@@ -12,7 +12,7 @@ navOrder: 180
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability, [tell us what you think](https://roadmap.octopus.com/c/263-project-templates).
 :::
 
 This document uses **Producer** and **Consumer** frequently. To avoid confusion, use these definitions:

--- a/src/pages/docs/platform-hub/templates/project-templates/best-practices.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/best-practices.md
@@ -12,7 +12,7 @@ navOrder: 180
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
 :::
 
 This document uses **Producer** and **Consumer** frequently. To avoid confusion, use these definitions:

--- a/src/pages/docs/platform-hub/templates/project-templates/best-practices.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/best-practices.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-05
-modDate: 2026-03-16
+modDate: 2026-05-28
 title: Project template best practices
 subtitle: Best practices for creating project templates in Platform Hub
 icon: fa-solid fa-layer-group
@@ -12,7 +12,7 @@ navOrder: 180
 ---
 
 :::div{.warning}
-Project templates are in Alpha. The feature is incomplete and standard SLAs do not apply. Don't use it for production workloads. It is available to Enterprise customers on Cloud. Self-hosted customers can access it as an early preview via Octopus 2026.2. We're actively developing this feature and would love your feedback.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
 :::
 
 This document uses **Producer** and **Consumer** frequently. To avoid confusion, use these definitions:

--- a/src/pages/docs/platform-hub/templates/project-templates/index.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/index.md
@@ -12,14 +12,14 @@ navOrder: 170
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
 :::
 
 ## Overview
 
 Project templates are reusable project blueprints that can be shared across multiple spaces in Octopus Deploy. Instead of manually configuring each new project from scratch, defining deployment steps and variables every time, you create a single template that any space can use as a starting point. This ensures teams follow the same standards and removes the risk of configuration drift.
 
-To create or manage your project templates, navigate to Platform Hub. If you haven't set up your Git repository, you must do so before creating a project template.
+To create or manage your project templates, navigate to Platform Hub. If you haven't set up your [Git repository](/docs/platform-hub#git-credentials-in-platform-hub), you must do so before creating a project template.
 
 1. Navigate to **Project Templates** in Platform Hub.
 2. Give the project template a **Name** and an optional **Description**.
@@ -66,7 +66,7 @@ We're interested in your [feedback](#feedback) on whether this behavior meets yo
 Parameters let you define the inputs a user must supply when they create a project from the template. They're the mechanism for making a template flexible. Rather than hardcoding values that differ between teams or spaces, you expose them as parameters.
 
 :::div{.warning}
-Project templates don't yet support parameter scoping or sensitive parameter values. We're still shaping how parameters, variables, and scoping work together and expect this area to evolve. We'd love your [feedback](#feedback).
+Project templates don't yet support parameter scoping or sensitive parameter default values. We're still shaping how parameters, variables, and scoping work together and expect this area to evolve. We'd love your [feedback](#feedback).
 :::
 
 For a full reference of supported parameter types and default values, see [Template parameters](/docs/platform-hub/templates/parameters).
@@ -98,9 +98,9 @@ Project template variables support the following types:
 
 You can scope a project template variable to any combination of the following:
 
-- A specific step in the deployment process.
-- A process template usage, when the template's deployment process includes one.
-- An environment parameter, target tag parameter, or tenant tag parameter defined on the template. The variable applies wherever the project's parameter value resolves to.
+- Specific steps in the deployment process.
+- Process template usages, when the template's deployment process includes one or more.
+- Environment parameters, target tag parameters, or tenant tag parameters defined on the template. Whatever the project's parameter value resolves to determines the scope.
 
 Scoping is fixed at the template level. The same scoping rules apply to every project created from the template.
 

--- a/src/pages/docs/platform-hub/templates/project-templates/index.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/index.md
@@ -12,7 +12,7 @@ navOrder: 170
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability, [tell us what you think](https://roadmap.octopus.com/c/263-project-templates).
 :::
 
 ## Overview
@@ -58,7 +58,7 @@ If your deployment process includes a process template configured to auto-update
 
 The project template process editor shows a warning callout when included process templates have received automatic updates since the template was last published. Use it to review the changes before publishing a new version.
 
-We're interested in your [feedback](#feedback) on whether this behavior meets your expectations.
+We're interested in your [feedback](https://roadmap.octopus.com/c/263-project-templates) on whether this behavior meets your expectations.
 :::
 
 ## Parameters

--- a/src/pages/docs/platform-hub/templates/project-templates/index.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-05
-modDate: 2026-03-16
+modDate: 2026-05-28
 title: Project templates
 subtitle: An overview of project templates
 icon: fa-solid fa-layer-group
@@ -12,14 +12,14 @@ navOrder: 170
 ---
 
 :::div{.warning}
-Project templates are in Alpha. The feature is incomplete and standard SLAs do not apply. Don't use it for production workloads. It is available to Enterprise customers on Cloud. Self-hosted customers can access it as an early preview via Octopus 2026.2. We're actively developing this feature and would love your feedback.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
 :::
 
 ## Overview
 
 Project templates are reusable project blueprints that can be shared across multiple spaces in Octopus Deploy. Instead of manually configuring each new project from scratch, defining deployment steps and variables every time, you create a single template that any space can use as a starting point. This ensures teams follow the same standards and removes the risk of configuration drift.
 
-To create or manage your project templates, navigate to the Platform Hub. If you haven't set up your Git repository, you must do so before creating a project template.
+To create or manage your project templates, navigate to Platform Hub. If you haven't set up your Git repository, you must do so before creating a project template.
 
 1. Navigate to **Project Templates** in Platform Hub.
 2. Give the project template a **Name** and an optional **Description**.
@@ -50,11 +50,15 @@ Some steps behave differently inside the project template editor. Instead of let
 :::
 
 :::div{.hint}
-Unlike standard projects, project templates validate the deployment process when you publish, not when you commit. You can save an incomplete process and continue configuring parameters and variables before publishing. This will change once we add inline parameter and variable configuration to the deployment process editor.
+Unlike standard projects, project templates validate the deployment process when you publish, not when you commit. You can save an incomplete process and continue configuring parameters and variables before publishing. This will change once we add inline variable configuration to the deployment process editor.
 :::
 
 :::div{.hint}
-If your deployment process includes a process template configured to auto-update on patch or minor versions, those updates flow through to templated projects automatically, even without you publishing a new version of the project template. This means two releases created on different days could use different versions of the process template, without anyone making any change to the project template or the project itself. We're interested in your [feedback](#feedback) on whether this behavior meets your expectations.
+If your deployment process includes a process template configured to auto-update on patch or minor versions, those updates flow through to templated projects automatically, even without you publishing a new version of the project template. This means two releases created on different days could use different versions of the process template, without anyone making any change to the project template or the project itself.
+
+The project template process editor shows a warning callout when included process templates have received automatic updates since the template was last published. Use it to review the changes before publishing a new version.
+
+We're interested in your [feedback](#feedback) on whether this behavior meets your expectations.
 :::
 
 ## Parameters
@@ -62,12 +66,12 @@ If your deployment process includes a process template configured to auto-update
 Parameters let you define the inputs a user must supply when they create a project from the template. They're the mechanism for making a template flexible. Rather than hardcoding values that differ between teams or spaces, you expose them as parameters.
 
 :::div{.warning}
-In the Alpha release, project templates don't support parameter scoping or sensitive parameter values. We're still working out how parameters, variables, and scoping should work in project templates and expect this to evolve throughout Alpha. We'd love your [feedback](#feedback).
+Project templates don't yet support parameter scoping or sensitive parameter values. We're still shaping how parameters, variables, and scoping work together and expect this area to evolve. We'd love your [feedback](#feedback).
 :::
 
 For a full reference of supported parameter types and default values, see [Template parameters](/docs/platform-hub/templates/parameters).
 
-To create a parameter, navigate to the **Parameters** tab on your project template and add a new parameter.
+To create a parameter, navigate to **Parameters** on your project template and add a new parameter.
 
 :::figure
 ![The Parameters tab in a project template](/docs/img/platform-hub/project-templates/project-templates-parameters.png)
@@ -81,12 +85,38 @@ Unlike parameters, users can't change the variables defined in a template when c
 
 Variable values can reference parameters, letting you combine fixed template-level values with project-supplied inputs where needed.
 
-:::div{.warning}
-In the Alpha release, the variable types you can use are limited to text, sensitive, and resources currently available in Platform Hub, such as Accounts. Variable scoping is also not supported. We're adding support for additional resource types throughout Alpha. We'd love your [feedback](#feedback) on what you need.
-:::
+### Variable types
+
+Project template variables support the following types:
+
+- **Text**: plain string values.
+- **Sensitive**: encrypted values like passwords and API keys.
+- **Account**: references to accounts defined in Platform Hub. Add the account in Platform Hub before using it in a template.
+- **Certificate**: references to certificates defined in Platform Hub.
+
+### Variable scoping
+
+You can scope a project template variable to any combination of the following:
+
+- A specific step in the deployment process.
+- A process template usage, when the template's deployment process includes one.
+- An environment parameter, target tag parameter, or tenant tag parameter defined on the template. The variable applies wherever the project's parameter value resolves to.
+
+Scoping is fixed at the template level. The same scoping rules apply to every project created from the template.
 
 :::figure
 ![The Variables tab in a project template](/docs/img/platform-hub/project-templates/project-templates-variables.png)
+:::
+
+## Project settings
+
+Project templates let you set a few project-level defaults that flow through to every project created from the template. Configure these in **Settings** on the project template.
+
+- **Multi-tenant Deployments**: choose whether projects created from the template require tenants, allow tenants, or run untenanted. Users can't change this on a project created from the template.
+- **Project Persistence**: choose the preferred storage for projects created from the template, either in Octopus or backed by Git. The project creation flow defaults to your recommendation and lets users pick a different option if they need to.
+
+:::div{.hint}
+We're planning to add more template-level settings, including default lifecycle and channel configuration, once those features are available in project templates.
 :::
 
 ## Git repository structure
@@ -118,4 +148,4 @@ After you publish and share a template, users in a space can create a new projec
 
 ## Feedback
 
-Project templates are in Alpha and we're actively shaping how the feature works. If you run into something unexpected or have thoughts on how parameters, variables, scoping, or anything else should work, we'd love to hear from you. [Share your feedback](https://oc.to/feedback) to help us build this the right way.
+Project templates are in Public Preview and we're actively shaping how the feature works. If you run into something unexpected or have thoughts on how parameters, variables, scoping, or anything else should work, we'd love to hear from you. [Share your feedback](https://oc.to/feedback) to help us build this the right way.

--- a/src/pages/docs/platform-hub/templates/project-templates/installation-guide.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/installation-guide.md
@@ -12,7 +12,7 @@ navOrder: 172
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
 :::
 
 ## License requirements

--- a/src/pages/docs/platform-hub/templates/project-templates/installation-guide.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/installation-guide.md
@@ -1,18 +1,18 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-16
-modDate: 2026-03-16
-title: Installing the Alpha preview of project templates
-subtitle: Guide for installing a preview version of Octopus Server with project templates
+modDate: 2026-05-28
+title: Installing the Public Preview of project templates
+subtitle: Guide for installing the Public Preview of Octopus Server with project templates
 icon: fa-solid fa-layer-group
 navTitle: Installation guide
 navSection: Project Templates
-description: Installation guide for self-hosted Octopus Server customers who want to access the project templates Alpha
+description: Installation guide for self-hosted Octopus Server customers who want to access the project templates Public Preview
 navOrder: 172
 ---
 
 :::div{.warning}
-Project templates are in Alpha. The feature is incomplete and standard SLAs do not apply. Don't use it for production workloads. It is available to Enterprise customers on Cloud. Self-hosted customers can access it as an early preview via Octopus 2026.2. We're actively developing this feature and would love your feedback.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
 :::
 
 ## License requirements
@@ -21,16 +21,13 @@ Project templates require an Octopus Enterprise license with the project templat
 
 ## How to install Octopus Server 2026.2
 
-Project templates are available to Cloud customers without any additional setup. Self-hosted customers can access project templates as an early preview by installing the latest Octopus Server 2026.2.
+Project templates are available to Cloud customers without any additional setup. Self-hosted customers can access project templates as a Public Preview by installing the latest Octopus Server 2026.2.
 
 :::div{.warning}
 You should only install a preview version of Octopus Server if you are comfortable adopting a feature before it's fully complete. Any issues or bugs you encounter with preview features may take longer to fix than normal. For other features, we provide the same level of support as for LTS versions. Contact <sales@octopus.com> with any questions about whether this approach is right for you.
 :::
 
-1. Download Octopus Server 2026.2.
-
-   - If you are running Octopus on Windows, you can [download the installer](https://download.octopusdeploy.com/octopus/Octopus.2026.2.2311-x64.msi) directly.
-   - If you are running Octopus on Linux, you can pull the Docker image. The preview version is `2026.2.2311-PublicPreview` — see the [Docker Hub page](https://hub.docker.com/repository/docker/octopusdeploy/octopusdeploy/tags/2026.2.2311-PublicPreview/sha256-b81bd5d752b22f25137306086a4ea76168e9a7e17f7d573116c509c6bfa23469) for the full image details.
+1. Download Octopus Server 2026.2 from [octopus.com/downloads](https://octopus.com/downloads).
 
 1. After downloading, upgrade your Octopus instance using the [upgrading guide](/docs/administration/upgrading).
 

--- a/src/pages/docs/platform-hub/templates/project-templates/troubleshooting.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-05
-modDate: 2026-03-16
+modDate: 2026-05-28
 title: Troubleshooting
 subtitle: Known issues and limitations for project templates
 icon: fa-solid fa-layer-group
@@ -12,12 +12,12 @@ navOrder: 173
 ---
 
 :::div{.warning}
-Project templates are in Alpha. The feature is incomplete and standard SLAs do not apply. Don't use it for production workloads. It is available to Enterprise customers on Cloud. Self-hosted customers can access it as an early preview via Octopus 2026.2. We're actively developing this feature and would love your feedback.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
 :::
 
-## Alpha limitations
+## Public Preview limitations
 
-Project templates are in Alpha. The following features are not yet supported and are planned for future releases:
+Project templates are in Public Preview. The following features are not yet supported and are planned for future releases:
 
 - Channels
 - Lifecycles
@@ -27,24 +27,24 @@ Project templates are in Alpha. The following features are not yet supported and
 - Cloning a project template through the Octopus UI
 - Creating and managing project templates through the REST API, CLI, or Terraform provider
 - Feeds
-- Project settings
+- Project settings, except for Multi-tenant Deployments
 - Runbooks
 - Triggers
 - Import and export of templated projects
 - Git Credentials
-- Inline variable and parameter configuration within the deployment process editor
+- Inline variable configuration within the deployment process editor
 
 We'll update this page as the feature evolves.
 
 ## Step support
 
-Project templates support most Octopus steps. The following step package framework steps are not supported:
+Project templates support most Octopus steps. The following steps are not supported:
 
 - Deploy a Bicep Template
 - AWS S3 Create Bucket
 - AWS ECS
 
-These steps are being migrated away from the step package framework and will be supported in the future.
+These steps will be supported in the future.
 
 ## Cloning project templates
 

--- a/src/pages/docs/platform-hub/templates/project-templates/troubleshooting.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/troubleshooting.md
@@ -12,7 +12,7 @@ navOrder: 173
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
 :::
 
 ## Public Preview limitations
@@ -23,18 +23,21 @@ Project templates are in Public Preview. The following features are not yet supp
 - Lifecycles
 - Environments
 - Ephemeral environments
-- Cloud target discovery on steps. Use project variables in the project instead
+- Cloud target discovery on steps (see below)
 - Cloning a project template through the Octopus UI
 - Creating and managing project templates through the REST API, CLI, or Terraform provider
 - Feeds
-- Project settings, except for Multi-tenant Deployments
+- Project settings, except for Multi-tenant Deployments and Project Persistence
 - Runbooks
 - Triggers
 - Import and export of templated projects
-- Git Credentials
 - Inline variable configuration within the deployment process editor
 
 We'll update this page as the feature evolves.
+
+## Cloud target discovery
+
+Project templates can't supply the account that cloud target discovery uses on a step. To use cloud target discovery in a templated project, configure it on the templated project itself. See [cloud target discovery](/docs/infrastructure/deployment-targets/cloud-target-discovery) for more information.
 
 ## Step support
 

--- a/src/pages/docs/platform-hub/templates/project-templates/using-project-templates.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/using-project-templates.md
@@ -12,7 +12,7 @@ navOrder: 171
 ---
 
 :::div{.warning}
-Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards General Availability.
 :::
 
 A **templated project** is a project created from a project template. It inherits the template's deployment process and variables, which you can't modify. You customize the project by supplying values for the parameters defined in the template.

--- a/src/pages/docs/platform-hub/templates/project-templates/using-project-templates.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/using-project-templates.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-16
-modDate: 2026-03-16
+modDate: 2026-05-28
 title: Templated projects
 subtitle: How to create and manage projects from a project template
 icon: fa-solid fa-layer-group
@@ -12,14 +12,16 @@ navOrder: 171
 ---
 
 :::div{.warning}
-Project templates are in Alpha. The feature is incomplete and standard SLAs do not apply. Don't use it for production workloads. It is available to Enterprise customers on Cloud. Self-hosted customers can access it as an early preview via Octopus 2026.2. We're actively developing this feature and would love your feedback.
+Project templates are in Public Preview. The feature is still evolving and standard SLAs don't apply. We don't recommend it for production workloads yet. It's available to Enterprise customers on Cloud and to self-hosted customers running Octopus 2026.2. We'd love your feedback as we work towards general availability.
 :::
 
-A **templated project** is a project created from a project template. It inherits the template's deployment process and variables, which you can't modify. You customize the project by supplying values for the parameters the producer has defined.
+A **templated project** is a project created from a project template. It inherits the template's deployment process and variables, which you can't modify. You customize the project by supplying values for the parameters defined in the template.
 
 ## Create a project from a template
 
 To use a project template, you create a new project based on it.
+
+<!-- markdownlint-disable MD029 -->
 
 1. Select **Projects** from the main navigation and click **Add Project**.
 2. If there are any available project templates, you'll see them listed here. Select the template you want to use.
@@ -28,24 +30,24 @@ To use a project template, you create a new project based on it.
 ![Selecting a project template when creating a new project](/docs/img/platform-hub/project-templates/project-template-selection.png)
 :::
 
-1. Give the project a **Name** and choose where its settings, non-sensitive variables, and template values will be stored.
+3. Give the project a **Name** and choose where its settings, non-sensitive variables, and template values will be stored.
 
 :::figure
 ![Naming a templated project and choosing storage settings](/docs/img/platform-hub/project-templates/templated-project-creation.png)
 :::
 
-1. Click **Next** to configure your versioning preferences. You can change these later in project settings.
+4. Click **Next** to configure your versioning preferences. You can change these later in project settings.
 
 If the template has pre-release versions, you'll also be asked to choose a version type:
 
 - **Stable**: intended for production use.
-- **Pre-release**: intended for testing purposes only, typically by the template producers. Not recommended for production use.
+- **Pre-release**: intended for testing purposes only, typically by the template owner. Not recommended for production use.
 
 :::figure
 ![Choosing between stable and pre-release template versions](/docs/img/platform-hub/project-templates/templated-project-version-selection.png)
 :::
 
-1. Select how you want the project to handle template updates:
+5. Select how you want the project to handle template updates:
 
    - **Accept minor changes**: automatically updates when a patch or minor version is published. Major versions require a manual update.
    - **Accept patches**: only automatically updates when a patch is published. Minor or major versions require a manual update.
@@ -54,11 +56,13 @@ If the template has pre-release versions, you'll also be asked to choose a versi
 ![Configuring template version update preferences](/docs/img/platform-hub/project-templates/templated-project-version-settings.png)
 :::
 
+<!-- markdownlint-enable MD029 -->
+
 Click **Create Project**. You'll be taken to the **Template values** page.
 
 ## Template values
 
-Template values are the parameters the producer has defined to let you customize the template for your project. They work like project variables: you can provide a value directly or use variable substitutions. Parameters with defaults are marked as optional.
+Template values are the parameters the template owner has defined to let you customize the template for your project. They work like project variables: you can provide a value directly or use variable substitutions. Parameters with defaults are marked as optional.
 
 :::figure
 ![The Template values page for a templated project](/docs/img/platform-hub/project-templates/templated-project-values.png)
@@ -67,12 +71,12 @@ Template values are the parameters the producer has defined to let you customize
 After you've provided the required values, you can create a release as usual.
 
 :::div{.hint}
-You can't modify the deployment process in a templated project. You can't add, remove, reorder, or disable steps. If you need to change the process, contact the template producer.
+You can't modify the deployment process in a templated project. You can't add, remove, reorder, or disable steps. If you need to change the process, contact the template owner.
 :::
 
 ## Template updates
 
-When the producer publishes a new version of the template, you'll receive the update. How and when it's applied depends on the versioning preferences you set when creating the project:
+When a new version of the template is published, you'll receive the update. How and when it's applied depends on the versioning preferences you set when creating the project:
 
 - **Patch and minor updates**: Octopus applies these automatically if you chose to accept them.
 - **Major updates**: you must manually apply these, regardless of your preferences.
@@ -81,7 +85,7 @@ When a major update is available, you'll need to review and apply it before you 
 
 ## Future direction
 
-We're still shaping what project templates can do, and there are a few areas we're actively thinking about. If any of these sound useful to you, we'd love to hear about it. [Share your feedback](https://oc.to/feedback).
+We're still shaping what project templates can do. [Share your feedback](https://oc.to/feedback) to help guide where we go next.
 
 ## Limitations
 


### PR DESCRIPTION
Closes MAS-2828
Closes MAS-2645

## Background

Project Templates is being released as a Public Preview feature in the 2026.2 Octopus Server release. These are the accompanying docs changes.

## Summary

- Update all Project Templates pages from Alpha to Public Preview.
- Document the new variable types (certificates) and scoping options now supported in templates.
- Add a Project settings section covering Multi-tenant Deployments and Project Persistence.
- Update the installation guide to point to octopus.com/downloads.
- Update the Public Preview limitations list to reflect what's now supported.
- Move Certificate parameters to the list of types that can have a default value.
- Copy and consistency fixes.