### PR TITLE
Register ocl as a Shiki language alias

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,7 +21,11 @@ export default defineConfig({
     ],
     markdown: {
         shikiConfig: {
-            theme: 'light-plus'
+            theme: 'light-plus',
+            // OCL is HCL-derived, so reuse the HCL grammar for ```ocl fences
+            langAlias: {
+                ocl: 'hcl'
+            }
         },
         processor: unified({
             remarkPlugins: [

--- a/src/pages/docs/platform-hub/policies/examples.md
+++ b/src/pages/docs/platform-hub/policies/examples.md
@@ -651,7 +651,7 @@ If you prefer to write policies directly in your Git repository instead of using
 
 ### OCL file format
 
-```hcl
+```ocl
 name = "Policy Name"
 description = "Policy description"
 violation_reason = "Custom message shown when the policy fails"

--- a/src/pages/docs/platform-hub/templates/process-templates/index.md
+++ b/src/pages/docs/platform-hub/templates/process-templates/index.md
@@ -72,7 +72,7 @@ Unlike the other parameters, sensitive default values are stored securely in the
 
 You can set a default value for a sensitive parameter by navigating to the parameters tab of your process template and committing your changes. When the template is saved, sensitive default values are stored encrypted in the database with a unique identifier. In the OCL, the parameter block will look something like this:
 
-```hcl
+```ocl
 parameter "Example Sensitive Parameter" {
     display_settings = {
         Octopus.ControlType = "Sensitive"

--- a/src/pages/docs/platform-hub/templates/process-templates/troubleshooting.md
+++ b/src/pages/docs/platform-hub/templates/process-templates/troubleshooting.md
@@ -187,7 +187,7 @@ Octopus.ProcessTemplate[ProcessTemplateUsageStepName].Action[StepName].Output.Pr
 
 Consider a process template named **Build and Create Web App** containing a step that runs a script and publishes an output variable `FilePath`:
 
-```hcl
+```ocl
 name = "Build and Create Web App"
 description = ""
 
@@ -212,7 +212,7 @@ Octopus.ProcessTemplate.Action[Collect Details].Output.FilePath
 
 When this process template is used in a project with a process template usage step named **Create Web App**:
 
-```hcl
+```ocl
 process_template "run-a-process-template" {
     name = "Create Web App"
     process_template_slug = "build-and-create-web-app"

--- a/src/pages/docs/projects/version-control/config-as-code-reference.mdx
+++ b/src/pages/docs/projects/version-control/config-as-code-reference.mdx
@@ -202,7 +202,7 @@ The runbooks/ directory will contain runbook-name.ocl files for any published ru
 
 The *deployment_process.ocl* file contains the configuration for your project's steps. Below is an example *deployment_process.ocl* for a project containing a single *Deploy a Package* step.
 
-```hcl
+```ocl
 step "deploy-a-package" {
     name = "Deploy a Package"
     properties = {
@@ -236,7 +236,7 @@ step "deploy-a-package" {
 
 The *deployment_settings.ocl* file contains the configuration for the deployment settings associated with the deployment process. If using the default deployment process settings, the .ocl will be mostly empty.
 
-```hcl
+```ocl
 connectivity_policy {
 }
 
@@ -246,7 +246,7 @@ versioning_strategy {
 
 However, configuring the settings via Octopus will populate the fields with their properties and values.
 
-```hcl
+```ocl
 default_guided_failure_mode = "On"
 deployment_changes_template = <<-EOT
         #{each release in Octopus.Deployment.Changes}
@@ -281,7 +281,7 @@ versioning_strategy {
 
 The *variables.ocl* file contains all non-sensitive variables for the project.
 
-```hcl
+```ocl
 variable "DatabaseName" {
     value "AU-BNE-TST-001" {
         environment = ["test"]

--- a/src/pages/docs/projects/version-control/ocl-file-format.md
+++ b/src/pages/docs/projects/version-control/ocl-file-format.md
@@ -12,14 +12,13 @@ navOrder: 70
 
 Octopus Configuration Language (OCL) is based on a subset of Hashicorp Configuration Language (HCL). OCL files use the `.ocl` file extension, and are located in the base path defined in the projects version control settings.
 
-General information about the OCL format can be found [here](https://github.com/OctopusDeploy/Ocl), including the [EBNF notation](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form).
+General information about the OCL format is available in the [OCL repository](https://github.com/OctopusDeploy/Ocl), including the [EBNF notation](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form).
 
 ## Deployment Process
 
 The Deployment Process is defined in the `deployment_process.ocl` file. It consists of one or more steps. These steps are defined as blocks in OCL.
 
 ### `step` block
-
 
 Each step contains one label, which is the slug of the step. This must be unique throughout the process.
 
@@ -46,7 +45,9 @@ Default: `LetOctopusDecide`
 ### `step.properties`
 
 Properties is a dictionary of key-value-pairs.
+
 Example:
+
 ```ocl
 properties = {
     Octopus.Account.Id = "My Awesome Account"
@@ -137,6 +138,7 @@ tenant_tags = ["My Tenant/My Tag", "My Tenant/My Other Tag"]
 ### `step.action.worker_pool`
 
 The slug of a worker pool where this action should execute.
+
 ```ocl
 worker_pool = "my-worker-pool"
 ```
@@ -144,6 +146,7 @@ worker_pool = "my-worker-pool"
 ### `step.action.worker_pool_variable`
 
 The name of the variable pointing to a worker pool where this action should execute.
+
 ```ocl
 worker_pool_variable = "WorkerPoolVariable"
 ```
@@ -178,7 +181,7 @@ packages "<PACKAGE_NAME>" {
 }
 ```
 
-#### Example
+#### Example: deployment process steps
 
 ```ocl
 step "Hello world (using PowerShell)" {
@@ -244,7 +247,7 @@ value "<VARIABLE_VALUE>" {
 
 Defines the variable type. If omitted, the type is `String` (text). Valid values are `AzureAccount`, `GoogleCloudAccount`, `AmazonWebServicesAccount`, `Certificate`, `WorkerPool`, `Sensitive`, and `String`. Sensitive values should not be stored in the `variables.ocl` file - they should be stored in the database by using the Octopus Deploy UI instead.
 
-#### Example
+#### Example: value type
 
 ```ocl
 variable "Backup worker pool" {
@@ -259,7 +262,7 @@ variable "Backup worker pool" {
 
 Defines a description for a variable. This is often used to more fully describe what the variable does or any important notes about changing its value.
 
-#### Example
+#### Example: value description
 
 ```ocl
 variable "Logging.Level" {
@@ -274,7 +277,7 @@ variable "Logging.Level" {
 
 The `value` block can optional contain a `prompt` block. This allows for values to be set manually during deployment.
 
-#### Example
+#### Example: prompted value
 
 ```ocl
 variable "VersionNumber" {
@@ -306,7 +309,7 @@ Determines whether the value can be left blank when a deployment is done. The va
 
 Defines one or more actions (steps) that the value will apply to.
 
-#### Example
+#### Example: action scope
 
 ```ocl
 variable "Logging.Level" {
@@ -321,7 +324,7 @@ variable "Logging.Level" {
 
 Defines one or more channels that the value will apply to.
 
-#### Example
+#### Example: channel scope
 
 ```ocl
 variable "Version.Tag" {
@@ -362,7 +365,7 @@ variable "Server.Label" {
 
 Defines one or more roles that the value will apply to.
 
-#### Example
+#### Example: role scope
 
 ```ocl
 variable "Application.Name" {

--- a/src/pages/docs/projects/version-control/ocl-file-format.md
+++ b/src/pages/docs/projects/version-control/ocl-file-format.md
@@ -45,7 +45,6 @@ Default: `LetOctopusDecide`
 ### `step.properties`
 
 Properties is a dictionary of key-value-pairs.
-
 Example:
 
 ```ocl

--- a/src/pages/docs/projects/version-control/ocl-file-format.md
+++ b/src/pages/docs/projects/version-control/ocl-file-format.md
@@ -23,7 +23,7 @@ The Deployment Process is defined in the `deployment_process.ocl` file. It consi
 
 Each step contains one label, which is the slug of the step. This must be unique throughout the process.
 
-```hcl
+```ocl
 step "<step-slug>" {
     ...
 }
@@ -47,7 +47,7 @@ Default: `LetOctopusDecide`
 
 Properties is a dictionary of key-value-pairs.
 Example:
-```hcl
+```ocl
 properties = {
     Octopus.Account.Id = "My Awesome Account"
     MyCustomProperty = "My Value"
@@ -65,7 +65,7 @@ Default: `StartAfterPrevious`
 Steps generally contain a single action. However, there are some cases where they can contain multiple steps.
 Actions are also defined as OCL blocks.
 
-```hcl
+```ocl
 action "<action-slug>" {
     ...
 }
@@ -79,7 +79,7 @@ Tells Octopus what type of action this is, e.g: `Octopus.Script`, `Octopus.Nginx
 
 A list of channel slugs which this action will be executed for.
 
-```hcl
+```ocl
 channels = ["default", "pre-release"]
 ```
 
@@ -92,7 +92,7 @@ Default: `Success`
 
 A list of environment slugs where this action will be executed.
 
-```hcl
+```ocl
 environments = ["production", "staging"]
 ```
 
@@ -100,7 +100,7 @@ environments = ["production", "staging"]
 
 A list of environment slugs where this action will be excluded from execution.
 
-```hcl
+```ocl
 excluded_environments = ["production", "staging"]
 ```
 
@@ -130,21 +130,21 @@ Same as the Step `properties`.
 
 A list of canonical tenant tag names which this action applies to.
 
-```hcl
+```ocl
 tenant_tags = ["My Tenant/My Tag", "My Tenant/My Other Tag"]
 ```
 
 ### `step.action.worker_pool`
 
 The slug of a worker pool where this action should execute.
-```hcl
+```ocl
 worker_pool = "my-worker-pool"
 ```
 
 ### `step.action.worker_pool_variable`
 
 The name of the variable pointing to a worker pool where this action should execute.
-```hcl
+```ocl
 worker_pool_variable = "WorkerPoolVariable"
 ```
 
@@ -152,7 +152,7 @@ worker_pool_variable = "WorkerPoolVariable"
 
 If the action should be executed in a container, the `container` block can be used to specify the container.
 
-```hcl
+```ocl
 container "<IMAGE_NAME>" {
     feed = "<CONTAINER_FEED_SLUG>"
 }
@@ -162,7 +162,7 @@ container "<IMAGE_NAME>" {
 
 Actions can reference packages using one or more `package` blocks.
 
-```hcl
+```ocl
 packages "<PACKAGE_NAME>" {
     acquisition_location = "Server|ExecutionTarget|NotAcquired"
     feed = "<FEED_SLUG>"
@@ -180,7 +180,7 @@ packages "<PACKAGE_NAME>" {
 
 #### Example
 
-```hcl
+```ocl
 step "Hello world (using PowerShell)" {
 
     action {
@@ -222,7 +222,7 @@ The Variables are defined in the `variables.ocl` file. Variables are defined as 
 
 ### `variable` block
 
-```hcl
+```ocl
 variable "<LABEL>" {
     ...
 }
@@ -234,7 +234,7 @@ The variable block contains one or more value blocks.
 
 ### `variable.value` block
 
-```hcl
+```ocl
 value "<VARIABLE_VALUE>" {
     ...
 }
@@ -246,7 +246,7 @@ Defines the variable type. If omitted, the type is `String` (text). Valid values
 
 #### Example
 
-```hcl
+```ocl
 variable "Backup worker pool" {
 
     value "WorkerPools-3" {
@@ -261,7 +261,7 @@ Defines a description for a variable. This is often used to more fully describe 
 
 #### Example
 
-```hcl
+```ocl
 variable "Logging.Level" {
 
     value "Info" {
@@ -276,7 +276,7 @@ The `value` block can optional contain a `prompt` block. This allows for values 
 
 #### Example
 
-```hcl
+```ocl
 variable "VersionNumber" {
 
     value {
@@ -308,7 +308,7 @@ Defines one or more actions (steps) that the value will apply to.
 
 #### Example
 
-```hcl
+```ocl
 variable "Logging.Level" {
 
     value "Info" {
@@ -323,7 +323,7 @@ Defines one or more channels that the value will apply to.
 
 #### Example
 
-```hcl
+```ocl
 variable "Version.Tag" {
 
     value "2022.3" {
@@ -336,7 +336,7 @@ variable "Version.Tag" {
 
 Defines one or more environments that the value will apply to.
 
-```hcl
+```ocl
 variable "API.Key" {
 
     value "20f5cb22-a4f1-493f-a327-a2206f39edd0" {
@@ -349,7 +349,7 @@ variable "API.Key" {
 
 Defines one or more machines that the value will apply to.
 
-```hcl
+```ocl
 variable "Server.Label" {
 
     value "Test SQL Server" {
@@ -364,7 +364,7 @@ Defines one or more roles that the value will apply to.
 
 #### Example
 
-```hcl
+```ocl
 variable "Application.Name" {
 
     value "HAL Portal" {


### PR DESCRIPTION
## Why

`astro build` logged `[Shiki] The language "ocl" doesn't exist, falling back to "plaintext".` Shiki ships no `ocl` grammar, so any ```ocl fence rendered as unhighlighted plaintext.

## What

- `astro.config.mjs`: added `shikiConfig.langAlias = { ocl: 'hcl' }`. OCL is HCL-derived, so the HCL grammar tokenizes it correctly. The rendered `<pre>` keeps `data-language="ocl"`.
- Retagged 30 fences from `hcl` to `ocl` where the sample is OCL.

Genuine Terraform samples keep `hcl`:

- `deployments/terraform/preparing-your-terraform-environment/index.md` (3)
- `best-practices/platform-engineering/secret-variables.md` (3, `octopusdeploy_*` provider resources)
- `argo-cd/instances/automated-installation.md` (1, `helm_release`)

## Pages to review

Every page below was checked on the PR environment and serves the expected number of `data-language="ocl"` blocks.

| Page | `ocl` fences | Preview |
| --- | --- | --- |
| `argo-cd/steps/update-application-image-tags` | 1 (already `ocl`, was unhighlighted) | [view](https://stoctodocspr3284.z22.web.core.windows.net/docs/argo-cd/steps/update-application-image-tags) |
| `projects/version-control/ocl-file-format` | 22 (retagged) | [view](https://stoctodocspr3284.z22.web.core.windows.net/docs/projects/version-control/ocl-file-format) |
| `projects/version-control/config-as-code-reference` | 4 (retagged) | [view](https://stoctodocspr3284.z22.web.core.windows.net/docs/projects/version-control/config-as-code-reference) |
| `platform-hub/templates/process-templates/troubleshooting` | 2 (retagged) | [view](https://stoctodocspr3284.z22.web.core.windows.net/docs/platform-hub/templates/process-templates/troubleshooting) |
| `platform-hub/templates/process-templates` | 1 (retagged) | [view](https://stoctodocspr3284.z22.web.core.windows.net/docs/platform-hub/templates/process-templates/) |
| `platform-hub/policies/examples` | 1 (retagged) | [view](https://stoctodocspr3284.z22.web.core.windows.net/docs/platform-hub/policies/examples) |

## Screenshots

Captured at 1280px / 2× DPI. Before = `main`, after = this branch.

### 1. The `ocl` fence that was falling back to plaintext

[update-application-image-tags](https://stoctodocspr3284.z22.web.core.windows.net/docs/argo-cd/steps/update-application-image-tags) — the only rendering change in the PR.

| Before | After |
| --- | --- |
| <img width="450" alt="OCL block rendered as unhighlighted plaintext" src="https://github.com/user-attachments/assets/a38a69a8-10c9-4072-b3d6-b4b3057a5255" /> | <img width="450" alt="Same OCL block with HCL syntax highlighting" src="https://github.com/user-attachments/assets/6a496964-bee9-4a84-8f2a-5428fab38bf2" /> |

### 2. MD059 link text

[ocl-file-format](https://stoctodocspr3284.z22.web.core.windows.net/docs/projects/version-control/ocl-file-format) — `here` became `OCL repository`.

| Before | After |
| --- | --- |
| <img width="450" alt="Intro paragraph linking the word here" src="https://github.com/user-attachments/assets/c282f2e2-6aa1-4892-b96f-60b350bf1ed0" /> | <img width="450" alt="Intro paragraph linking the words OCL repository" src="https://github.com/user-attachments/assets/5c34c491-872f-4e46-a01c-d6fd07ff1798" /> |

### 3. MD024 duplicate headings

[ocl-file-format, `variable.value.type`](https://stoctodocspr3284.z22.web.core.windows.net/docs/projects/version-control/ocl-file-format#variablevaluetype) — one of seven `Example` headings, now named. The code block underneath is identical in both shots, which is the point: retagging `hcl` to `ocl` changes nothing visually.

| Before | After |
| --- | --- |
| <img width="450" alt="Heading reading Example" src="https://github.com/user-attachments/assets/be74099d-1268-429f-af01-2cfc435c9d8b" /> | <img width="450" alt="Heading reading Example: value type" src="https://github.com/user-attachments/assets/07261f96-7b83-4b45-9693-94dbb5db08f3" /> |

## Markdownlint fixes

Linting runs over changed files, so touching `ocl-file-format.md` surfaced pre-existing errors. None were auto-fixable; all were fixed by hand in `dd0f477`:

| Rule | Fix |
| --- | --- |
| MD059 descriptive-link-text | `[here]` became `[OCL repository]` |
| MD012 no-multiple-blanks | removed a double blank line under the `step` block heading |
| MD031 blanks-around-fences | added a blank line before three fences (`step.properties`, `step.action.worker_pool`, `step.action.worker_pool_variable`) |
| MD024 no-duplicate-heading | the seven `#### Example` headings became distinct: deployment process steps, value type, value description, prompted value, action scope, channel scope, role scope |

No inbound links target the old `#example` anchors, so the heading renames break nothing.

## Verification

- `markdownlint-cli2 --config .markdownlint.json` over the 5 changed md/mdx files: `0 issues in 0 files`.
- Full `astro build` passes with no Shiki warning (2697 pages).
- Rendering `hcl` and aliased `ocl` through Astro's markdown processor produces identical HTML once `data-language` is normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
