### PR TITLE
Adopt the design system tokens in the docs theme

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -3416,7 +3416,7 @@ img.btn__icon {
   padding: 1rem;
   border: 2px solid var(--border-color-tab-active);
   border-radius: var(--standard-radius);
-  background: var(--aft);
+  background: var(--color-base-primary);
   overflow: auto;
 }
 

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -253,6 +253,11 @@
 }
 
 html[data-theme='dark'] {
+  /* The side navigation is a recessed panel, darker than the page. The design
+     system's dark backgrounds only step lighter from
+     --colorBackgroundPrimaryDefault (#111A23 -> #1F303F -> #2E475D), so there
+     is no token for a surface below the page, and this stays hand-themed. */
+  --bg-color-menu: #0c1a24;
   --bg-color-menu-open: var(--blue-grey-dark);
   --body-link-alt: var(--white);
   --search-placeholder-color: var(--navy-400);

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -42,9 +42,7 @@
 
   --blue-500: var(--colorScalesBlue500);
 
-  /* TODO: --green-400 only colors two icons in main.css (.fa-circle-check and
-     .fa-heart.green). Those could use --colorIconSuccess instead, which would
-     retire this entry. */
+  /* TODO: remove green-400 as it's being used in one place only */
   --green-400: var(--colorScalesGreen400);
   --green-500: var(--colorScalesGreen500);
   /* Brand greens, no scale equivalent */

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -106,25 +106,25 @@
   --border-color-tab: var(--colorBorderPrimary);
   --border-color-tab-active: var(--colorBorderTertiary);
 
-  --color-hint: var(--colorTextPrimary);
-  --bg-color-hint: var(--colorBackgroundInfo);
-  --border-color-hint: var(--colorBorderInfo);
+  --color-hint: var(--colorCalloutTextInfo);
+  --bg-color-hint: var(--colorCalloutBackgroundInfoDefault);
+  --border-color-hint: var(--colorCalloutBorderInfo);
 
-  --color-info: var(--colorTextPrimary);
-  --bg-color-info: var(--colorBackgroundInfo);
-  --border-color-info: var(--colorBorderInfo);
+  --color-info: var(--colorCalloutTextInfo);
+  --bg-color-info: var(--colorCalloutBackgroundInfoDefault);
+  --border-color-info: var(--colorCalloutBorderInfo);
 
-  --color-success: var(--colorTextPrimary);
-  --bg-color-success: var(--colorBackgroundSuccess);
-  --border-color-success: var(--colorBorderSuccess);
+  --color-success: var(--colorCalloutTextSuccess);
+  --bg-color-success: var(--colorCalloutBackgroundSuccessDefault);
+  --border-color-success: var(--colorCalloutBorderSuccess);
 
-  --color-warning: var(--colorTextPrimary);
-  --bg-color-warning: var(--colorBackgroundWarning);
-  --border-color-warning: var(--colorBorderWarning);
+  --color-warning: var(--colorCalloutTextWarning);
+  --bg-color-warning: var(--colorCalloutBackgroundWarningDefault);
+  --border-color-warning: var(--colorCalloutBorderWarning);
 
-  --color-problem: var(--colorTextPrimary);
-  --bg-color-problem: var(--colorBackgroundDanger);
-  --border-color-problem: var(--colorBorderDanger);
+  --color-problem: var(--colorCalloutTextDanger);
+  --bg-color-problem: var(--colorCalloutBackgroundDangerDefault);
+  --border-color-problem: var(--colorCalloutBorderDanger);
 
   --duration-default: 300ms;
 
@@ -253,11 +253,11 @@
 }
 
 html[data-theme='dark'] {
-  /* The page sits mid-ramp; the nav and code wells are recessed below it */
-  --color-base-primary: var(--colorBackgroundSecondaryDefault);
+  /* Page, header and nav share the darkest background; panels sit above it */
+  --color-base-primary: var(--colorBackgroundPrimaryDefault);
   --bg-color-menu: var(--colorBackgroundPrimaryDefault);
   --bg-color-menu-open: var(--blue-grey-dark);
-  --header-bg: var(--colorBackgroundSecondaryDefault);
+  --header-bg: var(--colorBackgroundPrimaryDefault);
   --body-link-alt: var(--white);
   --search-placeholder-color: var(--navy-400);
   --search-remove-icon-color: var(--white);
@@ -272,9 +272,6 @@ html[data-theme='dark'] {
   --header-link-alt: var(--color-text);
   --grey-light: var(--navy-700);
   --octopus-logo-text-color: var(--white);
-  /* No translucent background token exists */
-  --bg-color-hint: rgba(13, 128, 216, 0.1);
-  --bg-color-info: var(--blue-grey-light);
   --footer-link-color: var(--color-menu-link);
   --search-overlay: rgba(12, 26, 36, 0.8);
   --header-icon-border: transparent;
@@ -286,5 +283,5 @@ html[data-theme='dark'] {
   --icon-tile-border: #1c3f59;
   --icon-tile-border-hover: var(--octo-blue-lightest);
   --icon-tile-shadow: 0px 6px 20px 0px var(--bg-color-menu);
-  --code-background: var(--colorBackgroundPrimaryDefault);
+  --code-background: var(--colorBackgroundSecondaryDefault);
 }

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -104,7 +104,7 @@
 
   --bg-color-tab: var(--colorBackgroundTertiary);
   --border-color-tab: var(--colorBorderPrimary);
-  --border-color-tab-active: var(--colorBorderTertiary);
+  --border-color-tab-active: var(--colorBorderSelected);
 
   --color-hint: var(--colorCalloutTextInfo);
   --bg-color-hint: var(--colorCalloutBackgroundInfoDefault);
@@ -260,12 +260,12 @@ html[data-theme='dark'] {
   --search-placeholder-color: var(--navy-400);
   --search-remove-icon-color: var(--white);
   --grey-lighter: var(--blue-grey-dark);
-  /* TODO: --navy-200 is still hand-themed because main.css uses it directly for
-     borders and one background (lines 112, 216, 262, 920, 2539). Point those at
-     --border-default-color / --bg-color-tab and this override can go. */
+  /* TODO: --navy-200 is still hand-themed because main.css uses it directly on
+     code, .image, figure:has(p > img) p, .card and .site-search-results__item.
+     Point those at --border-default-color / --bg-color-tab and this can go. */
   --navy-200: #314c62;
-  /* TODO: --blue-grey is hand-themed for .card__description (main.css:1016).
-     That is secondary text, so --color-text-secondary already covers it. */
+  /* TODO: --blue-grey is hand-themed for .card__description, which is
+     secondary text, so --color-text-secondary already covers it. */
   --blue-grey: #dae2e9ff;
   --header-link-alt: var(--color-text);
   --grey-light: var(--navy-700);
@@ -273,12 +273,10 @@ html[data-theme='dark'] {
   --footer-link-color: var(--color-menu-link);
   --search-overlay: rgba(12, 26, 36, 0.8);
   --header-icon-border: transparent;
-  --header-icon-background: var(--blue-grey-dark);
   --badge-background: rgba(31, 192, 255, 0.1);
   --badge-color: var(--octo-blue-lightest);
-  --icon-tile-background: var(--colorBackgroundTertiary);
-  --icon-tile-background-hover: #223950;
-  --icon-tile-border: #1c3f59;
-  --icon-tile-border-hover: var(--octo-blue-lightest);
-  --icon-tile-shadow: 0px 6px 20px 0px var(--bg-color-menu);
+  /* Tiles sit one step above the page so hover has somewhere lighter to go */
+  --icon-tile-background-hover: var(--colorBackgroundTertiary);
+  --icon-tile-border-hover: var(--colorBorderSelected);
+  --icon-tile-shadow: 0px 6px 20px 0px rgba(0, 0, 0, 0.4);
 }

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -60,7 +60,7 @@
 
   --blue-grey-dark: #152b3dff;
   --blue-gray-darker: #1f2f3cff;
-  --blue-grey-medium: #113049ff;
+  --blue-grey-medium: var(--brandGrey);
   --blue-grey: var(--navy-700);
   --blue-grey-light: #274b66ff;
   /* This is navy 500 in the design system's scale */
@@ -116,7 +116,7 @@
 
   --color-success: #04502f;
   --bg-color-success: #e8ffeb;
-  --border-color-success: #00b065;
+  --border-color-success: var(--brandGreen);
 
   --color-warning: #a23623;
   --bg-color-warning: #fefae9;
@@ -142,7 +142,7 @@
   --separator-color: var(--colorBorderPrimary);
 
   /* Scrollbar */
-  --scrollbar-color: #a9bbcb;
+  --scrollbar-color: var(--navy-300);
 
   /* Icon Tile */
   --icon-tile-border: var(--border-default-color);

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -253,12 +253,11 @@
 }
 
 html[data-theme='dark'] {
-  /* The side navigation is a recessed panel, darker than the page. The design
-     system's dark backgrounds only step lighter from
-     --colorBackgroundPrimaryDefault (#111A23 -> #1F303F -> #2E475D), so there
-     is no token for a surface below the page, and this stays hand-themed. */
-  --bg-color-menu: #0c1a24;
+  /* The page sits mid-ramp; the nav and code wells are recessed below it */
+  --color-base-primary: var(--colorBackgroundSecondaryDefault);
+  --bg-color-menu: var(--colorBackgroundPrimaryDefault);
   --bg-color-menu-open: var(--blue-grey-dark);
+  --header-bg: var(--colorBackgroundSecondaryDefault);
   --body-link-alt: var(--white);
   --search-placeholder-color: var(--navy-400);
   --search-remove-icon-color: var(--white);
@@ -273,14 +272,19 @@ html[data-theme='dark'] {
   --header-link-alt: var(--color-text);
   --grey-light: var(--navy-700);
   --octopus-logo-text-color: var(--white);
+  /* No translucent background token exists */
+  --bg-color-hint: rgba(13, 128, 216, 0.1);
+  --bg-color-info: var(--blue-grey-light);
   --footer-link-color: var(--color-menu-link);
   --search-overlay: rgba(12, 26, 36, 0.8);
   --header-icon-border: transparent;
   --header-icon-background: var(--blue-grey-dark);
   --badge-background: rgba(31, 192, 255, 0.1);
   --badge-color: var(--octo-blue-lightest);
+  --icon-tile-background: var(--colorBackgroundTertiary);
   --icon-tile-background-hover: #223950;
   --icon-tile-border: #1c3f59;
   --icon-tile-border-hover: var(--octo-blue-lightest);
   --icon-tile-shadow: 0px 6px 20px 0px var(--bg-color-menu);
+  --code-background: var(--colorBackgroundPrimaryDefault);
 }

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -85,32 +85,32 @@
   --font-size-medium: 1rem;
   --font-size-small: 0.875rem;
 
-  --color-base-primary: var(--white);
+  --color-base-primary: var(--colorBackgroundPrimaryDefault);
 
-  --color-text: var(--blue-midnight);
-  --color-heading: var(--blue-grey-dark);
-  --color-text-secondary: var(--navy-700);
+  --color-text: var(--colorTextPrimary);
+  --color-heading: var(--colorTextPrimary);
+  --color-text-secondary: var(--colorTextSecondary);
 
-  --color-subtitle: var(--navy-600);
+  --color-subtitle: var(--colorTextSecondary);
   --font-size-subtitle: var(--font-size-large);
   --font-size-title: var(--font-size-xxlarge);
 
-  --border-color-header: var(--navy-200);
+  --border-color-header: var(--colorBorderPrimary);
 
-  --color-menu-link: var(--navy-600);
-  --color-menu-link-active: var(--navy-700);
-  --color-menu-link-alt: var(--blue-500);
+  --color-menu-link: var(--colorTextSecondary);
+  --color-menu-link-active: var(--colorTextPrimary);
+  --color-menu-link-alt: var(--colorTextLinkDefault);
   --color-menu-marker: var(--navy-300);
-  --bg-color-menu: var(--blue-qqq);
+  --bg-color-menu: var(--colorBackgroundSecondaryDefault);
   --bg-color-menu-open: rgba(13, 128, 216, 0.1);
-  --border-color-menu-open: var(--navy-200);
+  --border-color-menu-open: var(--colorBorderPrimary);
   --gap-menu: 0.6em;
 
   --navigation-width: 21.25rem;
 
   --bg-color-tab: var(--navy-200);
-  --border-color-tab: var(--navy-200);
-  --border-color-tab-active: var(--navy-400);
+  --border-color-tab: var(--colorBorderPrimary);
+  --border-color-tab-active: var(--colorBorderTertiary);
 
   --color-hint: #124164;
   --bg-color-hint: var(--lightest-blue);
@@ -135,17 +135,17 @@
   --duration-default: 300ms;
 
   --code-color: var(--color-text);
-  --code-background: var(--blue-100);
+  --code-background: var(--colorBackgroundSecondaryDefault);
 
   /* Backgrounds TODO - update with design system */
-  --background-light: var(--blue-100);
-  --background-default: var(--white);
+  --background-light: var(--colorBackgroundSecondaryDefault);
+  --background-default: var(--colorBackgroundPrimaryDefault);
 
   /* Borders TODO - update with design system */
-  --border-default-color: var(--blue-200);
+  --border-default-color: var(--colorBorderPrimary);
 
   /* Separator */
-  --separator-color: #dae2e9;
+  --separator-color: var(--colorBorderPrimary);
 
   /* Scrollbar */
   --scrollbar-color: #a9bbcb;
@@ -158,7 +158,7 @@
   --icon-tile-shadow: 0px 4px 10px 0px rgba(13, 128, 216, 0.2);
 
   /* Article header */
-  --header-separator-color: var(--navy-200);
+  --header-separator-color: var(--colorBorderPrimary);
   --header-icon-border: var(--border-default-color);
   --header-icon-background: var(--background-light);
 
@@ -190,7 +190,7 @@
   --hamburger-lines-color: var(--blue-grey-light);
 
   /* Theme Switcher */
-  --theme-switcher-border: var(--navy-200);
+  --theme-switcher-border: var(--colorBorderPrimary);
 
   /* Badge */
   --badge-background: rgba(162, 209, 244, 0.2);
@@ -204,7 +204,7 @@
 
   /* To be checked and cleaned */
 
-  --octo-blue: var(--blue-500);
+  --octo-blue: var(--colorTextLinkDefault);
   --lightest-blue: #e5f4ffff;
   --octo-blue-lighter: #2f95e3ff;
   --octo-blue-lightest: #1fc0ffff;
@@ -218,7 +218,7 @@
   --bold-font: var(--font-family);
   --code-font: Consolas, monaco, monospace;
 
-  --header-bg: var(--white);
+  --header-bg: var(--colorBackgroundPrimaryDefault);
   --header-icon-stroke: var(--blue-grey-light);
   --header-link-color: var(--octo-blue);
   --header-link-alt: var(--blue-gray-darker);
@@ -263,32 +263,18 @@
 }
 
 html[data-theme='dark'] {
-  --color-base-primary: #10202e;
-  --color-menu-link: var(--navy-300);
-  --color-menu-link-active: var(--navy-100);
-  --bg-color-menu: #0c1a24;
   --bg-color-menu-open: var(--blue-grey-dark);
-  --border-color-menu-open: var(--navy-700);
-  --header-bg: var(--blue-grey-dark);
-  --color-text: #dae2e9ff;
-  --color-heading: var(--white);
-  --color-subtitle: #f5f6f8;
   --body-link-alt: var(--white);
   --search-placeholder-color: var(--navy-400);
   --search-remove-icon-color: var(--white);
   --grey-lighter: var(--blue-grey-dark);
   /* TODO: update this */
   --navy-200: #314c62;
-  --octo-blue: var(--octo-blue-lightest);
-  --border-color-header: var(--navy-700);
   /* TODO: update this */
   --blue-grey: #dae2e9ff;
   --header-link-alt: var(--color-text);
   --grey-light: var(--navy-700);
-  --color-menu-link-alt: var(--octo-blue-lightest);
-  --body-link-color: var(--octo-blue-lightest);
   --octopus-logo-text-color: var(--white);
-  --theme-switcher-border: var(--navy-700);
   --color-hint: var(--color-text);
   --bg-color-hint: rgba(13, 128, 216, 0.1);
   --color-info: var(--color-text);
@@ -296,17 +282,12 @@ html[data-theme='dark'] {
   --hamburger-lines-color: var(--white);
   --footer-link-color: var(--color-menu-link);
   --search-overlay: rgba(12, 26, 36, 0.8);
-  --header-separator-color: var(--navy-700);
   --header-icon-border: transparent;
   --header-icon-background: var(--blue-grey-dark);
   --badge-background: rgba(31, 192, 255, 0.1);
   --badge-color: var(--octo-blue-lightest);
-  --color-text-secondary: #dae2e9;
-  --icon-tile-background: #132838;
   --icon-tile-background-hover: #223950;
   --icon-tile-border: #1c3f59;
   --icon-tile-border-hover: var(--octo-blue-lightest);
   --icon-tile-shadow: 0px 6px 20px 0px var(--bg-color-menu);
-  --separator-color: var(--navy-700);
-  --code-background: #0c1a24;
 }

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -253,11 +253,9 @@
 }
 
 html[data-theme='dark'] {
-  /* Page, header and nav share the darkest background; panels sit above it */
-  --color-base-primary: var(--colorBackgroundPrimaryDefault);
+  /* The navigation matches the page in dark, unlike light */
   --bg-color-menu: var(--colorBackgroundPrimaryDefault);
   --bg-color-menu-open: var(--blue-grey-dark);
-  --header-bg: var(--colorBackgroundPrimaryDefault);
   --body-link-alt: var(--white);
   --search-placeholder-color: var(--navy-400);
   --search-remove-icon-color: var(--white);
@@ -283,5 +281,4 @@ html[data-theme='dark'] {
   --icon-tile-border: #1c3f59;
   --icon-tile-border-hover: var(--octo-blue-lightest);
   --icon-tile-shadow: 0px 6px 20px 0px var(--bg-color-menu);
-  --code-background: var(--colorBackgroundSecondaryDefault);
 }

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -146,10 +146,9 @@
 
   /* Icon Tile */
   --icon-tile-border: var(--border-default-color);
-  --icon-tile-border-hover: var(--border-default-color);
+  --icon-tile-border-hover: var(--colorBorderSelected);
   --icon-tile-background: var(--background-light);
   --icon-tile-background-hover: var(--background-default);
-  --icon-tile-shadow: 0px 4px 10px 0px rgba(13, 128, 216, 0.2);
 
   /* Article header */
   --header-separator-color: var(--colorBorderPrimary);
@@ -277,6 +276,4 @@ html[data-theme='dark'] {
   --badge-color: var(--octo-blue-lightest);
   /* Tiles sit one step above the page so hover has somewhere lighter to go */
   --icon-tile-background-hover: var(--colorBackgroundTertiary);
-  --icon-tile-border-hover: var(--colorBorderSelected);
-  --icon-tile-shadow: 0px 6px 20px 0px rgba(0, 0, 0, 0.4);
 }

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -142,7 +142,7 @@
   --separator-color: var(--colorBorderPrimary);
 
   /* Scrollbar */
-  --scrollbar-color: var(--navy-300);
+  --scrollbar-color: var(--colorScrollbarHandle);
 
   /* Icon Tile */
   --icon-tile-border: var(--border-default-color);

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -35,17 +35,12 @@
   --white: var(--colorScalesWhite);
 
   --navy-700: var(--colorScalesNavy700);
-  --navy-600: var(--colorScalesNavy600);
   --navy-400: var(--colorScalesNavy400);
   --navy-300: var(--colorScalesNavy300);
   --navy-200: var(--colorScalesNavy200);
   --navy-100: var(--colorScalesNavy100);
 
   --blue-500: var(--colorScalesBlue500);
-  --blue-200: var(--colorScalesBlue200);
-  --blue-100: var(--colorScalesBlue100);
-  /* No scale equivalent */
-  --blue-qqq: #fafdff;
 
   /* TODO: remove green-400 as it's being used in one place only */
   --green-400: var(--colorScalesGreen400);
@@ -61,7 +56,6 @@
 
   --blue-midnight-dark: #070e14ff;
   --blue-midnight-darker: #0a202fff;
-  --blue-midnight: #10212fff;
   --blue-midnight-lighter: #22425cff;
 
   --blue-grey-dark: #152b3dff;

--- a/public/docs/css/vars.css
+++ b/public/docs/css/vars.css
@@ -42,7 +42,9 @@
 
   --blue-500: var(--colorScalesBlue500);
 
-  /* TODO: remove green-400 as it's being used in one place only */
+  /* TODO: --green-400 only colors two icons in main.css (.fa-circle-check and
+     .fa-heart.green). Those could use --colorIconSuccess instead, which would
+     retire this entry. */
   --green-400: var(--colorScalesGreen400);
   --green-500: var(--colorScalesGreen500);
   /* Brand greens, no scale equivalent */
@@ -102,40 +104,40 @@
 
   --navigation-width: 21.25rem;
 
-  --bg-color-tab: var(--navy-200);
+  --bg-color-tab: var(--colorBackgroundTertiary);
   --border-color-tab: var(--colorBorderPrimary);
   --border-color-tab-active: var(--colorBorderTertiary);
 
-  --color-hint: #124164;
-  --bg-color-hint: var(--lightest-blue);
-  --border-color-hint: var(--blue-500);
+  --color-hint: var(--colorTextPrimary);
+  --bg-color-hint: var(--colorBackgroundInfo);
+  --border-color-hint: var(--colorBorderInfo);
 
-  --color-info: #124164;
-  --bg-color-info: var(--lightest-blue);
-  --border-color-info: var(--blue-500);
+  --color-info: var(--colorTextPrimary);
+  --bg-color-info: var(--colorBackgroundInfo);
+  --border-color-info: var(--colorBorderInfo);
 
-  --color-success: #04502f;
-  --bg-color-success: #e8ffeb;
-  --border-color-success: var(--brandGreen);
+  --color-success: var(--colorTextPrimary);
+  --bg-color-success: var(--colorBackgroundSuccess);
+  --border-color-success: var(--colorBorderSuccess);
 
-  --color-warning: #a23623;
-  --bg-color-warning: #fefae9;
-  --border-color-warning: #fc8431;
+  --color-warning: var(--colorTextPrimary);
+  --bg-color-warning: var(--colorBackgroundWarning);
+  --border-color-warning: var(--colorBorderWarning);
 
-  --color-problem: #931919;
-  --bg-color-problem: #fff2ee;
-  --border-color-problem: #ff4848;
+  --color-problem: var(--colorTextPrimary);
+  --bg-color-problem: var(--colorBackgroundDanger);
+  --border-color-problem: var(--colorBorderDanger);
 
   --duration-default: 300ms;
 
   --code-color: var(--color-text);
   --code-background: var(--colorBackgroundSecondaryDefault);
 
-  /* Backgrounds TODO - update with design system */
+  /* Backgrounds */
   --background-light: var(--colorBackgroundSecondaryDefault);
   --background-default: var(--colorBackgroundPrimaryDefault);
 
-  /* Borders TODO - update with design system */
+  /* Borders */
   --border-default-color: var(--colorBorderPrimary);
 
   /* Separator */
@@ -181,7 +183,7 @@
   --hamburger-translate-y: calc(
     var(--hamburger-line-height) + var(--hamburger-line-margin)
   );
-  --hamburger-lines-color: var(--blue-grey-light);
+  --hamburger-lines-color: var(--colorIconPrimary);
 
   /* Theme Switcher */
   --theme-switcher-border: var(--colorBorderPrimary);
@@ -199,7 +201,6 @@
   /* To be checked and cleaned */
 
   --octo-blue: var(--colorTextLinkDefault);
-  --lightest-blue: #e5f4ffff;
   --octo-blue-lighter: #2f95e3ff;
   --octo-blue-lightest: #1fc0ffff;
 
@@ -213,12 +214,9 @@
   --code-font: Consolas, monaco, monospace;
 
   --header-bg: var(--colorBackgroundPrimaryDefault);
-  --header-icon-stroke: var(--blue-grey-light);
   --header-link-color: var(--octo-blue);
   --header-link-alt: var(--blue-gray-darker);
-  --header-link-alt-bg: var(--blue-grey-smoke);
 
-  --image-bg: var(--blue-grey-smoke);
   --content-bg: var(--white);
 
   --body-link-color: var(--octo-blue);
@@ -227,7 +225,7 @@
   --footer-link-color: var(--navy-200);
 
   --icon-stroke: var(--white);
-  --icon-fill: var(--blue-grey-light);
+  --icon-fill: var(--colorIconSecondary);
 
   --octopus-logo-text-color: #0f2535;
 
@@ -262,18 +260,16 @@ html[data-theme='dark'] {
   --search-placeholder-color: var(--navy-400);
   --search-remove-icon-color: var(--white);
   --grey-lighter: var(--blue-grey-dark);
-  /* TODO: update this */
+  /* TODO: --navy-200 is still hand-themed because main.css uses it directly for
+     borders and one background (lines 112, 216, 262, 920, 2539). Point those at
+     --border-default-color / --bg-color-tab and this override can go. */
   --navy-200: #314c62;
-  /* TODO: update this */
+  /* TODO: --blue-grey is hand-themed for .card__description (main.css:1016).
+     That is secondary text, so --color-text-secondary already covers it. */
   --blue-grey: #dae2e9ff;
   --header-link-alt: var(--color-text);
   --grey-light: var(--navy-700);
   --octopus-logo-text-color: var(--white);
-  --color-hint: var(--color-text);
-  --bg-color-hint: rgba(13, 128, 216, 0.1);
-  --color-info: var(--color-text);
-  --bg-color-info: var(--blue-grey-light);
-  --hamburger-lines-color: var(--white);
   --footer-link-color: var(--color-menu-link);
   --search-overlay: rgba(12, 26, 36, 0.8);
   --header-icon-border: transparent;


### PR DESCRIPTION
# Background

The docs site loads [`@octopusdeploy/design-system-tokens`](https://www.npmjs.com/package/@octopusdeploy/design-system-tokens) as CSS custom properties (#3261), and its raw palette maps onto the token color scales (#3262). Nothing was consuming the tokens yet.

`vars.css` still defined its own theme: site variables resolving to hand-picked hex values, plus a 44-entry `html[data-theme='dark']` block maintaining a second set for dark mode. Several variables had no dark value at all.

This is the first adoption — pointing the theme at the design system. It is deliberately a broad, shallow pass over `vars.css` only. Component-by-component tuning against the new design comes later.

# Results

One file. **40 values change in light and 43 in dark**, `html[data-theme='dark']` goes from **44 overrides to 17**, and **10 unused variables** are removed.

## What now comes from tokens

| group | site variables | token |
| --- | --- | --- |
| Text | `--color-text`, `--color-heading`, `--color-menu-link-active` | `--colorTextPrimary` |
| | `--color-text-secondary`, `--color-subtitle`, `--color-menu-link` | `--colorTextSecondary` |
| Links | `--octo-blue`, `--color-menu-link-alt` | `--colorTextLinkDefault` |
| Borders | `--border-color-header`, `--border-color-menu-open`, `--border-color-tab`, `--border-default-color`, `--separator-color`, `--header-separator-color`, `--theme-switcher-border` | `--colorBorderPrimary` |
| | `--border-color-tab-active` | `--colorBorderSelected` |
| Backgrounds | `--color-base-primary`, `--background-default`, `--header-bg` | `--colorBackgroundPrimaryDefault` |
| | `--bg-color-menu`, `--code-background`, `--background-light` | `--colorBackgroundSecondaryDefault` |
| | `--bg-color-tab` | `--colorBackgroundTertiary` |
| Callouts | 15 variables across hint, info, success, warning, problem | `--colorCalloutText/Background/Border*` |
| Icons | `--icon-fill` | `--colorIconSecondary` |
| | `--hamburger-lines-color` | `--colorIconPrimary` |
| Brand | `--blue-grey-medium` | `--brandGrey` |
| Scrollbar | `--scrollbar-color` | `--colorScrollbarHandle` |
| Tiles | `--icon-tile-border-hover` | `--colorBorderSelected` |

Seven of those border variables previously carried their own dark override. Because tokens theme themselves, all seven collapse to one declaration.

## Light mode: close to unchanged

23 of the 39 light changes are within a delta of 30 — border greys shifting `#dae2e9` → `#dee1e6`, tinted surfaces going neutral `#f2f8fd` → `#f5f6f8`, body text `#10212f` → `#282f38`. **Link color does not change at all** (`#1a77ca` either way).

Two exceptions worth looking at:

- The **warning callout** shifts hue — text `#a23623` → `#3b2c00`, border `#fc8431` → `#b98f02`. Rust and orange become olive and mustard.
- `--border-color-tab-active`, the selected-tab indicator, becomes blue: `#7c98b4` → `#1a77ca`.

## Dark mode: a substantial change, aligned to the new design

This is where the old theme diverged most from the design system, so it moves the most.

Surfaces use three levels of the token ramp, keeping the page darkest:

```
--colorBackgroundPrimaryDefault    #111A23   page, header, side navigation
--colorBackgroundSecondaryDefault  #1F303F   code blocks, icon tiles
--colorBackgroundTertiary          #2E475D   icon tile hover
```

Because those tokens theme themselves, the page, header and code background need no dark override at all. `--bg-color-menu` is the only surface that does, because the navigation is a distinct panel in light and matches the page in dark.

Text and links:

```
--color-text      #dae2e9 -> #f4f6f8
--color-heading   #ffffff -> #f4f6f8
--octo-blue       #1fc0ff -> #87bfec
```

**Callouts had no dark theming at all.** `--color-success`, `--color-warning`, `--color-problem` and their backgrounds and borders carried no dark override, so a success callout rendered as `#e8ffeb` pale green with `#04502f` text on a dark page. All five callout types now use the `--colorCallout*` family, whose backgrounds are translucent and whose text colors are paired to them. Measured in a browser, every callout is AAA in both themes — worst case 9.59:1.

**Two accessibility fixes came out of review.** The selected-tab indicator had landed on `--colorBorderTertiary`, which is byte-identical to `--colorBorderDisabled`, dropping it to 1.97:1 in light and 2.65:1 in dark against a 3:1 requirement; it now uses `--colorBorderSelected` at 4.63:1 and 5.87:1. The scrollbar thumb was 1.97:1 on white and now uses `--colorScrollbarHandle` at 3.00:1.

**One `main.css` fix.** `[role='tabpanel']` set `background: var(--aft)`, a variable defined nowhere, so every tab panel was transparent. It now uses `--color-base-primary`, matching the selected tab's own fill so the two read as one surface. The tabs are built at runtime by `public/docs/js/modules/detail-tabs.js`, which is why none of this markup appears in the static HTML. Fixed here because moving the indicator to `--colorBorderSelected` draws a 2px blue border around every panel, which made the missing background obvious.

**Two latent bugs fixed.** `--background-default` and `--background-light` had no dark override, so they resolved to `#ffffff` and `#f2f8fd` — white and pale blue — in dark mode.

## Still hand-themed, and why

17 dark overrides remain. Most have no token equivalent: `--search-*`, `--badge-*`, `--octopus-logo-text-color`, and the `--blue-midnight` / `--blue-grey` families.

Two carry a note explaining what blocks them — `--navy-200` and `--blue-grey` are only hand-themed because `main.css` consumes those palette entries directly, so unpicking them means editing rules rather than variables.

## Removed

Ten variables, each referenced nowhere: `--navy-600`, `--blue-100`, `--blue-200`, `--blue-qqq`, `--blue-midnight`, `--lightest-blue` were orphaned once the theme stopped pointing at them; `--header-icon-stroke`, `--header-link-alt-bg`, `--image-bg` were already dead; and `--icon-tile-shadow` was declared in both blocks but read nowhere in `main.css`.

## Compatibility note

The callout background tokens use CSS Color 4 relative color syntax, `rgb(from #CDE4F7 r g b / 0.5)`, which needs Chrome 119, Safari 16.4 or Firefox 128. Older browsers treat the declaration as invalid and drop the fill; callout text and the left border still render and both stay legible.

# Screenshots

Every image is a side-by-side pair: **octopus.com as it is now on the left, this PR on the right.**

## Surfaces — dark

### Page, header, navigation and code block
`/docs/getting-started/first-deployment`

<img width="2944" height="969" alt="03-article-surfaces-dark" src="https://github.com/user-attachments/assets/408a12bb-ed17-4689-a7e6-4884bd97b593" />

### Code block
The page is the darkest surface, so code blocks move from a recessed well to a raised panel.

<img width="2944" height="214" alt="04-code-block-dark" src="https://github.com/user-attachments/assets/38fe85d0-c691-420c-b9d5-8fb33562c386" />

### Navigation, header and page surfaces
`/docs/getting-started`

<img width="2944" height="969" alt="01-getting-started-dark" src="https://github.com/user-attachments/assets/3f96a6d0-9d5b-40cc-bf9b-263e17224263" />

## Surfaces — light

### Navigation, header and page surfaces
`/docs/getting-started` — for comparison, light is close to unchanged.

<img width="2944" height="969" alt="02-getting-started-light" src="https://github.com/user-attachments/assets/25f9c970-df40-4dd8-bfa0-b6f8c46412aa" />

### Tab group
`/docs/deployments/custom-scripts` — "Scripts that block deployments". The selected-tab indicator and panel outline move from `#7c98b4` to `--colorBorderSelected`, and the panel gains the background it was missing.

Light:
<img width="2944" height="364" alt="13-tabs-light" src="https://github.com/user-attachments/assets/477a533f-c3ba-40d8-ae37-58b7cafacc17" />

Dark:
<img width="2944" height="364" alt="13-tabs-dark" src="https://github.com/user-attachments/assets/43b41696-67cc-4c14-8d8a-9618c57db92e" />

## Callouts

### Hint
`/docs/administration/data/data-migration/` — 408 pages use `.hint`

Light:

<img width="2944" height="263" alt="05-hint-light" src="https://github.com/user-attachments/assets/2371d74d-fafd-4274-9bc1-c1bfed7ef262" />

Dark:

<img width="2944" height="263" alt="06-hint-dark" src="https://github.com/user-attachments/assets/6a360f36-692b-4029-8a78-5ced06457b27" />

### Success
`/docs/administration/data/changing-octopus-database-collation/` — 279 pages

Light:

<img width="2944" height="308" alt="07-success-light" src="https://github.com/user-attachments/assets/34017c12-5771-48fc-86c3-b50a0684fff4" />

Dark — previously a pale green box on a dark page, because the success callout had no dark override:

<img width="2944" height="308" alt="08-success-dark" src="https://github.com/user-attachments/assets/404d5959-f332-4780-af89-e67abf59f174" />

### Warning
Same page — 227 pages. This is the one callout whose light colors shift noticeably: text `#a23623` to `#3b2c00`, border `#fc8431` to `#b98f02`.

Light:

<img width="2944" height="263" alt="09-warning-light" src="https://github.com/user-attachments/assets/65de7d07-cfae-4e65-ae0e-69bf1c53093c" />

Dark:

<img width="2944" height="263" alt="10-warning-dark" src="https://github.com/user-attachments/assets/619eea4e-8a87-4870-b17d-070ead425776" />

### Problem
`/docs/administration/data/backup-and-restore/` — 39 pages

Light:

<img width="2944" height="537" alt="11-problem-light" src="https://github.com/user-attachments/assets/207f664f-4417-44e6-baa9-a301f9bc84ab" />

Dark:

<img width="2944" height="537" alt="12-problem-dark" src="https://github.com/user-attachments/assets/81b96f7c-b67b-4c1d-b80d-7778214eaebc" />

# Next steps

This is the first step, not the finished job. The intent is to go component by component and tune each against the new design. Known follow-ups:

- `main.css` reaches past the theme into raw palette entries, which is what keeps `--navy-200` and `--blue-grey` hand-themed.
- `.hint` and `.info` now resolve identically. The design system has no separate hint concept, so they either become synonyms or `.info` moves to another callout family.
- `--content-bg` is white in both themes and paints the mobile navigation and search overlay, so that overlay is white in dark mode. Pre-existing.
- `--bg-color-tab` and `--border-color-tab` resolve to the same colour in both themes, so the tab border is invisible. Unchanged from `main`, but it now expresses one colour through two token families.
- `.icon-tile` renders only on `/components/`, so the tile changes in this PR affect that page alone.
- The CTA button greens have no token. `#00ffa3` is the brand's Neon Green and `#00e693` is not in the brand palette, but neither value appears anywhere in the token package. The nearest bright green is `--brandGreen` `#00B065`, which is far enough away to matter: against the current `#113049` label it scores 4.80:1 where `#00e693` scores 8.26:1, so adopting it means changing the label colour too.

# Every changed value

<details>
<summary><b>Light — 40 values changed</b></summary>

| variable | before | after |
| --- | --- | --- |
| `--bg-color-hint` | `#e5f4ff` | `rgb(from #cde4f7 r g b / 0.5)` |
| `--bg-color-info` | `#e5f4ff` | `rgb(from #cde4f7 r g b / 0.5)` |
| `--bg-color-problem` | `#fff2ee` | `rgb(from #ffd8d8 r g b / 0.5)` |
| `--bg-color-success` | `#e8ffeb` | `rgb(from #b8e7d3 r g b / 0.45)` |
| `--bg-color-warning` | `#fefae9` | `rgb(from #ffdf62 r g b / 0.32)` |
| `--icon-tile-border-hover` | `#cde4f7` | `#1a77ca` |
| `--color-warning` | `#a23623` | `#3b2c00` |
| `--border-color-tab-active` | `#7c98b4` | `#1a77ca` |
| `--border-color-warning` | `#fc8431` | `#b98f02` |
| `--scrollbar-color` | `#a9bbcb` | `#959595` |
| `--color-problem` | `#931919` | `#571818` |
| `--hamburger-lines-color` | `#274b66` | `#282f38` |
| `--border-color-success` | `#00b065` | `#00874d` |
| `--icon-fill` | `#274b66` | `#515d70` |
| `--color-menu-link-active` | `#2e475d` | `#282f38` |
| `--color-text-secondary` | `#2e475d` | `#515d70` |
| `--border-color-problem` | `#ff4848` | `#d63d3d` |
| `--color-success` | `#04502f` | `#00361f` |
| `--code-color` | `#10212f` | `#282f38` |
| `--color-text` | `#10212f` | `#282f38` |
| `--color-hint` | `#124164` | `#093051` |
| `--color-info` | `#124164` | `#093051` |
| `--border-default-color` | `#cde4f7` | `#dee1e6` |
| `--header-icon-border` | `#cde4f7` | `#dee1e6` |
| `--icon-tile-border` | `#cde4f7` | `#dee1e6` |
| `--color-menu-link` | `#3e607d` | `#515d70` |
| `--color-subtitle` | `#3e607d` | `#515d70` |
| `--color-heading` | `#152b3d` | `#282f38` |
| `--bg-color-menu` | `#fafdff` | `#f5f6f8` |
| `--background-light` | `#f2f8fd` | `#f5f6f8` |
| `--code-background` | `#f2f8fd` | `#f5f6f8` |
| `--header-icon-background` | `#f2f8fd` | `#f5f6f8` |
| `--icon-tile-background` | `#f2f8fd` | `#f5f6f8` |
| `--bg-color-tab` | `#dae2e9` | `#dee1e6` |
| `--border-color-header` | `#dae2e9` | `#dee1e6` |
| `--border-color-menu-open` | `#dae2e9` | `#dee1e6` |
| `--border-color-tab` | `#dae2e9` | `#dee1e6` |
| `--header-separator-color` | `#dae2e9` | `#dee1e6` |
| `--separator-color` | `#dae2e9` | `#dee1e6` |
| `--theme-switcher-border` | `#dae2e9` | `#dee1e6` |

</details>

<details>
<summary><b>Dark — 43 values changed</b></summary>

| variable | before | after |
| --- | --- | --- |
| `--bg-color-hint` | `rgba(13, 128, 216, 0.1)` | `rgb(from #093051 r g b / 0.8)` |
| `--bg-color-info` | `#274b66` | `rgb(from #093051 r g b / 0.8)` |
| `--bg-color-problem` | `#fff2ee` | `rgb(from #571818 r g b / 0.8)` |
| `--bg-color-success` | `#e8ffeb` | `rgb(from #00361f r g b / 0.75)` |
| `--bg-color-warning` | `#fefae9` | `rgb(from #584201 r g b / 0.90)` |
| `--background-default` | `#ffffff` | `#111a23` |
| `--background-light` | `#f2f8fd` | `#1f303f` |
| `--color-problem` | `#931919` | `#ffd8d8` |
| `--color-success` | `#04502f` | `#b8e7d3` |
| `--color-warning` | `#a23623` | `#fff7d9` |
| `--border-default-color` | `#cde4f7` | `#2e475d` |
| `--icon-fill` | `#274b66` | `#a9bbcb` |
| `--scrollbar-color` | `#a9bbcb` | `#557999` |
| `--body-link-color` | `#1fc0ff` | `#87bfec` |
| `--color-menu-link-alt` | `#1fc0ff` | `#87bfec` |
| `--color-subtitle` | `#f5f6f8` | `#a9bbcb` |
| `--header-link-color` | `#1fc0ff` | `#87bfec` |
| `--octo-blue` | `#1fc0ff` | `#87bfec` |
| `--border-color-warning` | `#fc8431` | `#b98f02` |
| `--border-color-tab-active` | `#7c98b4` | `#449be1` |
| `--color-text-secondary` | `#dae2e9` | `#a9bbcb` |
| `--border-color-hint` | `#1a77ca` | `#449be1` |
| `--border-color-info` | `#1a77ca` | `#449be1` |
| `--icon-tile-border-hover` | `#1fc0ff` | `#449be1` |
| `--code-background` | `#0c1a24` | `#1f303f` |
| `--code-color` | `#dae2e9` | `#f4f6f8` |
| `--color-text` | `#dae2e9` | `#f4f6f8` |
| `--header-link-alt` | `#dae2e9` | `#f4f6f8` |
| `--header-bg` | `#152b3d` | `#111a23` |
| `--border-color-problem` | `#ff4848` | `#ff5d5d` |
| `--icon-tile-background-hover` | `#223950` | `#2e475d` |
| `--icon-tile-border` | `#1c3f59` | `#2e475d` |
| `--color-hint` | `#dae2e9` | `#cde4f7` |
| `--color-info` | `#dae2e9` | `#cde4f7` |
| `--color-heading` | `#ffffff` | `#f4f6f8` |
| `--hamburger-lines-color` | `#ffffff` | `#f4f6f8` |
| `--icon-tile-background` | `#132838` | `#1f303f` |
| `--color-base-primary` | `#10202e` | `#111a23` |
| `--header-icon-background` | `#152b3d` | `#1f303f` |
| `--bg-color-tab` | `#314c62` | `#2e475d` |
| `--border-color-tab` | `#314c62` | `#2e475d` |
| `--border-color-success` | `#00b065` | `#00ab62` |
| `--bg-color-menu` | `#0c1a24` | `#111a23` |

</details>

Captured by snapshotting all computed custom properties plus the rendered color, background, border and font of seven elements, in both themes, before and after. Production build clean: 2,697 pages. `pnpm spellcheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





