### PR TITLE
Update styling for <code> blocks, wrap text on word boundaries

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,9 @@ import { unified } from '@astrojs/markdown-remark';
 import mdx from '@astrojs/mdx';
 import { attributeMarkdown, wrapTables } from '/src/themes/octopus/utilities/custom-markdown.mjs';
 import llmMdEmitter from './src/integrations/llm-md-emitter.ts';
+import rehypeWbr from './src/plugins/rehype-wbr.js';
+
+console.log('rehypeWbr =', rehypeWbr);
 
 // https://astro.build/config
 export default defineConfig({
@@ -29,6 +32,9 @@ export default defineConfig({
                 remarkHeading,
                 attributeMarkdown,
                 wrapTables
+            ],
+            rehypePlugins: [
+                rehypeWbr
             ],
         }),
     },

--- a/src/plugins/rehype-wbr.js
+++ b/src/plugins/rehype-wbr.js
@@ -1,0 +1,32 @@
+import { visit } from 'unist-util-visit';
+
+// Break *before* each of these characters
+const SEPARATORS = /(?=[.\[:\/\\])/;
+
+function withBreaks(value) {
+  const parts = value.split(SEPARATORS).filter(Boolean);
+  if (parts.length < 2) return null;
+
+  return parts.flatMap((part, i) => {
+    const text = { type: 'text', value: part };
+    return i === 0
+      ? [text]
+      : [
+          { type: 'element', tagName: 'wbr', properties: {}, children: [] },
+          text,
+        ];
+  });
+}
+
+export default function rehypeWbr() {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName !== 'code') return;
+      if (parent?.tagName === 'pre') return; // fenced blocks, leave alone
+
+      node.children = node.children.flatMap((child) =>
+        child.type === 'text' ? (withBreaks(child.value) ?? [child]) : [child]
+      );
+    });
+  };
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -108,26 +108,27 @@ blockquote cite {
 
 /* TODO: Refactor code snippets. This needs to be a component. */
 code {
-  font-family: var(--code-font);
-  background-color: var(--navy-200);
+  font-family: var(--fontFamilyCode);
+  border-radius: var(--borderRadiusSmall);
+  border: var(--borderWidth1) solid var(--colorBorderPrimary);
+  background: var(--colorBackgroundSecondaryDefault);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 
 pre {
   padding: 0.5rem 1rem;
   white-space: break-spaces;
-  background-color: var(--code-background) !important;
-  border-radius: var(--standard-radius);
-  font-family: var(--code-font);
-  color: var(--code-color);
+  background: var(--colorBackgroundSecondaryDefault) !important;
+  border: var(--borderWidth1) solid var(--colorBorderPrimary);
+  border-radius: var(--borderRadiusLarge);
+  font-family: var(--fontFamilyCode);
+  color: var(--color-text);
 }
 
 pre code {
   background-color: unset;
-}
-
-.dark pre {
-  background-color: var(--color-base-primary) !important;
-  filter: invert(98%) hue-rotate(180deg);
+  border: unset;
 }
 
 /* TODO: Also will be removed once component is implemented */
@@ -137,8 +138,8 @@ div.warning code:not(pre code),
 div.problem code:not(pre code),
 div.question code:not(pre code),
 div.hint code:not(pre code) {
-  background-color: var(--code-background);
-  color: var(--code-color);
+  background-color: var(--colorBackgroundSecondaryDefault);
+  color: var(--color-text);
 }
 
 html[data-theme='dark'] {

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -128,9 +128,6 @@
 
   --duration-default: 300ms;
 
-  --code-color: var(--color-text);
-  --code-background: var(--colorBackgroundSecondaryDefault);
-
   /* Backgrounds */
   --background-light: var(--colorBackgroundSecondaryDefault);
   --background-default: var(--colorBackgroundPrimaryDefault);
@@ -201,14 +198,14 @@
   --octo-blue-lighter: #2f95e3ff;
   --octo-blue-lightest: #1fc0ffff;
 
-  --font-family-system: system-ui, -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif,
-    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  --font-family-system:
+    system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
   --font-family: var(--font-family-system);
   --heading-font: var(--font-family);
   --body-font: var(--font-family);
   --bold-font: var(--font-family);
-  --code-font: Consolas, monaco, monospace;
 
   --header-bg: var(--colorBackgroundPrimaryDefault);
   --header-link-color: var(--octo-blue);


### PR DESCRIPTION
Uses the styling from design tokens / ui design figma and applies it to `<code>` blocks

# Before

<img width="919" height="585" alt="image" src="https://github.com/user-attachments/assets/e12c67f7-3312-4ffe-9240-36a1290b2e50" />

<img width="919" height="585" alt="image" src="https://github.com/user-attachments/assets/3a6189b9-1fa4-4870-bf86-667fbdf3f0c6" />

Word wrapping:

<img width="919" height="228" alt="image" src="https://github.com/user-attachments/assets/d8fbb7fa-1f64-40ed-b7bb-7dc1710c3be8" />

# After

<img width="919" height="585" alt="image" src="https://github.com/user-attachments/assets/bd7c99c2-f6b1-45c7-bf3c-21392d491b3d" />

<img width="919" height="585" alt="image" src="https://github.com/user-attachments/assets/ccde4c3a-0065-4336-bbf2-c9d7751c03e1" />

Word wrapping:

<img width="919" height="267" alt="image" src="https://github.com/user-attachments/assets/2234148b-c11b-44fe-be0a-6006f06448f3" />
