### PR TITLE
Cut docs build time by ~70% (3.7x faster)

### DIFF
--- a/src/components/ArticleHeader.astro
+++ b/src/components/ArticleHeader.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Lang } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('components/ArticleHeader.astro');
 stats.start();
 

--- a/src/components/ArticleJourney.astro
+++ b/src/components/ArticleJourney.astro
@@ -1,11 +1,10 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
-import { SITE } from '@config';
 import { Lang } from '@util/Languages';
+import { journeyOrder } from '@lib/navigationTree';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('components/ArticleJourney.astro');
 stats.start();
 
@@ -21,25 +20,12 @@ const { lang, frontmatter, headings } = Astro.props satisfies Props;
 const _ = Lang(lang);
 
 // Logic
-const articles: NavPage[] = [];
-
-function flatten(pageTree: NavPage[]) {
-  pageTree.sort((a, b) => a.order - b.order);
-  pageTree.forEach((page) => {
-    if (page.children.length == 0) {
-      articles.push(page);
-    } else {
-      flatten(page.children);
-    }
-  });
-}
-
 const currentUrl = new URL(Astro.request.url);
-const pages = accelerator.navigation.autoMenu(SITE.subfolder);
-accelerator.navigation.setCurrentPage(pages, currentUrl);
-flatten(pages);
+const articles = journeyOrder();
 
-const current = articles.findIndex((p) => p.ariaCurrent);
+// Was: setCurrentPage() over a freshly rebuilt tree, then findIndex on the
+// ariaCurrent flag it set. Same predicate, no rebuild.
+const current = articles.findIndex((p) => p.url === currentUrl.pathname);
 
 const previous = articles[current - 1] || null;
 const next = articles[current + 1] || null;

--- a/src/components/ArticleNav.astro
+++ b/src/components/ArticleNav.astro
@@ -1,10 +1,9 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
-import { Accelerator } from 'astro-accelerator-utils';
 import Separator from './Separator.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/ArticleNav.astro');
 stats.start();
 

--- a/src/components/EditOnGithub.astro
+++ b/src/components/EditOnGithub.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Lang, Translations } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/ArticleList.astro'
 );

--- a/src/components/Feedback.astro
+++ b/src/components/Feedback.astro
@@ -1,9 +1,8 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('components/Feedback.astro');
 stats.start();
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { Lang } from '@util/Languages';
 import { SITE } from '@config';
@@ -9,7 +9,6 @@ import OctopusLogo from '../../public/docs/img/OctopusLogo.astro';
 import SunIcon from '../../public/docs/img/SunIcon.astro';
 import MoonIcon from '../../public/docs/img/MoonIcon.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('components/Header.astro');
 stats.start();
 

--- a/src/components/LastUpdated.astro
+++ b/src/components/LastUpdated.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Lang, Translations } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('components/LastUpdated.astro');
 stats.start();
 

--- a/src/components/Related.astro
+++ b/src/components/Related.astro
@@ -1,9 +1,6 @@
 ---
-import {
-  PostFiltering,
-  PostOrdering,
-  Accelerator,
-} from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering, PostOrdering } from 'astro-accelerator-utils';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import type { MarkdownInstance } from 'astro';
@@ -12,7 +9,6 @@ import { getImageInfo } from '@util/custom-markdown.mjs';
 
 import AuthorsMini from '@components/AuthorsMini.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('components/Related.astro');
 stats.start();
 

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -1,5 +1,6 @@
 ---
-import { Accelerator, PostFiltering } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering } from 'astro-accelerator-utils';
 import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { getImageInfo } from '@util/custom-markdown.mjs';
@@ -42,8 +43,6 @@ const lang = frontmatter.lang ?? SITE.default.lang;
 const textDirection = frontmatter.dir ?? SITE.default.dir;
 
 // Logic
-const accelerator = new Accelerator(SITE);
-
 const metaImage = frontmatter.bannerImage
   ? getImageInfo(frontmatter.bannerImage.src, '', SITE.images.contentSize)
   : null;

--- a/src/lib/accelerator.ts
+++ b/src/lib/accelerator.ts
@@ -1,0 +1,65 @@
+import { Accelerator } from 'astro-accelerator-utils';
+import { SITE } from '@config';
+
+// Shared, memoized Accelerator for the whole build process.
+//
+// Every getter on Accelerator constructs a brand new helper on each property
+// access, and Posts.all() round-trips the entire page set through a ~1.1 MB
+// JSON file on disk (readFileSync + JSON.parse) on every single call. With
+// ~1,270 content pages and 6-8 call sites per page that measured at ~23s of
+// the build, all of it recomputing an identical answer.
+//
+// Nothing here changes behaviour: the page set is fixed for the duration of a
+// build, so one snapshot is correct for every page.
+
+const accelerator = new Accelerator(SITE);
+
+// Capture the originals *before* shadowing, so the prototype getters still run
+// once each and see the real (unmemoized) dependencies.
+const cache = accelerator.cache;
+const urlFormatter = accelerator.urlFormatter;
+const markdown = accelerator.markdown;
+const dateFormatter = accelerator.dateFormatter;
+const posts = accelerator.posts;
+
+// Resolved lazily, never at module-init time: Posts.all() runs an eager
+// import.meta.glob over every page, so forcing it during module init would
+// pull page modules in before their own imports have finished initialising and
+// hand back undefined entries.
+//
+// Navigation.breadcrumbs() splices the array it is handed, so return a fresh
+// shallow copy each call. Copying 2,700 references is microseconds; parsing
+// 1.1 MB of JSON is ~18 ms.
+// Builds only. In dev the page set changes under you, so keep reading through.
+const readAll = posts.all.bind(posts);
+let allPosts: ReturnType<typeof readAll> | null = null;
+
+if (import.meta.env.PROD) {
+  posts.all = () => {
+    if (allPosts === null) allPosts = readAll();
+    return allPosts.slice();
+  };
+}
+
+const shadow = (key: string, value: unknown) =>
+  Object.defineProperty(accelerator, key, { get: () => value });
+
+shadow('cache', cache);
+shadow('urlFormatter', urlFormatter);
+shadow('markdown', markdown);
+shadow('dateFormatter', dateFormatter);
+shadow('posts', posts);
+
+// These read this.posts / this.cache / this.urlFormatter, so they must be
+// built after the shadows above are in place.
+const taxonomy = accelerator.taxonomy;
+shadow('taxonomy', taxonomy);
+
+const navigation = accelerator.navigation;
+shadow('navigation', navigation);
+
+const authors = accelerator.authors;
+shadow('authors', authors);
+
+export { accelerator };
+export default accelerator;

--- a/src/lib/accelerator.ts
+++ b/src/lib/accelerator.ts
@@ -9,13 +9,13 @@ import { SITE } from '@config';
 // ~1,270 content pages and 6-8 call sites per page that measured at ~23s of
 // the build, all of it recomputing an identical answer.
 //
-// Nothing here changes behaviour: the page set is fixed for the duration of a
+// Nothing here changes behavior: the page set is fixed for the duration of a
 // build, so one snapshot is correct for every page.
 
 const accelerator = new Accelerator(SITE);
 
 // Capture the originals *before* shadowing, so the prototype getters still run
-// once each and see the real (unmemoized) dependencies.
+// once each and see the real dependencies.
 const cache = accelerator.cache;
 const urlFormatter = accelerator.urlFormatter;
 const markdown = accelerator.markdown;
@@ -24,7 +24,7 @@ const posts = accelerator.posts;
 
 // Resolved lazily, never at module-init time: Posts.all() runs an eager
 // import.meta.glob over every page, so forcing it during module init would
-// pull page modules in before their own imports have finished initialising and
+// pull page modules in before their own imports have finished initializing and
 // hand back undefined entries.
 //
 // Navigation.breadcrumbs() splices the array it is handed, so return a fresh

--- a/src/lib/navigationTree.ts
+++ b/src/lib/navigationTree.ts
@@ -1,0 +1,64 @@
+import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
+import { SITE } from '@config';
+import { menu } from '@data/navigation';
+import { accelerator } from './accelerator';
+
+// Navigation.autoMenu() rebuilds the whole site nav tree from all ~2,700 pages
+// on every page render, and its getChildren() runs a full scan of that page
+// list at every node - O(n^2) per page. That measured at ~82s of a ~196s
+// build, by far the single largest cost.
+//
+// The tree itself is identical for every page. Only the isOpen / ariaCurrent
+// flags vary, and those are cheap to recompute. So build the tree once per
+// process and let callers derive their own view of it.
+//
+// Built against a URL that matches no page so the template starts neutral;
+// callers overwrite every flag anyway via applyCurrentPage().
+const TEMPLATE_URL = new URL('https://octopus.com/__nav-template__');
+
+let template: NavPage[] | null = null;
+
+export function menuTemplate(): NavPage[] {
+  // Builds only. In dev, rebuild every time so a new or renamed page shows up
+  // in the nav without restarting the server.
+  if (!import.meta.env.PROD) {
+    return accelerator.navigation.menu(TEMPLATE_URL, SITE.subfolder, menu);
+  }
+  if (template === null) {
+    template = accelerator.navigation.menu(TEMPLATE_URL, SITE.subfolder, menu);
+  }
+  return template;
+}
+
+// The prev/next "article journey" is the nav tree flattened to its leaves in
+// menu order. Like the tree itself this is the same for every page - only the
+// reader's position in it changes - so build it once. Cloned first because
+// flattening sorts each level in place and the template must stay untouched.
+let journey: NavPage[] | null = null;
+
+export function journeyOrder(): NavPage[] {
+  if (journey !== null && import.meta.env.PROD) return journey;
+
+  const leaves: NavPage[] = [];
+  const flatten = (nodes: NavPage[]) => {
+    nodes.sort((a, b) => a.order - b.order);
+    for (const node of nodes) {
+      if (node.children.length === 0) leaves.push(node);
+      else flatten(node.children);
+    }
+  };
+  flatten(structuredClone(menuTemplate()));
+
+  if (import.meta.env.PROD) journey = leaves;
+  return leaves;
+}
+
+// Mirrors Navigation.setCurrentPage() in astro-accelerator-utils. Assigns
+// unconditionally, so it is safe to run over cloned nodes carrying stale flags.
+export function applyCurrentPage(pages: NavPage[], currentUrl: URL): void {
+  for (const page of pages) {
+    page.isOpen = currentUrl.pathname.startsWith(page.url);
+    page.ariaCurrent = page.url === currentUrl.pathname ? 'page' : false;
+    if (page.children) applyCurrentPage(page.children, currentUrl);
+  }
+}

--- a/src/pages/docs/category/[category]/[page].astro
+++ b/src/pages/docs/category/[category]/[page].astro
@@ -2,11 +2,8 @@
 // warning: This file is overwritten by Astro Accelerator
 
 // For listing by frontmatter.categories
-import {
-  PostFiltering,
-  PostOrdering,
-  Accelerator,
-} from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering, PostOrdering } from 'astro-accelerator-utils';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import type { MarkdownInstance } from 'astro-accelerator-utils/types/Astro';
 import type { Page } from 'astro';
@@ -16,7 +13,6 @@ import Default from 'src/layouts/Default.astro';
 import ArticleList from '@components/ArticleList.astro';
 import PagingLinks from '@components/PagingLinks.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'pages/authors/[category]/[page].astro'
 );

--- a/src/pages/docs/llms-full.txt.ts
+++ b/src/pages/docs/llms-full.txt.ts
@@ -1,5 +1,5 @@
+import { accelerator } from '@lib/accelerator';
 import { SITE } from '@config';
-import { Accelerator } from 'astro-accelerator-utils';
 import {
   compareForLlmSurfaces,
   eligibleForMarkdown,
@@ -22,7 +22,6 @@ const raws = import.meta.glob<string>(['./**/*.md', './**/*.mdx'], {
 const subfolderPrefix = SITE.subfolder.replace(/\/$/, '') + '/';
 
 async function getData() {
-  const accelerator = new Accelerator(SITE);
   const entries: {
     body: string;
     slug: string;

--- a/src/pages/docs/llms.txt.ts
+++ b/src/pages/docs/llms.txt.ts
@@ -1,7 +1,7 @@
 // Generates llms.txt per https://llmstxt.org
 
+import { accelerator } from '@lib/accelerator';
 import { SITE } from '@config';
-import { Accelerator } from 'astro-accelerator-utils';
 import {
   compareForLlmSurfaces,
   eligibleForMarkdown,
@@ -19,7 +19,6 @@ const allRaws = import.meta.glob<string>(['./**/*.md', './**/*.mdx'], {
 });
 
 async function getData() {
-  const accelerator = new Accelerator(SITE);
   const subfolderPrefix = SITE.subfolder.replace(/\/$/, '') + '/';
 
   type Page = {

--- a/src/pages/docs/search.json.ts
+++ b/src/pages/docs/search.json.ts
@@ -2,7 +2,8 @@
 
 // warning: This file is overwritten by Astro Accelerator
 
-import { Accelerator, PostFiltering } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering } from 'astro-accelerator-utils';
 import type { MarkdownInstance } from 'astro';
 import { SITE } from '@config';
 import { convert } from 'html-to-text';
@@ -12,8 +13,6 @@ const getData = async () => {
   //@ts-ignore
   const allPages = import.meta.glob(['./**/*.md', './**/*.mdx']);
   const items = [];
-
-  const accelerator = new Accelerator(SITE);
 
   for (const path in allPages) {
     const page = (await allPages[path]()) as MarkdownInstance<Record<string, any>>;

--- a/src/pages/docs/sitemap.xml.ts
+++ b/src/pages/docs/sitemap.xml.ts
@@ -1,14 +1,14 @@
 // warning: This file is overwritten by Astro Accelerator
 
 // Generates an ATOM feed of recent posts
+import { accelerator } from '@lib/accelerator';
 import { SITE } from '@config';
-import { PostFiltering, Accelerator } from 'astro-accelerator-utils';
+import { PostFiltering } from 'astro-accelerator-utils';
 
 async function getData() {
   //@ts-ignore
   const allPages = import.meta.glob(['./**/*.md', './**/*.mdx']);
 
-  const accelerator = new Accelerator(SITE);
   let pages = [];
 
   for (const path in allPages) {

--- a/src/pages/docs/tag/[tag]/[page].astro
+++ b/src/pages/docs/tag/[tag]/[page].astro
@@ -2,11 +2,8 @@
 // warning: This file is overwritten by Astro Accelerator
 
 // For listing by frontmatter.tags
-import {
-  PostFiltering,
-  PostOrdering,
-  Accelerator,
-} from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering, PostOrdering } from 'astro-accelerator-utils';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import type { MarkdownInstance } from 'astro-accelerator-utils/types/Astro';
 import type { Page } from 'astro';
@@ -16,7 +13,6 @@ import Default from 'src/layouts/Default.astro';
 import ArticleList from '@components/ArticleList.astro';
 import PagingLinks from '@components/PagingLinks.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('pages/authors/[tag]/[page].astro');
 stats.start();
 

--- a/src/pages/report/missing-banner.astro
+++ b/src/pages/report/missing-banner.astro
@@ -1,9 +1,9 @@
 ---
-import { PostOrdering, Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostOrdering } from 'astro-accelerator-utils';
 import { SITE } from '@config';
 
 // Logic
-const accelerator = new Accelerator(SITE);
 
 const allPages = accelerator.posts.all();
 const missingBanner = allPages.filter(

--- a/src/pages/report/missing-meta.astro
+++ b/src/pages/report/missing-meta.astro
@@ -1,9 +1,9 @@
 ---
-import { PostOrdering, Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostOrdering } from 'astro-accelerator-utils';
 import { SITE } from '@config';
 
 // Logic
-const accelerator = new Accelerator(SITE);
 
 const allPages = accelerator.posts.all();
 const missingMeta = allPages.filter(

--- a/src/pages/report/missing-pubdate.astro
+++ b/src/pages/report/missing-pubdate.astro
@@ -1,9 +1,8 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import { SITE } from '@config';
 
 // Logic
-const accelerator = new Accelerator(SITE);
 
 const allPages = accelerator.posts.all();
 const missingMeta = allPages.filter(

--- a/src/pages/report/oldest-content/[page].astro
+++ b/src/pages/report/oldest-content/[page].astro
@@ -1,9 +1,6 @@
 ---
-import {
-  PostOrdering,
-  PostFiltering,
-  Accelerator,
-} from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostOrdering, PostFiltering } from 'astro-accelerator-utils';
 import type { MarkdownInstance } from 'astro-accelerator-utils/types/Astro';
 import type { Page } from 'astro';
 import { SITE } from '@config';
@@ -20,14 +17,12 @@ const { page } = Astro.props satisfies Props;
 const lang = SITE.default.lang;
 
 // Logic
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'report/oldest-content/[page].astro'
 );
 stats.start();
 
 export async function getData() {
-  const accelerator = new Accelerator(SITE);
   const allPages = accelerator.posts.all();
   const pageCount = allPages.length;
   const pages = allPages

--- a/src/pages/report/taxonomy.astro
+++ b/src/pages/report/taxonomy.astro
@@ -1,5 +1,5 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import { Lang } from '@util/Languages';
 import { Translations } from '@util/Languages';
 import { SITE } from '@config';
@@ -8,7 +8,6 @@ import { SITE } from '@config';
 const _ = Lang('en');
 
 // Logic
-const accelerator = new Accelerator(SITE);
 
 const links = accelerator.taxonomy.links(Translations, _, SITE.subfolder);
 const entries = accelerator.taxonomy.all();

--- a/src/themes/octopus/components/ArticleList.astro
+++ b/src/themes/octopus/components/ArticleList.astro
@@ -1,12 +1,11 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import type { MarkdownInstance } from 'astro';
 import { SITE } from '@config';
 import { getImageInfo } from '@util/custom-markdown.mjs';
 import AuthorsMini from '@components/AuthorsMini.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/ArticleList.astro'
 );

--- a/src/themes/octopus/components/Authors.astro
+++ b/src/themes/octopus/components/Authors.astro
@@ -1,11 +1,10 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
 import { getImageInfo } from '@util/custom-markdown.mjs';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Authors.astro');
 stats.start();
 

--- a/src/themes/octopus/components/AuthorsMini.astro
+++ b/src/themes/octopus/components/AuthorsMini.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/AuthorsMini.astro'
 );

--- a/src/themes/octopus/components/Breadcrumbs.astro
+++ b/src/themes/octopus/components/Breadcrumbs.astro
@@ -1,5 +1,5 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
@@ -9,7 +9,6 @@ type Frontmatter = OriginalFrontmatter & {
   crumbTitle?: string;
 };
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/Breadcrumbs.astro'
 );

--- a/src/themes/octopus/components/Copyright.astro
+++ b/src/themes/octopus/components/Copyright.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Copyright.astro');
 stats.start();
 

--- a/src/themes/octopus/components/Footer.astro
+++ b/src/themes/octopus/components/Footer.astro
@@ -1,12 +1,11 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
 import { menu } from 'src/data/footer';
 import FooterItem from '@components/FooterItem.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Footer.astro');
 stats.start();
 

--- a/src/themes/octopus/components/FooterItem.astro
+++ b/src/themes/octopus/components/FooterItem.astro
@@ -1,9 +1,8 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
-import { Accelerator } from 'astro-accelerator-utils';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/FooterItem.astro');
 stats.start();
 

--- a/src/themes/octopus/components/Header.astro
+++ b/src/themes/octopus/components/Header.astro
@@ -1,10 +1,10 @@
 ---
-import { PostFiltering, Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering } from 'astro-accelerator-utils';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Header.astro');
 stats.start();
 

--- a/src/themes/octopus/components/HtmlHead.astro
+++ b/src/themes/octopus/components/HtmlHead.astro
@@ -1,12 +1,11 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE, OPEN_GRAPH, HEADER_SCRIPTS } from '@config';
 import { getEligibleSlugs } from '@util/mdxContent';
 import JsonLd from '@components/JsonLd.astro';
 import { ASSETS, ASSETS_ORIGIN } from 'src/lib/sharedNavbarFooter';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/HtmlHead.astro');
 stats.start();
 

--- a/src/themes/octopus/components/Navigation.astro
+++ b/src/themes/octopus/components/Navigation.astro
@@ -1,12 +1,10 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
 import { Translations, Lang } from '@util/Languages';
-import { menu } from '@data/navigation';
 import NavigationItem from '@components/NavigationItem.astro';
-import { SITE } from '@config';
+import { applyCurrentPage, menuTemplate } from '@lib/navigationTree';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Navigation.astro');
 stats.start();
 
@@ -18,7 +16,6 @@ const { lang } = Astro.props satisfies Props;
 const _ = Lang(lang);
 
 const currentUrl = new URL(Astro.request.url);
-const pages = accelerator.navigation.menu(currentUrl, SITE.subfolder, menu);
 
 // Expand the current section in place; collapse every other section to a
 // labelled link.
@@ -37,15 +34,25 @@ function markActiveBranchOpen(items: NavPage[]): void {
   }
 }
 
+// Only the branch the reader is inside is ever rendered expanded, so clone
+// that one branch off the shared template rather than rebuilding the whole
+// tree per page.
+const pages: NavPage[] = menuTemplate().map((top) => {
+  const hasChildren = (top.children?.length ?? 0) > 0;
+  const expand = hasChildren && isOnActivePath(top);
+  return {
+    ...top,
+    title: hasChildren && !expand && top.section ? top.section : top.title,
+    children: expand ? structuredClone(top.children) : [],
+  };
+});
+
+applyCurrentPage(pages, currentUrl);
+
 for (const top of pages) {
-  if (top.children && top.children.length > 0) {
-    if (isOnActivePath(top)) {
-      top.isOpen = true;
-      markActiveBranchOpen(top.children);
-    } else {
-      if (top.section) top.title = top.section;
-      top.children = [];
-    }
+  if (top.children.length > 0) {
+    top.isOpen = true;
+    markActiveBranchOpen(top.children);
   }
 }
 

--- a/src/themes/octopus/components/NavigationBar.astro
+++ b/src/themes/octopus/components/NavigationBar.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import { Translations, Lang } from '@util/Languages';
 import { SITE } from '@config';
 import { menu } from '@data/navigation';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/NavigationBar.astro'
 );

--- a/src/themes/octopus/components/NavigationItem.astro
+++ b/src/themes/octopus/components/NavigationItem.astro
@@ -1,9 +1,8 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/NavigationItem.astro'
 );
@@ -24,6 +23,7 @@ const displayLink = page.title != null;
 
 stats.stop();
 ---
+
 {
   displayLink && page.children.length == 0 && (
     <li class="site-nav__list-item">

--- a/src/themes/octopus/components/PagingLinks.astro
+++ b/src/themes/octopus/components/PagingLinks.astro
@@ -1,11 +1,10 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Link } from 'astro-accelerator-utils/lib/v1/paging.mjs';
 import { SITE } from '@config';
 import type { MarkdownInstance, Page } from 'astro';
 import { Translations, Lang } from '@util/Languages';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/PagingLinks.astro'
 );

--- a/src/themes/octopus/components/RecentlyUpdated.astro
+++ b/src/themes/octopus/components/RecentlyUpdated.astro
@@ -1,12 +1,8 @@
 ---
-import {
-  PostOrdering,
-  PostFiltering,
-  Accelerator,
-} from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostOrdering, PostFiltering } from 'astro-accelerator-utils';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/RecentlyUpdated.astro'
 );

--- a/src/themes/octopus/components/Related.astro
+++ b/src/themes/octopus/components/Related.astro
@@ -1,9 +1,6 @@
 ---
-import {
-  PostFiltering,
-  PostOrdering,
-  Accelerator,
-} from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering, PostOrdering } from 'astro-accelerator-utils';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import type { MarkdownInstance } from 'astro';
@@ -11,7 +8,6 @@ import { getImageInfo } from '@util/custom-markdown.mjs';
 
 import AuthorsMini from '@components/AuthorsMini.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Related.astro');
 stats.start();
 

--- a/src/themes/octopus/components/Search.astro
+++ b/src/themes/octopus/components/Search.astro
@@ -1,9 +1,9 @@
 ---
-import { Accelerator, PostFiltering } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
+import { PostFiltering } from 'astro-accelerator-utils';
 import { Translations, Lang } from '@util/Languages';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Search.astro');
 stats.start();
 

--- a/src/themes/octopus/components/SkipLinks.astro
+++ b/src/themes/octopus/components/SkipLinks.astro
@@ -1,10 +1,9 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { Translations, Lang } from '@util/Languages';
-import { Accelerator } from 'astro-accelerator-utils';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/SkipLinks.astro');
 stats.start();
 

--- a/src/themes/octopus/components/TableOfContents.astro
+++ b/src/themes/octopus/components/TableOfContents.astro
@@ -1,10 +1,9 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
-import { Accelerator } from 'astro-accelerator-utils';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics(
   'octopus/components/TableOfContents.astro'
 );

--- a/src/themes/octopus/components/Taxonomy.astro
+++ b/src/themes/octopus/components/Taxonomy.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { Translations, Lang } from '@util/Languages';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/components/Taxonomy.astro');
 stats.start();
 

--- a/src/themes/octopus/layouts/Author.astro
+++ b/src/themes/octopus/layouts/Author.astro
@@ -1,10 +1,9 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import Redirect from './Redirect.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/layouts/Author.astro');
 stats.start();
 

--- a/src/themes/octopus/layouts/Default.astro
+++ b/src/themes/octopus/layouts/Default.astro
@@ -1,5 +1,5 @@
 ---
-import { Accelerator } from 'astro-accelerator-utils';
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { getImageInfo } from '@util/custom-markdown.mjs';
 import { SITE } from '@config';
@@ -15,7 +15,6 @@ import Authors from '@components/Authors.astro';
 import Taxonomy from '@components/Taxonomy.astro';
 import Related from '@components/Related.astro';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/layouts/Default.astro');
 stats.start();
 

--- a/src/themes/octopus/layouts/Redirect.astro
+++ b/src/themes/octopus/layouts/Redirect.astro
@@ -1,9 +1,8 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
-import { Accelerator } from 'astro-accelerator-utils';
 import { SITE } from '@config';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/layouts/Redirect.astro');
 stats.start();
 

--- a/src/themes/octopus/layouts/Search.astro
+++ b/src/themes/octopus/layouts/Search.astro
@@ -1,11 +1,10 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
 import Default from './Default.astro';
-import { Accelerator } from 'astro-accelerator-utils';
 
-const accelerator = new Accelerator(SITE);
 const stats = new accelerator.statistics('octopus/layouts/Search.astro');
 stats.start();
 

--- a/src/themes/octopus/utilities/mdxContent.ts
+++ b/src/themes/octopus/utilities/mdxContent.ts
@@ -59,9 +59,18 @@ function globKeyToSlug(globKey: string): string | null {
   return relPathToSlug(m[1]);
 }
 
-// No memoization: dev edits to docs frontmatter must be reflected without
-// a server restart. The walk is sub-second on the current corpus.
+// Memoized for builds only: CopyMarkdown.astro calls this on every page, and
+// the walk re-parses frontmatter for all ~2,660 docs pages each time (~23ms x
+// ~1,270 pages ≈ 29s of build time). During a build the corpus cannot change,
+// so one pass is enough. In dev it stays uncached so edits to docs frontmatter
+// are reflected without a server restart.
+let eligibleSlugsCache: Set<string> | null = null;
+
 export function getEligibleSlugs(): Set<string> {
+  if (import.meta.env.PROD && eligibleSlugsCache !== null) {
+    return eligibleSlugsCache;
+  }
+
   const slugs = new Set<string>();
   for (const path in docPageRaws) {
     const raw = docPageRaws[path];
@@ -73,6 +82,8 @@ export function getEligibleSlugs(): Set<string> {
     if (!slug) continue;
     slugs.add(slug);
   }
+
+  if (import.meta.env.PROD) eligibleSlugsCache = slugs;
 
   return slugs;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "@config": ["src/config"],
         // Layouts and components for the theme
         "@data/*": ["src/data/*"],
+        "@lib/*": ["src/lib/*"],
         "@util/*": ["src/themes/octopus/utilities/*"],
         "@layouts/*": ["src/themes/octopus/layouts/*"],
         "@components/*": ["src/themes/octopus/components/*"],


### PR DESCRIPTION
I was unhappy with how long it takes to build our docs site. I prompted claude with the following and let it run.

> I am unhappy with how long it takes to build the docs site. It is built using pnpm build; more details are in the README.md file.
We upgraded to astro 7 and I was expecting a bigger performance uplift. I suspect that some plugins or customisations we've made might be bottlenecking it and slowing things down. Additionally I notice when the build process runs it doesn't seem to use more than a single CPU core.
Can you help figure out what is affecting the build performance. If you can, try and put the repo in a vanilla astro state (no plugins/customisations) but still has a successful build; then binary search the plugin space and tell me where the time is going and what we could do to improve it. Also consider that I may be wrong and it may not be plugins, but I'd like to understand where the time is going

It investigated many things and made some meaningful changes. 

Numbers from GitHub actions:

In a previous PR, the "Astro build and test" phase took **9 minutes 22 seconds**
In this PR, the "Astro build and test" phase took **4 minutes 44 seconds**

While we don't see a 70% reduction there, note that it's including the tests as well, which weren't part of the optimization.

The rest of the PR description beyond this point is written by Claude; I asked it to summarize the changes it made, and provide evidence as to why this change was safe.

-----------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

`pnpm build` is now **~3.7x faster — about 73% less wall-clock time**, with byte-identical output.

Measured across six full builds on one machine (16-core macOS, Node 24): **190.9s → 51.8s** mean, a 3.53x–3.87x range run to run. Absolute numbers will differ on your hardware and in CI; the ratio is the portable figure. The phase that shrank is static route generation: **157s → 17.5s (~9x)**.

The cause was not plugins or Astro 7. ~78% of the build was three pieces of per-page code recomputing data that is identical for every page.

## Where the time went

Profiled a full build with `node --cpu-prof`. Of ~198s:

| Cost | Time | Share |
|---|---|---|
| `Navigation.autoMenu()` → `getChildren()` | **95.2s** | 48% |
| `getEligibleSlugs()` in `CopyMarkdown.astro` | **29.0s** | 15% |
| `Posts.all()` → disk cache `readFileSync` + `JSON.parse` | **22.9s** | 12% |
| markdown/MDX compile (micromark, remark, shiki) | 26.5s | 13% |
| vite/rolldown/esbuild bundling | 20.0s | 10% |
| copying the 609 MB `public/` dir | 5.2s | 3% |

Per-page render times were bimodal: 1,408 redirect pages at ~1ms, and 1,270 content pages at **~120ms each**. Everything above lives in that 120ms.

The three culprits:

1. **`astro-accelerator-utils` `Navigation.getChildren()`** is recursive and runs a full scan of all ~2,700 pages *at every node* — O(n²) per page, for a tree that is identical on every page. Called twice per page: from `Navigation.astro`, and from `ArticleJourney.astro` (which flattens the whole tree just to find prev/next links).
2. **`getEligibleSlugs()`** re-parses frontmatter for all 2,661 docs pages on every page render. Its comment said "No memoization… the walk is sub-second" — true per call, but it's called 1,270 times.
3. **`Posts.all()`** has no in-memory cache. It round-trips the entire page set through `.cache/v1_posts.all.json` (1.1 MB) — `readFileSync` + `JSON.parse` — on *every* call, 6–8 times per page. `Accelerator`'s getters also construct a brand-new `Posts`/`Cache`/`Navigation` on every property access, so memoization was impossible by design.

**It isn't the plugins.** Swapping `Default.astro` for a bare `<html><slot/></html>` while keeping every integration (mdx, the custom remark processor, shiki, `llm-md-emitter`) builds in 39.8s on the same machine — i.e. the plugin surface plus content compilation is ~77% of what the build now costs, and we're within ~12s of that floor. `llm-md-emitter` costs about 1s.

## What changed

- **`src/lib/accelerator.ts`** (new) — one shared `Accelerator` per process with memoized helpers and a memoized `posts.all()`. Returns a shallow copy per call because `Navigation.breadcrumbs()` splices the array it's given. Resolved lazily; see the gotcha below.
- **`src/lib/navigationTree.ts`** (new) — builds the nav tree once. `Navigation.astro` clones only the branch the reader is in (every other section renders collapsed anyway) and recomputes `isOpen`/`ariaCurrent` itself. `ArticleJourney.astro` indexes into a pre-flattened leaf list.
- **`mdxContent.ts`** — memoized `getEligibleSlugs()`.
- 43 files mechanically switched from `new Accelerator(SITE)` to the shared import.

All three memoizations are gated on `import.meta.env.PROD`, so `astro dev` keeps its current always-fresh behaviour — adding or renaming a page still updates the nav without a server restart.

## How to gain confidence this isn't breaking

This is a pure-performance change, so the bar is that the site is *identical*, not merely working. Three independent checks:

**1. Byte-for-byte output comparison — the main one.** I built `main` and this branch and compared every generated file:

```
main: 3953 files | branch: 3953 files | only-main: 0 | only-branch: 0
DIFFERING: 0
```

That covers all 2,697 HTML pages plus the 1,252 emitted per-page `.md` files, `llms.txt`, `llms-full.txt`, `sitemap.xml` and `search.json`. The only normalisation applied was the footer's `data-shared-note="fetched … at <timestamp>"` attribute, which already differs between any two builds of `main` because the footer is fetched live at build time.

To reproduce:

```bash
git checkout main && rm -rf .cache && pnpm build && cp -r dist /tmp/out-main
git checkout perf/build-investigation && rm -rf .cache && pnpm build
diff -rq /tmp/out-main dist   # only the footer timestamp should differ
```

**2. Playwright suite: 90/90 passing**, including `redirect.spec.ts` which checks all **1,389 redirects**, and `llm-endpoints.spec.ts` which independently verifies that the emitted `.md` set, the `CopyMarkdown` dropdown and the `llms.txt` slug set all still agree — that's a direct check on the `getEligibleSlugs()` memoization.

**3. Reasoning about the risky bits.** The two places where shared state could realistically leak between pages:

- `posts.all()` now returns a snapshot. `Navigation.breadcrumbs()` **splices the array it receives**, which is why `all()` hands out `.slice()` rather than the array itself. Copying 2,700 references is microseconds; parsing 1.1 MB of JSON is ~18ms.
- The nav template is shared read-only. `Navigation.astro` spreads each top-level node and `structuredClone`s only the expanded branch before touching any flags; `journeyOrder()` clones before flattening, because flattening sorts each level in place.

If you want more assurance than the byte diff, the highest-value manual spot-check is the left-hand nav on a deep page (correct section expanded, correct item highlighted, others collapsed to their section label) and the prev/next links at the bottom of an article — those are the two components whose logic actually changed.

## Notes for review

- **A gotcha worth knowing.** My first attempt resolved `posts.all()` at module-init time and broke the build: `Posts.all()` runs an eager `import.meta.glob` over every page, so forcing it during module init pulls page modules in before their own imports have initialised, yielding `undefined` entries. Worse, those got written to `.cache/v1_posts.all.json`, and the *next* build read them back as `null` and failed in an unrelated file. It's resolved lazily now, but it shows `.cache/` can poison a subsequent build.
- **`.cache/` is arguably dead weight now.** It persists between builds with a 200-second TTL (`cacheMaxAge` in `src/config.ts`), which also means any build slower than 200s expired its own cache mid-flight and rewrote it. With `posts.all()` memoized in-process it no longer does anything useful for the build. Removing it would be a reasonable follow-up, but it's out of scope here.
- **On the single-core observation.** Astro's `build.concurrency` defaults to `1`, but raising it barely helps: at `concurrency: 8` I measured 50.1s vs 50.7s and still only ~117% CPU. Page rendering is synchronous single-threaded JS, so concurrency only overlaps the async parts. Output was identical, so it's safe if you want the ~3s, but I left it out to keep this diff focused.
- **Remaining profile is flat** — markdown compile 23.4s, bundling 17.6s, asset copy 4.2s. No hotspot left worth chasing. The next-largest lever would be the 609 MB `public/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)