### PR TITLE
Update Uptime SLO stats for June 2026

### DIFF
--- a/src/pages/docs/octopus-cloud/uptime-slo.md
+++ b/src/pages/docs/octopus-cloud/uptime-slo.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2026-06-01
+modDate: 2026-07-07
 title: Uptime SLO
 navTitle: Uptime SLO
 navOrder: 70
@@ -26,6 +26,7 @@ We list our achieved uptime percentage and weekly unplanned downtime duration. W
 
 | Month | Uptime % | Weekly unplanned downtime | Uptime % incl. planned maintenance | Weekly downtime incl. planned maintenance |
 | :----- | ------: | ------: | ------: | ------: |
+| June 2026 | 99.9987% | 14s | 99.9212% | 483s |
 | May 2026 | 99.9959% | 28s | 99.9234% | 469s |
 | April 2026 | 99.9857% | 91s | 99.9186% | 497s |
 | March 2026 | 99.9973% | 21s | 99.8632% | 833s |
@@ -37,7 +38,6 @@ We list our achieved uptime percentage and weekly unplanned downtime duration. W
 | September 2025 | 99.9989% | 7s | 99.8722% | 777s |
 | August 2025 | 99.9989% | 7s | 99.9281% | 441s |
 | July 2025 | 99.9992% | 7s | 99.9207% | 483s |
-| June 2025 | 99.9974% | 21s | 99.9307% | 420s |
 
 ### How we calculate uptime
 


### PR DESCRIPTION
Add statistics for June 2026.

Data sheet: https://docs.google.com/spreadsheets/d/1kqJi6hHx7CKM5OThVm8cg8EkaUsJQ6Vgt9TJhHclHWU/edit?gid=1331425694#gid=1331425694

Note: [#incident-20260608-better-uptime-alerts-vn-i083876-to-be-down](https://octopusdeploy.slack.com/archives/C0B9S6CJNG0) has no impact on this data. See comment [here](https://linear.app/octopus/issue/CLOUDPT-11453/publish-june-2026-cloud-uptime-stats-to-docs#comment-f8b038be) for further explanation.

ref CLOUDPT-11453