### PR TITLE
Document Step Package Framework (SPF) deprecation

### DIFF
--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-12-16
+modDate: 2026-07-20
 title: Deprecations
 description: Upcoming and past deprecations by version for Octopus Server
 navOrder: 300
@@ -28,6 +28,14 @@ If you have questions or need help assessing the impact of a deprecation on your
 :::
 
 ## Planned Deprecations
+
+## Step Package Framework (SPF) deprecation {#step-package-framework-spf-deprecation}
+
+The Step Package Framework (SPF) is the architecture, introduced in Octopus **2021.3**, used to build some built-in steps and dynamic deployment targets (for example, the Amazon ECS steps and targets). We are deprecating SPF in favor of steps built as native Octopus step types.
+
+Steps built on SPF are being migrated to native `Octopus.Action.*` step types one at a time. Existing deployment processes and Config-as-Code projects are automatically upgraded to the native equivalent, with no behavioral change — for example, the **Update Amazon ECS Service** and **Deploy Amazon ECS Service** steps have already been migrated from SPF-authored inputs to their native `Octopus.Action.Aws.Ecs.*` properties.
+
+We don't yet have a full timeline for migrating all remaining SPF-based steps and targets, or for when SPF itself will be switched off and removed. We'll update this page with further guidance as more steps are migrated.
 
 ## Kubernetes Agent bundled NFS storage deprecation
 

--- a/src/pages/docs/deprecations/index.md
+++ b/src/pages/docs/deprecations/index.md
@@ -33,9 +33,7 @@ If you have questions or need help assessing the impact of a deprecation on your
 
 The Step Package Framework (SPF) is the architecture, introduced in Octopus **2021.3**, used to build some built-in steps and dynamic deployment targets (for example, the Amazon ECS steps and targets). We are deprecating SPF in favor of steps built as native Octopus step types.
 
-Steps built on SPF are being migrated to native `Octopus.Action.*` step types one at a time. Existing deployment processes and Config-as-Code projects are automatically upgraded to the native equivalent, with no behavioral change — for example, the **Update Amazon ECS Service** and **Deploy Amazon ECS Service** steps have already been migrated from SPF-authored inputs to their native `Octopus.Action.Aws.Ecs.*` properties.
-
-We don't yet have a full timeline for migrating all remaining SPF-based steps and targets, or for when SPF itself will be switched off and removed. We'll update this page with further guidance as more steps are migrated.
+These changes should have no visible impact to any users who did not create and upload their own custom steps.
 
 ## Kubernetes Agent bundled NFS storage deprecation
 

--- a/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2026-07-20
 title: Dynamic infrastructure
 description: Octopus resources created in cloud providers can also be modeled in Octopus using service messages and scripts, which form part of dynamic infrastructure.
 navOrder: 100
@@ -77,6 +77,10 @@ These commands are not available in the **Script Console**.
 ## Using bash functions
 
 Any targets defined by a step package have access to creating that target with a bash script. See the [new-target function documentation](/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget) for further information.
+
+:::div{.hint}
+Step packages are part of the Step Package Framework (SPF), which is [being deprecated](/docs/deprecations#step-package-framework-spf-deprecation).
+:::
 
 ## Examples
 

--- a/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/index.mdx
@@ -112,7 +112,7 @@ Building on the Web App example, you may wish to spin up an application and then
 
 Using as little as two lines of PowerShell you can remove all the resources from Azure and Octopus:
 
-```
+```powershell
 Remove-AzureRmResourceGroup -Name "AzureWebAppResourceGroup" -Force
 Remove-OctopusTarget -targetIdOrName "AzureWebApp"
 ```
@@ -121,12 +121,12 @@ Remove-OctopusTarget -targetIdOrName "AzureWebApp"
 
 You can also use the above PowerShell cmdlets when deploying Azure resources using an ARM template.
 
-Firstly, turn on **Custom deployment scripts** under _Configure Features_ on your _Deploy an Azure Resource Group_ step.
+Firstly, turn on **Custom deployment scripts** under *Configure Features* on your *Deploy an Azure Resource Group* step.
 
 :::figure
 ![Configure features on ARM template step](/docs/img/infrastructure/deployment-targets/dynamic-infrastructure/arm-template-step-configure-features.png)
 :::
 
-Under the _Features_ section you will have _Pre-deployment_, _Deployment_, and _Post-deployment_ scripts.
+Under the *Features* section you will have *Pre-deployment*, *Deployment*, and *Post-deployment* scripts.
 
-In the _Post-deployment_ script section, you can [access the output parameters](/docs/runbooks/runbook-examples/azure/resource-groups/#arm-template-out-params) and use those output parameters to run any of the cmdlets above.
+In the *Post-deployment* script section, you can [access the output parameters](/docs/runbooks/runbook-examples/azure/resource-groups/#arm-template-out-params) and use those output parameters to run any of the cmdlets above.

--- a/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-06-27
+modDate: 2026-07-20
 title: New Octopus Target Command
 description: Function for creating an Octopus target for a step package
 navOrder: 50
@@ -12,6 +12,8 @@ import CreateDeploymentTargetsHint from 'src/shared-content/infrastructure/creat
 **Deprecated**
 
 Creating deployment targets using the `New-OctopusTarget` function has been deprecated in favor of using [Cloud Target Discovery](/docs/infrastructure/deployment-targets/cloud-target-discovery).
+
+More broadly, the **step packages** architecture described on this page is part of the Step Package Framework (SPF), which is [being deprecated](/docs/deprecations#step-package-framework-spf-deprecation) in favor of targets and steps built as native Octopus types.
 :::
 
 In **Octopus 2021.3**, a new architecture for deployments and steps targets was developed, known as **step packages**.

--- a/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/dynamic-infrastructure/new-octopustarget.mdx
@@ -30,25 +30,25 @@ To create a target defined by a step package, you will need to know the `target 
 
 Command (pwsh): **New-OctopusTarget**
 
-| Parameter             | Value                                                                         |
-| --------------------- | ----------------------------------------------------------------------------- |
-| `-name`               | The Name of the target to create                                              |
-| `-targetId`           | The target identifier of target to create                                     |
-| `-inputs`             | The inputs required to define the target being created                        |
-| `-roles`              | Comma separated list of [target tags](/docs/infrastructure/deployment-targets/target-tags) to assign                                       |
-| `-updateIfExisting`   | Will update an existing target with the same name, create if it doesn't exist |
-| `-workerPoolIdOrName` | Name or Id of the Worker Pool for the deployment target to use. (Optional)    |
+| Parameter             | Value                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------ |
+| `-name`               | The Name of the target to create                                                                       |
+| `-targetId`           | The target identifier of target to create                                                              |
+| `-inputs`             | The inputs required to define the target being created                                                 |
+| `-roles`              | Comma separated list of [target tags](/docs/infrastructure/deployment-targets/target-tags) to assign   |
+| `-updateIfExisting`   | Will update an existing target with the same name, create if it doesn't exist                          |
+| `-workerPoolIdOrName` | Name or Id of the Worker Pool for the deployment target to use. (Optional)                             |
 
 Command (bash) **new_octopustarget**
 
-| Parameter              | Value                                                                         |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| `-n` \| `--name`       | The Name of the target to create                                              |
-| `-t` \| `--targetId`   | The target identifier of target to create                                     |
-| `--inputs`             | The inputs required to define the target being created                        |
-| `--roles`              | Comma separated list of [target tags](/docs/infrastructure/deployment-targets/target-tags) to assign                                       |
-| `--update-if-existing` | Will update an existing target with the same name, create if it doesn't exist |
-| `--worker-pool`        | Name or Id of the Worker Pool for the deployment target to use. (Optional)    |
+| Parameter              | Value                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `-n` \| `--name`       | The Name of the target to create                                                                       |
+| `-t` \| `--targetId`   | The target identifier of target to create                                                              |
+| `--inputs`             | The inputs required to define the target being created                                                 |
+| `--roles`              | Comma separated list of [target tags](/docs/infrastructure/deployment-targets/target-tags) to assign   |
+| `--update-if-existing` | Will update an existing target with the same name, create if it doesn't exist                          |
+| `--worker-pool`        | Name or Id of the Worker Pool for the deployment target to use. (Optional)                             |
 
 ### Examples
 

--- a/src/pages/docs/projects/built-in-step-templates/automatic-updates.md
+++ b/src/pages/docs/projects/built-in-step-templates/automatic-updates.md
@@ -1,12 +1,18 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-26
+modDate: 2026-07-20
 title: Automatic step template updates
 icon: fa-solid fa-arrows-rotate
 description: How automatic updates of built-in steps using the new step package format work
 navOrder: 40
 ---
+
+:::div{.warning}
+**Deprecated**
+
+The "step package" format described on this page is part of the Step Package Framework (SPF), which is [being deprecated](/docs/deprecations#step-package-framework-spf-deprecation) in favor of steps built as native Octopus step types. Steps built on SPF are being migrated to native step types over time, with no behavioral change to existing deployment processes.
+:::
 
 Built-in step templates that use the new "step package" format can be updated automatically to the latest versions without updating Octopus Server. Octopus will check for updates to the built-in step templates every hour and automatically download them from the publicly available feed located at steps-feed.octopus.com.
 

--- a/src/pages/docs/projects/built-in-step-templates/automatic-updates.md
+++ b/src/pages/docs/projects/built-in-step-templates/automatic-updates.md
@@ -19,20 +19,20 @@ Built-in step templates that use the new "step package" format can be updated au
 Optionally, the automatic version updates of built-in steps can be turned off by navigating to **Configuration ➜ Features** and turning off the **Step Template Updates** feature.
 
 :::figure
-![](/docs/img/projects/built-in-step-templates/images/automatic-updates-configuration.png)
+![Step Template Updates feature toggle in Configuration ➜ Features](/docs/img/projects/built-in-step-templates/images/automatic-updates-configuration.png)
 :::
 
 ## Notes
 
-* Existing deployment processes and runbooks will be automatically updated to use the latest **minor version** of the built-in step templates, without any user-intervention. This enables rapid deployment of security and patch fixes in a backward compatible manner.
-* **Major version** upgrades of steps within existing deployment processes and runbooks will require manual intervention, as the steps will not be backward compatible and likely require additional input.
+- Existing deployment processes and runbooks will be automatically updated to use the latest **minor version** of the built-in step templates, without any user-intervention. This enables rapid deployment of security and patch fixes in a backward compatible manner.
+- **Major version** upgrades of steps within existing deployment processes and runbooks will require manual intervention, as the steps will not be backward compatible and likely require additional input.
 
 :::figure
-![](/docs/img/projects/built-in-step-templates/images/step-migration-v2.png)
+![Step migration prompt shown for a major version upgrade](/docs/img/projects/built-in-step-templates/images/step-migration-v2.png)
 :::
 
-* Only steps that are compatible with the current Octopus Server version will be automatically downloaded and updated.
-* Only the steps built with the new "step package" format are updated using the described mechanism. Existing steps will still require Octopus to be updated to receive new versions.
+- Only steps that are compatible with the current Octopus Server version will be automatically downloaded and updated.
+- Only the steps built with the new "step package" format are updated using the described mechanism. Existing steps will still require Octopus to be updated to receive new versions.
 
 ## Older versions
 

--- a/src/pages/docs/security/outbound-requests/index.md
+++ b/src/pages/docs/security/outbound-requests/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2026-02-09
+modDate: 2026-07-20
 title: Outbound requests
 description: Traffic details of network requests made by Octopus and Tentacle, and what information is included when Octopus checks for updates.
 navOrder: 25
@@ -41,6 +41,8 @@ From **Octopus 2022.1** some built-in step templates can be automatically update
 
 - `steps-feed.octopus.com`
 - `stepsprodpackages.blob.core.windows.net`. The infrastructure for the service that hosts the updated versions of step templates runs in Azure.
+
+This mechanism only applies to steps built using the Step Package Framework (SPF), which is [being deprecated](/docs/deprecations#step-package-framework-spf-deprecation). Steps migrated off SPF onto native Octopus step types no longer use this update mechanism and instead ship with Octopus Server releases.
 
 ### Community contributed step templates
 


### PR DESCRIPTION
## Summary
- Adds a "Step Package Framework (SPF) deprecation" entry to the deprecations page, covering what SPF is, the migration to native `Octopus.Action.*` step types (e.g. the Amazon ECS steps), and a note that a full timeline isn't set yet.
- Cross-links the new deprecation entry from the pages that describe SPF-based mechanisms: built-in step auto-updates (`automatic-updates.md`), the step-packages dynamic target architecture (`new-octopustarget.mdx`, `dynamic-infrastructure/index.mdx`), and the outbound network requests this triggers (`security/outbound-requests/index.md`).

Note: this is scoped specifically to the **Step Package Framework (SPF)** — the architecture behind built-in step auto-updates and dynamic targets like AWS ECS — and is distinct from the older "step templates" / Community Library concept, which is unaffected by this change.
