### PR TITLE
Docs: Reflect resilient deployments on Octopus Cloud

### DIFF
--- a/src/pages/docs/octopus-cloud/frequently-asked-questions.md
+++ b/src/pages/docs/octopus-cloud/frequently-asked-questions.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2024-11-08
-modDate: 2025-06-06
+modDate: 2026-06-23
 title: Octopus Cloud Frequently Asked Questions
 navTitle: Octopus Cloud FAQ
 navOrder: 110
@@ -198,6 +198,10 @@ We publish Octopus Cloud’s [uptime track record](/docs/octopus-cloud/uptime-sl
 ### How can we check Octopus Cloud's status?
 
 We publish Octopus Cloud's [operational status](https://status.octopus.com/). You can subscribe to status change emails from our [operational status page](https://status.octopus.com/).
+
+### What happens to my deployments during a maintenance window?
+
+Deployments and runbook runs on Octopus Cloud are resilient. If a [maintenance window](/docs/octopus-cloud/maintenance-window) or node restart interrupts a deployment or runbook run, it continues automatically once your instance is back online, rather than failing. You don't need to manually re-run them afterwards. Other task types are not yet resilient and may be abandoned during an outage.
 
 ## Logs and data
 

--- a/src/pages/docs/octopus-cloud/maintenance-window.md
+++ b/src/pages/docs/octopus-cloud/maintenance-window.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-08-13
+modDate: 2026-06-23
 title: Maintenance windows
 navTitle: Maintenance windows
 navOrder: 80
@@ -48,7 +48,7 @@ On rare occasions, a maintenance action will require an outage. During the two-h
 
 We follow this process to minimize impact:
 
-- In-progress tasks get a few minutes to complete before being abandoned
+- In-progress tasks get a few minutes to complete. Deployments and runbook runs still running at the end of that time are resilient — they continue automatically once your instance is back online, rather than failing. Other in-progress tasks may still be abandoned
 - Users receive a maintenance page, and API requests return a 503 Service Unavailable status code
 - Maintenance operations occur
 - Your instance will start up again, and we confirm it is in a healthy state
@@ -56,10 +56,8 @@ We follow this process to minimize impact:
 - Tasks paused during shutdown will be resumed
 - Tasks scheduled to start during the outage commence
 
-We recommend avoiding non-idempotent deployments and runbook runs during maintenance windows.
-
 :::div{.hint}
-One impact of an outage is that deployments and runbook runs may fail. We are actively working on [Resilient Scalable Deployments](https://roadmap.octopus.com/c/95-alpha-program-resilient-scalable-deployments-in-octopus-cloud) to allow deployments and runbook runs to resume post-outage.  
+Deployments and runbook runs on Octopus Cloud are now resilient: if an outage interrupts a deployment or runbook run, it continues automatically once your instance is back online, rather than failing. You no longer need to manually re-run them after a maintenance window. Other task types are not yet resilient and may be abandoned during an outage.
 :::
 
 ## How to view or change your maintenance window

--- a/src/pages/docs/octopus-rest-api/examples/bulk-operations/rerun-deployments-and-runbooks-after-node-shutdown.mdx
+++ b/src/pages/docs/octopus-rest-api/examples/bulk-operations/rerun-deployments-and-runbooks-after-node-shutdown.mdx
@@ -1,11 +1,15 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2026-06-23
 title: Rerun all canceled deployments and runbook runs after node shutdown.
 description: An example script that determine which deployments and runbook runs were canceled because of a node shutdown and resubmit them.
 ---
 import RerunDeploymentsAndRunbooksAfterNodeFailure from 'src/shared-content/scripts/rerun-deployments-and-runbooks-after-node-failure.include.md';
+
+:::div{.hint}
+**Octopus Cloud:** This script is no longer needed for deployments and runbook runs. On Octopus Cloud, these tasks are resilient — they continue automatically after a node restart or maintenance window rather than being cancelled. This script remains useful for self-hosted High Availability instances, where node restarts still cancel active tasks.
+:::
 
 This script demonstrates how to programmatically determine which deployments and runbook runs can be resubmitted because they were canceled because of a node shutdown.  The node could have been shutdown for normal reasons, or it could have stopped responding, or it could have been turned off.
 
@@ -23,9 +27,9 @@ This script has guardrails in place to ensure you don't make too many changes.
 
 - A what if variable.  Set that to `$true` and it will skip the submission step.  It will print out all the deployments and runbook runs it would've done.
 - This script will not resubmit every canceled runbook run or deployment.  For a runbook run or deployment to be considered it must:
-    - Have been canceled within the time frame provided.
-    - Have been running on the node or nodes that were provided.
-    - Have been canceled because of a node shutdown.
+  - Have been canceled within the time frame provided.
+  - Have been running on the node or nodes that were provided.
+  - Have been canceled because of a node shutdown.
 
 ## Script
 


### PR DESCRIPTION
## What

Deployments and runbook runs on Octopus Cloud now survive node restarts and maintenance windows — they pause and resume automatically rather than failing. Several docs still framed task failure during outages as expected behaviour, or described resilience as future roadmap work. This updates them.

## Scope

**Octopus Cloud only, deployments and runbook runs only.** The claim is *resilience shipped on Cloud*, not *maintenance windows removed* — maintenance windows still exist; deployments and runbook runs now survive them.

Other task types (e.g. system tasks, health checks) are **not** resilient yet, so the maintenance-window page keeps the "other in-progress system tasks may still be abandoned" caveat.

Self-hosted HA pages are **intentionally left unchanged** — resilience is not yet on self-hosted.

## Changes

| File | Change |
|---|---|
| `octopus-cloud/maintenance-window.md` | Replace the "resilience is future roadmap work" hint with shipped behaviour; scope the shutdown-timeout note to deployments/runbook runs (other in-progress system tasks may still be abandoned) |
| `octopus-cloud/frequently-asked-questions.md` | Add "What happens to my deployments during a maintenance window?" under Availability |
| `octopus-rest-api/.../rerun-deployments-and-runbooks-after-node-shutdown.mdx` | Add a Cloud-obsolescence note; script remains relevant for self-hosted HA |

🤖 Generated with [Claude Code](https://claude.com/claude-code)