### PR TITLE
Document configurable token lifetime for Google Cloud OIDC accounts

### DIFF
--- a/src/pages/docs/infrastructure/accounts/google-cloud/index.md
+++ b/src/pages/docs/infrastructure/accounts/google-cloud/index.md
@@ -36,6 +36,7 @@ Google Cloud rejects lifetimes longer than 1 hour (3600 seconds) unless the orga
 :::
 
 ## Generic OpenId Connect Account
+
 Google Cloud steps can use a Generic OpenId Connect Account for authentication.
 
 1. Navigate to **Deploy ➜ Manage ➜ Accounts**, click the **ADD ACCOUNT** and select **Generic Oidc Account**.
@@ -64,7 +65,6 @@ gcloud iam workload-identity-pools create-cred-config \
     --app-id-uri=<serverUri>
 ```
 
-
 :::div{.hint}
 The default audience format is `https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID` while `workload-identity-pools create-cred-config` command expects the audience without `https://iam.googleapis.com`. In this scenario Octopus expects the full audience value to be set on the account including `https://iam.googleapis.com` but will trim the `https://iam.googleapis.com` when running the create-cred-config command.  
 :::
@@ -80,7 +80,7 @@ Google Cloud steps can use a Google Cloud Account for authentication.
 
 See the [Google cloud documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) for instructions to create a service account and download the key file.
 
-5. Click the **SAVE AND TEST** to save the account and verify the credentials are valid.
+1. Click the **SAVE AND TEST** to save the account and verify the credentials are valid.
 
 :::div{.hint}
 Google Cloud steps can also defer to the service account assigned to the instance/virtual machine that hosts the Octopus Tentacles for authentication. In this scenario there is no need to create a Google Cloud account in Octopus Deploy.

--- a/src/pages/docs/infrastructure/accounts/google-cloud/index.md
+++ b/src/pages/docs/infrastructure/accounts/google-cloud/index.md
@@ -1,19 +1,39 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2026-07-09
 title: Google cloud accounts
 description:  Configure your infrastructure so Octopus can deploy infrastructure to GCP and run scripts against the gcloud CLI.
 navOrder: 30
 ---
 
 :::div{.hint}
-Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect Accounts were added in **2025.1**
+Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect Accounts were added in **2025.1**, and the OpenID Connect authentication method for Google Cloud Accounts was added in **{RELEASE_VERSION}**
 :::
 
-To deploy infrastructure to Google Cloud Platform, you can define a Google cloud or Generic OpenId Connect account in Octopus.
+To deploy infrastructure to Google Cloud Platform, you can define a Google Cloud account or a Generic OpenId Connect account in Octopus.
 
-The Generic OpenId Connect Account generates a JWT that can be used for [OpenID Connect](/docs/infrastructure/accounts/openid-connect) authentication. The Google cloud account uses the JSON key file credentials that can be retrieved from the service account assigned to the instance that is executing the deployment.
+A Google Cloud account authenticates either with a JSON key file or with OpenID Connect, chosen via the account's authentication method. The OpenID Connect option and the Generic OpenId Connect account both generate a JWT that is used for [OpenID Connect](/docs/infrastructure/accounts/openid-connect) authentication against a Workload Identity Federation; the Google Cloud account's OpenID Connect option is the recommended choice for GCP as it exposes GCP-specific settings such as the token lifetime.
+
+## Google Cloud OpenID Connect Account
+
+Google Cloud steps can use OpenID Connect for authentication, configured on a **Google Cloud Account** by choosing the OpenID Connect authentication method. This is the recommended way to use OpenID Connect with Google Cloud.
+
+1. Navigate to **Deploy ➜ Manage ➜ Accounts**, click **ADD ACCOUNT** and select **Google Cloud Account**.
+1. Add a memorable name for the account.
+1. Under **Authentication Method**, select **Use OpenID Connect**.
+1. Set the [Deployments and Runbooks](/docs/infrastructure/accounts/openid-connect#subject-key-parts) subject generator.
+1. Set an audience. This should match the audience set on the Workload Identity Federation. By default, this is `https://iam.googleapis.com/projects/{project-id}/locations/global/workloadIdentityPools/{pool-id}/providers/{provider-id}`.
+1. Optionally set the **Token Lifetime** (see [Token lifetime](#token-lifetime)).
+1. Click **SAVE**. To test the account, set it as the account on a gcloud script step.
+
+### Token lifetime
+
+**Token Lifetime** controls how long, in seconds, the federated Google Cloud access token is valid. Octopus passes it to gcloud as `--service-account-token-lifetime-seconds`. Valid values are **600 to 43200** seconds (10 minutes to 12 hours); the default is **3600** seconds (1 hour).
+
+:::div{.hint}
+Google Cloud rejects lifetimes longer than 1 hour (3600 seconds) unless the organization policy constraint `iam.allowServiceAccountCredentialLifetimeExtension` lists the impersonated service account. Without that policy, values above 3600 will fail when gcloud requests the token.
+:::
 
 ## Generic OpenId Connect Account
 Google Cloud steps can use a Generic OpenId Connect Account for authentication.
@@ -26,13 +46,17 @@ Google Cloud steps can use a Generic OpenId Connect Account for authentication.
 
 See the [Google cloud documentation](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers) for instructions on creating and configuring a Workload Identity Federation.
 
-Behind the scenes Octopus calls the gcloud cli with the following command to authenticate:
+:::div{.hint}
+The Generic OpenId Connect Account does not have a token lifetime setting. When it is used with Google Cloud the token lifetime defaults to 3600 seconds. To override it, add a project variable named `<account-variable>.OpenIdConnect.TokenLifetimeSeconds` (where `<account-variable>` is the name of the account variable the step references) set to a value between 600 and 43200. If you need a first-class token lifetime setting, use the Google Cloud OpenID Connect Account instead.
+:::
+
+Behind the scenes Octopus calls the gcloud cli with the following command to authenticate. For both OpenID Connect account types the `--service-account-token-lifetime-seconds` value comes from the account's **Token Lifetime** (or the project variable above for a Generic account), and defaults to 3600:
 
 ```bash
 gcloud iam workload-identity-pools create-cred-config \
     <audience> \
     --service-account=<impersonationEmails> \
-    --service-account-token-lifetime-seconds=3600 \
+    --service-account-token-lifetime-seconds=<token-lifetime> \
     --output-file=<jsonAuthFilePath> \
     --credential-source-file=<jwtFilePath> \
     --credential-source-type=text \

--- a/src/pages/docs/projects/variables/google-cloud-account-variables.md
+++ b/src/pages/docs/projects/variables/google-cloud-account-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-29
+modDate: 2026-07-09
 title: Google Cloud account variables
 icon: fa-brands fa-google
 description: Create a Google Cloud account variable to use it in Google Cloud deployment steps
@@ -28,7 +28,10 @@ The Google Cloud account variable also exposes the following properties that you
 
 | Name and description |
 | -------------------- | 
-| **`JsonKey`** <br/> The JSON Key for the Google cloud account|
+| **`JsonKey`** <br/> The JSON Key for the Google Cloud account. <br/> Only set if **Use a Key File** is selected |
+| **`OpenIdConnect.Jwt`** <br/> The JWT identity token for the current task. <br/> Only set if **Use OpenID Connect** is selected |
+| **`Audience`** <br/> The Workload Identity Federation audience. <br/> Only set if **Use OpenID Connect** is selected |
+| **`OpenIdConnect.TokenLifetimeSeconds`** <br/> The lifetime, in seconds, of the federated Google Cloud access token (600–43200, default 3600), passed to gcloud as `--service-account-token-lifetime-seconds`. Set from the account's **Token Lifetime** when **Use OpenID Connect** is selected. A Generic OpenId Connect account has no Token Lifetime setting, so define this variable yourself to override the 3600 default. |
 
 ### Accessing the properties in a script
 
@@ -44,6 +47,10 @@ Write-Host 'GoogleCloudAccount.JsonKey=' $OctopusParameters["google cloud accoun
 # Directly as a variable
 Write-Host 'GoogleCloudAccount.Id=' #{google cloud account}
 Write-Host 'GoogleCloudAccount.JsonKey=' #{google cloud account.JsonKey}
+
+# For an account using OpenID Connect
+Write-Host 'GoogleCloudAccount.OpenIdConnect.Jwt=' #{google cloud account.OpenIdConnect.Jwt}
+Write-Host 'GoogleCloudAccount.OpenIdConnect.TokenLifetimeSeconds=' #{google cloud account.OpenIdConnect.TokenLifetimeSeconds}
 ```
 
 ## Add a Google Cloud account to Octopus

--- a/src/pages/docs/projects/variables/google-cloud-account-variables.md
+++ b/src/pages/docs/projects/variables/google-cloud-account-variables.md
@@ -27,7 +27,7 @@ Select the Google Cloud account you want to access from the project to assign it
 The Google Cloud account variable also exposes the following properties that you can reference in a PowerShell script:
 
 | Name and description |
-| -------------------- | 
+| -------------------- |
 | **`JsonKey`** <br/> The JSON Key for the Google Cloud account. <br/> Only set if **Use a Key File** is selected |
 | **`OpenIdConnect.Jwt`** <br/> The JWT identity token for the current task. <br/> Only set if **Use OpenID Connect** is selected |
 | **`Audience`** <br/> The Workload Identity Federation audience. <br/> Only set if **Use OpenID Connect** is selected |
@@ -58,7 +58,8 @@ Write-Host 'GoogleCloudAccount.OpenIdConnect.TokenLifetimeSeconds=' #{google clo
 For instructions to set up a Google Cloud account in Octopus, see [Google Cloud Accounts](/docs/infrastructure/accounts/google-cloud).
 
 ## Older versions
-* Google Cloud accounts are available from Octopus Deploy **2021.3** onwards.
+
+- Google Cloud accounts are available from Octopus Deploy **2021.3** onwards.
 
 ## Learn more
 


### PR DESCRIPTION
# Background

FD-535 makes the Google Cloud OIDC service-account token lifetime configurable (it was previously hardcoded to 3600 seconds). A Google Cloud account now offers an OpenID Connect authentication method with a **Token Lifetime** setting, and the generic OpenID Connect account no longer carries a token lifetime field.

# Results

Updates the Google Cloud docs to match:

- **`infrastructure/accounts/google-cloud`** : adds the OpenID Connect authentication method, a Token Lifetime section (600–43200 seconds, default 3600) with the GCP org-policy caveat for lifetimes over 1 hour, and a note on overriding the lifetime for a generic OIDC account via a project variable. The example `gcloud` command now shows the configurable value.
- **`projects/variables/google-cloud-account-variables`** : adds the OIDC variables that were missing (`OpenIdConnect.Jwt`, `Audience`, `OpenIdConnect.TokenLifetimeSeconds`), matching the AWS and Azure account-variable docs.

Relates to FD-535. Pairs with OctopusDeploy PR #44767.
