### PR TITLE
Make the Infrastructure target-tag matrix table fill the content column

### DIFF
--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -417,6 +417,9 @@ h6:hover .bookmark-link,
 
 table {
   border-collapse: collapse;
+  /* Without this, auto layout shrinks tables to their content width and leaves
+     a ragged gap on the right of the content column. */
+  width: 100%;
 }
 
 table thead {

--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -419,6 +419,10 @@ table {
   border-collapse: collapse;
 }
 
+.table-full-width table {
+  width: 100%;
+}
+
 table thead {
   font-weight: 700;
 }

--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -419,14 +419,6 @@ table {
   border-collapse: collapse;
 }
 
-.table-full-width table {
-  width: 100%;
-}
-
-.table-full-width th {
-  text-align: left;
-}
-
 table thead {
   font-weight: 700;
 }
@@ -445,6 +437,14 @@ table tr td:first-child {
 
 table th {
   padding: 0.8rem 1rem;
+}
+
+.table-full-width table {
+  width: 100%;
+}
+
+.table-full-width th {
+  text-align: left;
 }
 
 .credits table,

--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -417,9 +417,6 @@ h6:hover .bookmark-link,
 
 table {
   border-collapse: collapse;
-  /* Without this, auto layout shrinks tables to their content width and leaves
-     a ragged gap on the right of the content column. */
-  width: 100%;
 }
 
 table thead {

--- a/public/docs/css/main.css
+++ b/public/docs/css/main.css
@@ -423,6 +423,10 @@ table {
   width: 100%;
 }
 
+.table-full-width th {
+  text-align: left;
+}
+
 table thead {
   font-weight: 700;
 }

--- a/src/pages/docs/infrastructure/index.mdx
+++ b/src/pages/docs/infrastructure/index.mdx
@@ -21,11 +21,11 @@ You assign deployment targets to an environment and you can set up a lifecycle t
 
 Target tags also make applying the same process to all environments easier. The table below shows a matrix of target tags and environments, with environments having different resource sets. Deployments proceed in an orderly fashion across the matrix.
 
-| | <div style="width:175px">Development</div> | <div style="width:175px">Staging</div> | Production |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------ | -------------- |
-| Web tag                | Dev-Target-1     | Staging-Target-1<br />Staging-Target-2     | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
-| API tag | Dev-Target-2     | Staging-Target-3<br />Staging-Target-4     | Production-Target-4<br />Production-Target-5 |
-| Database tag | Dev-Target-3 | Staging-Target-5 | Production-Target-6<br />Production-Target-7 |
+| Target tag   | Development  | Staging                                | Production                                                            |
+| ------------ | ------------ | -------------------------------------- | --------------------------------------------------------------------- |
+| Web tag      | Dev-Target-1 | Staging-Target-1<br />Staging-Target-2  | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
+| API tag      | Dev-Target-2 | Staging-Target-3<br />Staging-Target-4  | Production-Target-4<br />Production-Target-5                          |
+| Database tag | Dev-Target-3 | Staging-Target-5                       | Production-Target-6<br />Production-Target-7                          |
 
 You can manage the machines and services you deploy your software to on the **Infrastructure** tab of the Octopus Web Portal:
 

--- a/src/pages/docs/infrastructure/index.mdx
+++ b/src/pages/docs/infrastructure/index.mdx
@@ -23,14 +23,14 @@ Target tags also make applying the same process to all environments easier. The 
 
 | Target tag   | Development  | Staging                                | Production                                                            |
 | ------------ | ------------ | -------------------------------------- | --------------------------------------------------------------------- |
-| Web tag      | Dev-Target-1 | Staging-Target-1<br />Staging-Target-2  | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
-| API tag      | Dev-Target-2 | Staging-Target-3<br />Staging-Target-4  | Production-Target-4<br />Production-Target-5                          |
+| Web tag      | Dev-Target-1 | Staging-Target-1<br />Staging-Target-2 | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
+| API tag      | Dev-Target-2 | Staging-Target-3<br />Staging-Target-4 | Production-Target-4<br />Production-Target-5                          |
 | Database tag | Dev-Target-3 | Staging-Target-5                       | Production-Target-6<br />Production-Target-7                          |
 
 You can manage the machines and services you deploy your software to on the **Infrastructure** tab of the Octopus Web Portal:
 
 :::figure
-![](/docs/img/infrastructure/images/infrastructure-overview-dashboard.png)
+![The Infrastructure overview dashboard in the Octopus Web Portal](/docs/img/infrastructure/images/infrastructure-overview-dashboard.png)
 :::
 
 There are a few key infrastructure concepts in Octopus Deploy:

--- a/src/pages/docs/infrastructure/index.mdx
+++ b/src/pages/docs/infrastructure/index.mdx
@@ -21,11 +21,15 @@ You assign deployment targets to an environment and you can set up a lifecycle t
 
 Target tags also make applying the same process to all environments easier. The table below shows a matrix of target tags and environments, with environments having different resource sets. Deployments proceed in an orderly fashion across the matrix.
 
-| Target tag   | <div style="width:175px">Development</div> | <div style="width:175px">Staging</div> | Production                                                            |
+:::div{.table-full-width}
+
+|              | <div style="width:175px">Development</div> | <div style="width:175px">Staging</div> | Production                                                            |
 | ------------ | ------------------------------------------ | -------------------------------------- | --------------------------------------------------------------------- |
 | Web tag      | Dev-Target-1                               | Staging-Target-1<br />Staging-Target-2 | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
 | API tag      | Dev-Target-2                               | Staging-Target-3<br />Staging-Target-4 | Production-Target-4<br />Production-Target-5                          |
 | Database tag | Dev-Target-3                               | Staging-Target-5                       | Production-Target-6<br />Production-Target-7                          |
+
+:::
 
 You can manage the machines and services you deploy your software to on the **Infrastructure** tab of the Octopus Web Portal:
 

--- a/src/pages/docs/infrastructure/index.mdx
+++ b/src/pages/docs/infrastructure/index.mdx
@@ -21,11 +21,11 @@ You assign deployment targets to an environment and you can set up a lifecycle t
 
 Target tags also make applying the same process to all environments easier. The table below shows a matrix of target tags and environments, with environments having different resource sets. Deployments proceed in an orderly fashion across the matrix.
 
-| Target tag   | Development  | Staging                                | Production                                                            |
-| ------------ | ------------ | -------------------------------------- | --------------------------------------------------------------------- |
-| Web tag      | Dev-Target-1 | Staging-Target-1<br />Staging-Target-2 | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
-| API tag      | Dev-Target-2 | Staging-Target-3<br />Staging-Target-4 | Production-Target-4<br />Production-Target-5                          |
-| Database tag | Dev-Target-3 | Staging-Target-5                       | Production-Target-6<br />Production-Target-7                          |
+| Target tag   | <div style="width:175px">Development</div> | <div style="width:175px">Staging</div> | Production                                                            |
+| ------------ | ------------------------------------------ | -------------------------------------- | --------------------------------------------------------------------- |
+| Web tag      | Dev-Target-1                               | Staging-Target-1<br />Staging-Target-2 | Production-Target-1<br />Production-Target-2<br />Production-Target-3 |
+| API tag      | Dev-Target-2                               | Staging-Target-3<br />Staging-Target-4 | Production-Target-4<br />Production-Target-5                          |
+| Database tag | Dev-Target-3                               | Staging-Target-5                       | Production-Target-6<br />Production-Target-7                          |
 
 You can manage the machines and services you deploy your software to on the **Infrastructure** tab of the Octopus Web Portal:
 


### PR DESCRIPTION
## What

The target-tag matrix table on `/docs/infrastructure` rendered **713px wide in an 800px content column**, so its row borders stopped short of the right edge and its headings sat 37–59px right of the data they label. Now 800px of 800px, headings aligned.

## Changes

One opt-in class in `public/docs/css/main.css`:

```css
.table-full-width table {
  width: 100%;
}

.table-full-width th {
  text-align: left;
}
```

and that table wrapped in `:::div{.table-full-width}`.

`th` has no `text-align` anywhere in the stylesheet, so it falls back to the browser default of `center` — unnoticeable while a table is only as wide as its content, wrong once it fills the column. Both properties are in the one class for that reason.

I tested applying it to all tables as default,  and ran side by side comparisons but it made some tables less readable, opted to instead implement this version with just one. 

## Scope

`.table-full-width` appears three times in the repo: that one table, and these two rules. No other table on the site changes, verified on the deployed build against a 12-table control page.

Mobile is unchanged. The table's min-content width is 628px, so below roughly 800px of content column nothing moves.


## Before / After

<img width="3834" height="1223" alt="image" src="https://github.com/user-attachments/assets/3a2b6786-65cf-4794-8463-e1cfdc6347d0" />
<img width="3837" height="1919" alt="image" src="https://github.com/user-attachments/assets/e940f6c6-82e2-4062-90f2-1ce14dd78dcf" />
<img width="3820" height="1268" alt="image" src="https://github.com/user-attachments/assets/3bfb6f3f-6cb6-4250-a46c-607cb3d7e580" />
