### PR TITLE
fix author pages on the sitemap

### DIFF
--- a/src/pages/docs/sitemap.xml.ts
+++ b/src/pages/docs/sitemap.xml.ts
@@ -18,7 +18,7 @@ async function getData() {
     let url = accelerator.urlFormatter.formatAddress(article.url);
 
     if (article.frontmatter.layout == 'src/layouts/Author.astro') {
-      url += '1/';
+      url += '/1/';
     }
 
     if (addToSitemap) {


### PR DESCRIPTION
Fixes the sitemap author links to be correct. Raised internally [HERE](https://octopusdeploy.slack.com/archives/C03UDS16R6G/p1783277074920859)