### PR TITLE
Remove Early Access label from SCIM for Azure AD/Entra ID

### DIFF
--- a/src/pages/docs/security/authentication/scim/configuring-microsoft-entra.mdx
+++ b/src/pages/docs/security/authentication/scim/configuring-microsoft-entra.mdx
@@ -1,18 +1,12 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-12-03
-modDate: 2026-01-23
+modDate: 2026-07-02
 title: Microsoft Entra ID
 description: Microsoft Entra ID can manage Octopus Users and Teams using the SCIM API.
 navTitle: Microsoft Entra ID
 navOrder: 10
 ---
-
-:::div{.hint}
-
-Support for Entra ID with SCIM is rolling out as an Early Access Preview to enterprise customers in Octopus Cloud.
-
-:::
 
 Octopus Deploy supports [SCIM](./) 2 as a feature of the Azure AD authentication provider. This allows users and groups created and managed in Entra ID to be synchronized with users and teams in Octopus Deploy, rather than manually provisioning users or provisioning them just-in-time via **Allow Auto User Creation**.
 

--- a/src/pages/docs/security/authentication/scim/index.mdx
+++ b/src/pages/docs/security/authentication/scim/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2025-12-02
-modDate: 2025-12-02
+modDate: 2026-07-02
 title: System for Cross-domain Identity Management (SCIM)
 description: Octopus Deploy supports SCIM for user and group provisioning
 navTitle: General
@@ -11,7 +11,7 @@ navOrder: 34
 
 [System for Cross-domain Identity Management](https://scim.cloud) is a standards-based approach used to allow identity providers to create, update and delete users and groups in other applications via an API. This makes it easier to provision and revoke user access to applications directly from the identity provider, as well as reduce the work involved in updating user details shared across systems, like names and email addresses.
 
-Octopus Deploy currently supports SCIM 2 as an Early Access feature of the Azure AD authentication provider.
+Octopus Deploy currently supports SCIM 2 as a feature of the Azure AD authentication provider.
 
 ## Benefits of SCIM
 


### PR DESCRIPTION
## Summary

Removes the "Early Access" label from SCIM support for Azure AD / Microsoft Entra ID