### PR TITLE
Space list items 6px apart and pin the body letter-spacing token

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -54,6 +54,25 @@ button forced visible. Normally it appears on hover or keyboard focus.
   }
 </style>
 
+## Body text \{#body-text}
+
+In this tutorial you'll set up a small deployment in Octopus and watch it run.
+You'll create a project, add a single step that prints Hello, World!, then create
+a release and deploy it to a test environment.
+
+Paragraphs sit one rem apart. List items after the first sit 6px below the item
+above, which the two lists below show.
+
+1. In the **Welcome to your Project** dialog, select **Thanks, got it**.
+1. In the process step template library, find the Run a Script card in the
+   **Featured** category and select **Add Step**.
+1. Leave the **Step Name** as the default *Run a Script*.
+
+- In the **Welcome to your Project** dialog, select **Thanks, got it**.
+- In the process step template library, find the Run a Script card in the
+  **Featured** category and select **Add Step**.
+- Leave the **Step Name** as the default *Run a Script*.
+
 ## Examples
 
 ### Boxes

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -315,9 +315,11 @@ strong {
 
 /* Figma puts space/6 above every list item after the first, so consecutive
    items read as a group while the list still sits tight against the block
-   above it. The component lists in the article body - the taxonomy chips and
-   the copy markdown menu - space themselves and opt out. */
-.page-content li + li:not(:where(.post-taxonomy *, .octo-copy-md *)) {
+   above it. Only markdown content lists are in scope, and those are the
+   classless ones - the component lists rendered into the article body (recent
+   updates, article cards, the copy markdown menu) all carry a class and space
+   themselves. */
+.page-content :where(ul, ol):not([class]) > li + li {
   padding-block-start: var(--space6);
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23,6 +23,10 @@ html {
 
 body {
   font: var(--textBodyRegularLarge);
+  /* The composite carries weight, size, line-height and family. Figma's
+     text/body/regular/large also names a letter-spacing token, which the
+     composite leaves out, so it is set here. */
+  letter-spacing: var(--letterSpacingNone);
   color: var(--color-text);
   background-color: var(--color-base-primary);
   transition-property: background-color, color;
@@ -307,6 +311,14 @@ strong {
 .page-content ul,
 .page-content ol {
   margin-inline-start: 2rem;
+}
+
+/* Figma puts space/6 above every list item after the first, so consecutive
+   items read as a group while the list still sits tight against the block
+   above it. The component lists in the article body - the taxonomy chips and
+   the copy markdown menu - space themselves and opt out. */
+.page-content li + li:not(:where(.post-taxonomy *, .octo-copy-md *)) {
+  padding-block-start: var(--space6);
 }
 
 /* Boxes */


### PR DESCRIPTION
Implements the **Body** section of the Documentation vision Figma file ([node 1561-20194](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1561-20194&m=dev)) — body text, paragraphs, and lists.

Stacked on #3276 (`wl/font-tokens`), so review that one first.

## What changed

- **List item spacing.** Figma specifies `space/6` above every list item after the first (`space/0` on the first). Nothing in `main.css` set list item spacing, so consecutive items sat 24px apart on the line-height alone. Markdown content lists in `.page-content` now carry `padding-block-start: var(--space6)` from the second item on, giving the 24/30/30px item pitch in the design. The rule opts in on `:where(ul, ol):not([class])`: markdown lists are classless, and the component lists rendered into the article body (recent updates, `.post-list` card grids, the copy markdown menu) all carry a class and space themselves.
- **Body letter-spacing.** `--textBodyRegularLarge` omits letter-spacing, so `body` names `--letterSpacingNone` directly to complete the `text/body/regular/large` spec.
- **Samples.** A Body text section in `src/pages/index.md` (the Index page, not published) with the paragraph and both lists from the design, including the bold and italic inline runs, so the item spacing is visible.

## Already matching Figma, unchanged

`body` renders `text/body/regular/large` through `--textBodyRegularLarge` (400 16px/24px, system-ui stack) in `--colorTextPrimary` (#282F38). Measured in the dev server: computed `16px / 24px`, `rgb(40, 47, 56)`, list item pitch 24 / 30 / 30px, which matches the Figma `ListItems` heights. The design specifies no borders and no margins on the list items; the white card, 10px radius and 20px padding around each sample belong to the Figma sample frames.

## Left alone

Figma's list markers sit ~24px from the content edge; the site uses `margin-inline-start: 2rem` (32px). The design's only annotation was the 6px item padding and the Figma plugin's list geometry is an approximation, so the indent is unchanged.

## Verification

Rendered these pages in the dev server and read the computed padding on every list inside `.page-content`:

| Page | Result |
| --- | --- |
| `/` (Index samples) | markdown `ol`/`ul`: first item 0, rest 6px |
| `/docs` | markdown lists 6px, `.recent-updates` untouched at 0 |
| `/docs/kubernetes` | markdown lists 6px including a nested sub-list |
| `/docs/administration/high-availability/how-high-availability-works` | 8 markdown lists 6px, `.octo-copy-md__options` untouched at 0 |
| `/docs/administration/data/backup-and-restore` | markdown lists 6px, menu untouched |

`cspell` and `markdownlint-cli2` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
