### PR TITLE
Emit bundled Astro assets under the /docs/ prefix

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,11 @@ import llmMdEmitter from './src/integrations/llm-md-emitter.ts';
 export default defineConfig({
     site: 'https://octopus.com',
     compressHTML: true, // preserve astro v6 behavior - https://docs.astro.build/en/guides/upgrade-to/v7/
+    build: {
+        // The site is proxied onto octopus.com under /docs/ only, so bundled
+        // assets must live inside that prefix or the CDN 404s them.
+        assets: 'docs/_astro',
+    },
     integrations: [
         mdx(),
         llmMdEmitter()

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
     compressHTML: true, // preserve astro v6 behavior - https://docs.astro.build/en/guides/upgrade-to/v7/
     build: {
         // The site is proxied onto octopus.com under /docs/ only, so bundled
-        // assets must live inside that prefix or the CDN 404s them.
+        // assets must live inside that prefix or the CDN 404s them
         assets: 'docs/_astro',
     },
     integrations: [


### PR DESCRIPTION
# Background

Azure Front Door serves this site at `octopus.com/docs` and declines anything outside `/docs`. 

See: sources it has is only under docs + octopus-public (this is for the footer actually not deployed by this)

<img width="250" height="230" alt="image" src="https://github.com/user-attachments/assets/72c37cd3-1b1f-4021-b468-bb6af72c9573" /> 

Astro emitted its bundled component CSS to `/_astro/`, so it 404s on the CDN.

Error example:
<img width="3547" height="553" alt="image" src="https://github.com/user-attachments/assets/b9b4109d-ba2f-47b6-8d1d-b3d605b4c50e" />


This broke the theme toggle selector and the search styles:

<img width="1877" height="276" alt="image" src="https://github.com/user-attachments/assets/9c6660c4-3d60-4411-b7ad-b5d684a94ab9" />

This was the first [CSS file bundled](https://docs.astro.build/en/guides/styling/#import-a-local-stylesheet) this way, hence why it didn't exist before.

# Result
Sets `build.assets: 'docs/_astro'` so the bundle lands inside the routed prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)