### PR TITLE
Add polling connection count troubleshooting section

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -108,7 +108,7 @@ To do this open **Control Panel ➜ Internet Options ➜ Advanced**, and uncheck
 
 ## Requests timing out during Deployments/Runbooks while the Tentacle is online
 
-If the tentacle is online and if while running multiple Deployments and Runbooks the following error:
+If the Polling Tentacle is online and if while running multiple Deployments or Runbooks the following error:
 
 > A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -112,7 +112,7 @@ If a Polling Tentacle is online but you occasionally see timeout errors during c
 
 **The Error:**
 
-```
+```text
 A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
 ```
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -103,7 +103,7 @@ If the command help is not displayed immediately (< 1s) you may need to consider
 To do this open **Control Panel ➜ Internet Options ➜ Advanced**, and uncheck the *Check for publisher's certificate revocation* option as shown below.
 
 :::figure
-![](/docs/img/infrastructure/deployment-targets/tentacle/images/5865771.png)
+![uncheck of the Check for publisher’s certificate revocation control panel option](/docs/img/infrastructure/deployment-targets/tentacle/images/5865771.png)
 :::
 
 ## Requests timing out while the Tentacle is online

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -108,18 +108,21 @@ To do this open **Control Panel ➜ Internet Options ➜ Advanced**, and uncheck
 
 ## Requests timing out during Deployments/Runbooks while the Tentacle is online
 
-If the Polling Tentacle is online and if while running multiple Deployments or Runbooks the following error:
+If a Polling Tentacle is online but you occasionally see timeout errors during concurrent deployments or runbooks, the Tentacle may be hitting its connection limit.
+
+**The Error:**
 
 > A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
 
-is occasionally seen. It could be that the Polling Tentacle is unable to process the requests quickly enough, despite the Tentacle's CPU and other 
-resources being under utilised.
+**The Cause:**
 
-This can occur because a Polling Tentacle may be configured to process no more than one request at a time, as their polling connection count is set to `1` or 
-defaults to `1`. Polling Tentacle Targets are by default configured to have a polling connection count of 1. While Polling Workers default to `max(5, Tentacle Core Count)`, 
-historically they have been configured with a Polling Connection Count of `1`.
+This issue occurs when a Polling Tentacle cannot process requests quickly enough, even if the host CPU and RAM utilization are low. By default, Polling Tentacle Deployment Targets are configured with a polling connection count of 1.
 
-To overcome this the polling connection count can be increased. For workers the recommended value is `max(5, Tentacle Core Count)`.
+While new Polling Workers automatically scale to `max(5, Tentacle Core Count)`, older Tentacles and standard Deployment Targets default to 1 and only process one request at a time.
+
+**The Solution:**
+
+Increase the polling connection count to allow concurrent request processing. The recommended value for targets and workers is `max(5, Tentacle Core Count)`.
 
 Set it from the Tentacle command line:
 
@@ -134,9 +137,5 @@ Or set it directly in the Tentacle configuration file:
 ```
 
 Restart the Tentacle for the change to take effect.
-
-:::div{.hint}
-New Polling Tentacle workers are automatically configured with a connection count of `max(5, processor count)`. Deployment targets — and any Tentacle configured before this option existed — default to `1`, so they are the most likely to benefit from increasing the count.
-:::
 
 <TentacleUninstall />

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -116,9 +116,9 @@ If a Polling Tentacle is online but you occasionally see timeout errors during c
 
 **The Cause:**
 
-This issue occurs when a Polling Tentacle cannot process requests quickly enough, even if the host CPU and RAM utilization are low. By default, Polling Tentacle Deployment Targets are configured with a polling connection count of 1.
+This issue occurs when a Polling Tentacle cannot process requests quickly enough, even if the host CPU and RAM utilization are low. By default, Polling Tentacle Deployment Targets are configured with a polling connection count of `1`.
 
-While new Polling Workers automatically scale to `max(5, Tentacle Core Count)`, older Tentacles and standard Deployment Targets default to 1 and only process one request at a time.
+While newly configured Polling Workers automatically scale to `max(5, Tentacle Core Count)`, previously configured Tentacles and standard Deployment Targets default to `1` and only process one request at a time.
 
 **The Solution:**
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -106,7 +106,7 @@ To do this open **Control Panel ➜ Internet Options ➜ Advanced**, and uncheck
 ![uncheck of the Check for publisher’s certificate revocation control panel option](/docs/img/infrastructure/deployment-targets/tentacle/images/5865771.png)
 :::
 
-## Requests timing out during Deployments/Runbook while the Tentacle is online
+## Requests timing out during Deployments/Runbooks while the Tentacle is online
 
 If the tentacle is online and if while running multiple Deployments and Runbooks the following error:
 
@@ -115,9 +115,9 @@ If the tentacle is online and if while running multiple Deployments and Runbooks
 is occasionally seen. It could be that the Polling Tentacle is unable to process the requests quickly enough, despite the Tentacle's CPU and other 
 resources being under utilised.
 
-This can occure because Polling Tentacle may be configured to process no more than one requests at a time, as their polling connect count is set to `1` or 
+This can occur because a Polling Tentacle may be configured to process no more than one request at a time, as their polling connection count is set to `1` or 
 defaults to `1`. Polling Tentacle Targets are by default configured to have a polling connection count of 1. While Polling Workers default to `max(5, Tentacle Core Count)`, 
-however historically theu have been configured with a Polling Connection Count of `1`.
+historically they have been configured with a Polling Connection Count of `1`.
 
 To overcome this the polling connection count can be increased. For workers the recommended value is `max(5, Tentacle Core Count)`.
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -112,7 +112,9 @@ If a Polling Tentacle is online but you occasionally see timeout errors during c
 
 **The Error:**
 
-> A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
+```
+A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
+```
 
 **The Cause:**
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -37,7 +37,7 @@ Octopus Cloud instances have HSTS enabled so it will be impossible to bypass the
 The page shown should look like the one below.
 
 :::figure
-![](/docs/img/infrastructure/deployment-targets/tentacle/images/3277906.png)
+![Octopus Server configured successfully page](/docs/img/infrastructure/deployment-targets/tentacle/images/3277906.png)
 :::
 
 If you've made it this far, good news! Your Octopus Server is running and ready to accept inbound connections from Polling Tentacles.

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -106,34 +106,37 @@ To do this open **Control Panel ➜ Internet Options ➜ Advanced**, and uncheck
 ![uncheck of the Check for publisher’s certificate revocation control panel option](/docs/img/infrastructure/deployment-targets/tentacle/images/5865771.png)
 :::
 
-## Requests timing out while the Tentacle is online
+## Requests timing out during Deployments/Runbook while the Tentacle is online
 
-If a health check or deployment fails with an error like:
+If the tentacle is online and if while running multiple Deployments and Runbooks the following error:
 
 > A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
 
-and the Tentacle is online and *is* successfully processing other requests, the Tentacle may simply be unable to collect requests fast enough to keep up.
+is occasionally seen. It could be that the Polling Tentacle is unable to process the requests quickly enough, despite the Tentacle's CPU and other 
+resources being under utilised.
 
-A polling Tentacle can only work on as many requests at once as it has open polling connections to the Octopus Server, and each connection handles a single request at a time. Historically polling Tentacles were configured with a connection count of `1`, which means a single long-running request — for example transferring a large package — blocks every other request behind it. Those queued requests can eventually time out with the error above even though the Tentacle itself is healthy and busy.
+This can occure because Polling Tentacle may be configured to process no more than one requests at a time, as their polling connect count is set to `1` or 
+defaults to `1`. Polling Tentacle Targets are by default configured to have a polling connection count of 1. While Polling Workers default to `max(5, Tentacle Core Count)`, 
+however historically theu have been configured with a Polling Connection Count of `1`.
 
-You can resolve this by increasing the number of polling connections the Tentacle opens, allowing it to process more requests concurrently.
+To overcome this the polling connection count can be increased. For workers the recommended value is `max(5, Tentacle Core Count)`.
 
 Set it from the Tentacle command line:
 
 ```bash
-Tentacle set-polling-connection-count --instance=MyInstance --pollingConnectionCount=16
+Tentacle set-polling-connection-count --instance=MyInstance --pollingConnectionCount=5
 ```
 
 Or set it directly in the Tentacle configuration file:
 
 ```xml
-<set key="Tentacle.Communication.PollingConnectionCount">16</set>
+<set key="Tentacle.Communication.PollingConnectionCount">5</set>
 ```
 
-Restart the Tentacle for the change to take effect. The value is clamped to between `1` and `512`.
+Restart the Tentacle for the change to take effect.
 
 :::div{.hint}
-New polling Tentacle workers are automatically configured with a connection count of `max(5, processor count)`. Deployment targets — and any Tentacle configured before this option existed — default to `1`, so they are the most likely to benefit from increasing the count.
+New Polling Tentacle workers are automatically configured with a connection count of `max(5, processor count)`. Deployment targets — and any Tentacle configured before this option existed — default to `1`, so they are the most likely to benefit from increasing the count.
 :::
 
 <TentacleUninstall />

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/troubleshooting/troubleshooting-polling.mdx
@@ -106,4 +106,34 @@ To do this open **Control Panel ➜ Internet Options ➜ Advanced**, and uncheck
 ![](/docs/img/infrastructure/deployment-targets/tentacle/images/5865771.png)
 :::
 
+## Requests timing out while the Tentacle is online
+
+If a health check or deployment fails with an error like:
+
+> A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.
+
+and the Tentacle is online and *is* successfully processing other requests, the Tentacle may simply be unable to collect requests fast enough to keep up.
+
+A polling Tentacle can only work on as many requests at once as it has open polling connections to the Octopus Server, and each connection handles a single request at a time. Historically polling Tentacles were configured with a connection count of `1`, which means a single long-running request — for example transferring a large package — blocks every other request behind it. Those queued requests can eventually time out with the error above even though the Tentacle itself is healthy and busy.
+
+You can resolve this by increasing the number of polling connections the Tentacle opens, allowing it to process more requests concurrently.
+
+Set it from the Tentacle command line:
+
+```bash
+Tentacle set-polling-connection-count --instance=MyInstance --pollingConnectionCount=16
+```
+
+Or set it directly in the Tentacle configuration file:
+
+```xml
+<set key="Tentacle.Communication.PollingConnectionCount">16</set>
+```
+
+Restart the Tentacle for the change to take effect. The value is clamped to between `1` and `512`.
+
+:::div{.hint}
+New polling Tentacle workers are automatically configured with a connection count of `max(5, processor count)`. Deployment targets — and any Tentacle configured before this option existed — default to `1`, so they are the most likely to benefit from increasing the count.
+:::
+
 <TentacleUninstall />


### PR DESCRIPTION
Adds a section to the **Troubleshooting Polling Tentacles** page covering what to do when you see:

> A request was sent to a polling endpoint, but the polling endpoint did not collect the request within the allowed time (00:02:00), so the request timed out.

while the Tentacle is online and actively processing requests.

It explains that this can be caused by the polling Tentacle not collecting requests fast enough — each polling connection handles one request at a time, and historically the count was `1`, so a single long-running request (e.g. a large file transfer) blocks the rest until they time out. It then shows how to increase the connection count via `set-polling-connection-count`, via the Tentacle config XML, notes the 1–512 range, and that new workers default to `max(5, processor count)`.

Relates to the Tentacle change: OctopusDeploy/OctopusTentacle#1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes EFT-3416