### PR TITLE
Consume design tokens as CSS custom properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dependencies": {
         "@astrojs/markdown-remark": "7.2.1",
         "@astrojs/mdx": "^7.0.3",
+        "@octopusdeploy/design-system-tokens": "^2026.3.8240",
         "astro": "^7.0.9",
         "astro-accelerator-utils": "^0.3.84",
         "glob": "^13.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^7.0.3
         version: 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(rollup@4.60.3)(yaml@2.8.4))
+      '@octopusdeploy/design-system-tokens':
+        specifier: ^2026.3.8240
+        version: 2026.3.8240
       astro:
         specifier: ^7.0.9
         version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(rollup@4.60.3)(yaml@2.8.4)
@@ -813,6 +816,9 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@octopusdeploy/design-system-tokens@2026.3.8240':
+    resolution: {integrity: sha512-SxabL5Y2bDD0kEEEtVUtTos3tiJ+2FEWTno1a40YVw/Y5eUbRnXUTChf4oVsRzw32GXpjBhxoTxiOBdOceeelA==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -3928,6 +3934,8 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@octopusdeploy/design-system-tokens@2026.3.8240': {}
 
   '@oslojs/encoding@1.1.0': {}
 

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -70,9 +70,9 @@ const isSearchPage =
 const showSearch = !isSearchPage;
 ---
 
-<html dir={textDirection} lang={lang} class="initial">
+<html dir={textDirection} lang={lang} class="initial" data-theme="light">
   <Head frontmatter={frontmatter} headings={headings} lang={lang} />
-  <body data-theme="dark">
+  <body>
     <SkipLinks frontmatter={frontmatter} headings={headings} lang={lang} />
     <Header
       frontmatter={frontmatter}

--- a/src/themes/octopus/components/HtmlHead.astro
+++ b/src/themes/octopus/components/HtmlHead.astro
@@ -6,6 +6,14 @@ import { getEligibleSlugs } from '@util/mdxContent';
 import JsonLd from '@components/JsonLd.astro';
 import { ASSETS, ASSETS_ORIGIN } from 'src/lib/sharedNavbarFooter';
 
+// Design tokens as CSS custom properties. globals and textTheme apply at :root;
+// lightTheme and darkTheme are selected by the data-theme attribute set on
+// <html> by the inline theme script in HEADER_SCRIPTS.
+import '@octopusdeploy/design-system-tokens/css/globals.css';
+import '@octopusdeploy/design-system-tokens/css/textTheme.css';
+import '@octopusdeploy/design-system-tokens/css/lightTheme.css';
+import '@octopusdeploy/design-system-tokens/css/darkTheme.css';
+
 const stats = new accelerator.statistics('octopus/components/HtmlHead.astro');
 stats.start();
 


### PR DESCRIPTION
## What

[`@octopusdeploy/design-system-tokens`](https://www.npmjs.com/package/@octopusdeploy/design-system-tokens) now ships its tokens as four stylesheets (added in [OctopusDeploy/OctopusDeploy#45543](https://github.com/OctopusDeploy/OctopusDeploy/pull/45543)). This site is Astro with no React runtime, so it has no `Theme` component to paint them and the package's TypeScript exports are unusable here.

`HtmlHead.astro` imports the four files. Vite resolves the `./css/*.css` subpath export and bundles them into one hashed stylesheet, so nothing is vendored and nothing can drift from the installed version.

| File | Contains | Selector |
| --- | --- | --- |
| `globals.css` | Spacing, radius, font size, other scales | `:root` |
| `textTheme.css` | Typography shorthands, font families | `:root` |
| `lightTheme.css` | Light colours and shadows | `[data-theme="light"]` |
| `darkTheme.css` | Dark colours and shadows | `[data-theme="dark"]` |

## Why the theme attribute moves from `<body>` to `<html>`

`lightTheme.css` and `darkTheme.css` select on an **unscoped** `[data-theme="..."]`, by design, so any element can be a theme root. Our own CSS scopes to `html[data-theme='dark']`, which made the hardcoded `data-theme="dark"` on `<body>` inert — but the token stylesheets *do* match it, and would force dark tokens on every page regardless of the toggle.

`<html>` also gains `data-theme="light"` as a no-JS default. The inline script in `HEADER_SCRIPTS` normally sets it before paint; without the attribute, neither theme stylesheet matches and no colour token resolves.

## Testing

Verified locally that a site variable can point at a token and that both themes follow, by temporarily pointing `--color-text` at `--colorTextPrimary` and `--octo-blue` at `--colorTextLinkDefault`:

| | token | resolved site var | rendered |
| --- | --- | --- | --- |
| light | `#282F38` | `#282F38` | `rgb(40, 47, 56)` |
| dark | `#F4F6F8` | `#F4F6F8` | `rgb(244, 246, 248)` |

The token themes itself, so the matching `html[data-theme='dark']` override in `vars.css` became redundant — two declarations collapse to one. `vars.css` loads *before* the token stylesheet and still resolves correctly, because `var()` resolves at use time rather than declaration time.

Those experiments were reverted. This PR is a **visual no-op**: 1,184 custom properties are defined and nothing consumes them yet. Production build verified — 2,697 pages, one 48.5KB stylesheet (7KB gzipped) in `dist/_astro/`, `:root` plus both `[data-theme]` blocks present.

## Follow-ups

Migrating `vars.css` onto tokens will come as separate PRs, grouped so each is independently reviewable and revertible: links, then text, then surfaces and borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)