### PR TITLE
Update docs to correctly reflect the default target tag set

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/target-tags.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/target-tags.mdx
@@ -48,13 +48,13 @@ Target tag sets are supported from Octopus version 2026.2.2344.
 
 Target tags are now organized into **target tag sets**, which are [tag sets](/docs/tenants/tag-sets) scoped to deployment targets. This gives you a structured way to group related target tags together, just as you can group tags for tenants, environments, projects, and runbooks.
 
-### The [System] Tag Set \{#system-tag-set}
+### The Default Target Tag Set \{#default-target-tag-set}
 
-All existing target tags are automatically migrated into a built-in tag set called **[System] Tag Set**. This set is managed by Octopus and cannot be renamed or deleted.
+All existing target tags are automatically migrated into a built-in tag set called **Default Target Tag Set**. This set is managed by Octopus and cannot be renamed or deleted.
 
 ### Custom target tag sets \{#custom-target-tag-sets}
 
-In addition to the [System] Tag Set, you can create your own target tag sets to organize deployment targets by attributes relevant to your team. For example, you might create a tag set for cloud provider, region, or tier.
+In addition to the Default Target Tag Set, you can create your own target tag sets to organize deployment targets by attributes relevant to your team. For example, you might create a tag set for cloud provider, region, or tier.
 
 To create a custom target tag set:
 


### PR DESCRIPTION
The docs were still referring to the tag set we create as part of the migration for target tags as `[System] Tag Set` but it should be `Default Target Tag Set` instead