### PR TITLE
Make the heading anchor an interactive copy-URL button

### DIFF
--- a/src/assets/icons/check.svg
+++ b/src/assets/icons/check.svg
@@ -1,0 +1,4 @@
+<!-- CheckIcon from @octopusdeploy/design-system-icons -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="currentColor" width="24" height="24" aria-hidden="true">
+  <path d="M33.391 10.608c.812.75.812 2.06 0 2.808L17.41 29.393c-.749.81-2.06.81-2.81 0l-7.99-7.988a1.924 1.924 0 0 1 0-2.808 1.926 1.926 0 0 1 2.81 0l6.617 6.552 14.546-14.54a1.926 1.926 0 0 1 2.81 0" />
+</svg>

--- a/src/assets/icons/link-on.svg
+++ b/src/assets/icons/link-on.svg
@@ -1,8 +1,4 @@
-<!-- LinkOnIcon from @octopusdeploy/design-system-icons
-     (src/icons/LinkOnIcon.tsx). The 40x40 viewBox is the icon set's grid - the
-     path clips at any other value. Referenced as a CSS mask by .bookmark-link,
-     which supplies the color, so the fill attribute below is only used if this
-     file is ever rendered directly. -->
+<!-- LinkOnIcon from @octopusdeploy/design-system-icons -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="currentColor" width="24" height="24" aria-hidden="true">
   <path d="M2 20c0-5.5 4.438-10 10-10h4.5c.813 0 1.5.688 1.5 1.5 0 .875-.687 1.5-1.5 1.5H12c-3.875 0-7 3.188-7 7 0 3.875 3.125 7 7 7h4.5c.813 0 1.5.688 1.5 1.5 0 .875-.687 1.5-1.5 1.5H12A9.95 9.95 0 0 1 2 20m36 0c0 5.563-4.5 10-10 10h-4.5c-.875 0-1.5-.625-1.5-1.5 0-.812.625-1.5 1.5-1.5H28c3.813 0 7-3.125 7-7 0-3.812-3.187-7-7-7h-4.5c-.875 0-1.5-.625-1.5-1.5 0-.812.625-1.5 1.5-1.5H28c5.5 0 10 4.5 10 10m-24.5-1.5h13c.813 0 1.5.688 1.5 1.5 0 .875-.687 1.5-1.5 1.5h-13c-.875 0-1.5-.625-1.5-1.5 0-.812.625-1.5 1.5-1.5"/>
 </svg>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -26,40 +26,6 @@ This page is not shown on the production site.
 - [Oldest content](/report/oldest-content/1)
 - [Taxonomy](/report/taxonomy)
 
-## Headings \{#headings}
-
-In each pair below, the first heading is at rest and the second has the anchor
-button forced visible. Normally it appears on hover or keyboard focus.
-
-<!-- The page title renders as an h1 from frontmatter, so this sample is a second
-     one. Deliberate - this page exists to show the heading styles. -->
-<!-- markdownlint-disable MD025 -->
-
-# Heading 1 (title)
-
-<!-- markdownlint-enable MD025 -->
-
-## Heading 2 \{#heading-2-a}
-
-## Heading 2 \{#heading-2-b}
-
-### Heading 3 \{#heading-3-a}
-
-### Heading 3 \{#heading-3-b}
-
-#### Heading 4
-
-##### Heading 5
-
-###### Heading 6
-
-<style>
-  #heading-2-b .bookmark-link,
-  #heading-3-b .bookmark-link {
-    opacity: 1;
-  }
-</style>
-
 ## Body text \{#body-text}
 
 In this tutorial you'll set up a small deployment in Octopus and watch it run.

--- a/src/scripts/modules/headers.js
+++ b/src/scripts/modules/headers.js
@@ -1,20 +1,124 @@
+// @ts-check
 import { qsa } from './query.js';
 
-/**
- * Enables copy on code blocks (<pre><code>...)
- */
-function enhanceHeaders() {
-  // Make code blocks focusable, so they can be keyboard scrolled
-  qsa('h2[id], h3[id], h4[id], h5[id], h6[id]').forEach((elem) => {
-    const linkContainer = document.createElement('a');
-    linkContainer.href = `#${elem.id}`;
-    linkContainer.className = 'bookmark-link';
-    // The icon is drawn by .bookmark-link::before, so the anchor has no content
-    // of its own and takes its accessible name from here.
-    linkContainer.setAttribute('aria-label', 'Link to this section');
+const REVERT_MS = 2000;
 
-    elem.appendChild(linkContainer);
+const REST = 'Copy URL';
+const COPIED = 'Copied';
+const FAILED = 'Copy failed';
+
+/** @type {HTMLElement | null} */
+let status = null;
+
+/** @type {WeakMap<HTMLElement, ReturnType<typeof setTimeout>>} */
+const timers = new WeakMap();
+
+/**
+ * Scoped to .page-content headings with an id: the feedback prompt and the
+ * navigation render their own headings, and those have nothing to link to.
+ *
+ * Each heading is given an aria-label of its own text. A heading is named from
+ * its contents, and those contents include a nested control's name, so without
+ * this every heading is announced with the button's label on the end.
+ */
+function addCopyButtons() {
+  qsa('.page-content :is(h2, h3, h4, h5, h6)[id]').forEach((heading) => {
+    const headingText = heading.textContent?.trim();
+    if (headingText) heading.setAttribute('aria-label', headingText);
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'copy-heading-url btn btn--xsmall';
+    button.dataset.tooltip = REST;
+    button.setAttribute('aria-label', 'Copy link to this section');
+
+    // Empty: the glyph is a CSS mask on the span itself.
+    const icon = document.createElement('span');
+    icon.className = 'copy-heading-url__icon btn__icon';
+
+    button.appendChild(icon);
+    heading.appendChild(button);
   });
+}
+
+function addCopyListener() {
+  document.addEventListener('click', (event) => {
+    if (!(event.target instanceof Element)) return;
+
+    const button = event.target.closest('.copy-heading-url');
+    if (button instanceof HTMLElement) copyHeadingUrl(button);
+  });
+}
+
+/**
+ * @param {HTMLElement} button
+ */
+async function copyHeadingUrl(button) {
+  const id = button.closest('h2, h3, h4, h5, h6')?.id;
+  if (!id) return;
+
+  const url = new URL(window.location.href);
+  url.hash = id;
+
+  let message = COPIED;
+  try {
+    // Nothing may be awaited before this: Safari spends the click's user
+    // activation on the first await, and the write then fails.
+    await navigator.clipboard.writeText(url.toString());
+  } catch (error) {
+    console.warn('[headers] clipboard write failed', error);
+    message = FAILED;
+  }
+
+  showResult(button, message);
+  announce(message);
+}
+
+/**
+ * @param {HTMLElement} button
+ * @param {string} message
+ */
+function showResult(button, message) {
+  button.dataset.tooltip = message;
+  button.dataset.copied = '';
+
+  clearTimeout(timers.get(button));
+  timers.set(
+    button,
+    setTimeout(() => {
+      button.dataset.tooltip = REST;
+      delete button.dataset.copied;
+      timers.delete(button);
+    }, REVERT_MS)
+  );
+}
+
+/**
+ * The region is appended to the body rather than the heading, so it cannot end
+ * up in a heading's accessible name.
+ *
+ * @param {string} message
+ */
+function announce(message) {
+  if (!status) {
+    status = document.createElement('div');
+    status.className = 'copy-heading-url-status';
+    status.setAttribute('aria-live', 'polite');
+    document.body.append(status);
+  }
+
+  // Cleared first, then set on a later task, so copying twice in a row reads as
+  // a change and is announced both times. Same as copy-markdown.js.
+  const region = status;
+  region.textContent = '';
+  setTimeout(() => {
+    region.textContent = message;
+  }, 50);
+}
+
+function enhanceHeaders() {
+  addCopyButtons();
+  addCopyListener();
 }
 
 export { enhanceHeaders };

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -392,47 +392,65 @@ strong {
   font: var(--textHeadingLarge);
 }
 
-.bookmark-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  /* box-sizing is set on html only and does not inherit, so without this the
-     min-width would exclude the padding and the button would be 36px. */
-  box-sizing: border-box;
-  min-width: 28px;
-  min-height: 28px;
-  padding: var(--space4);
+.copy-heading-url {
+  position: relative;
+  top: -0.1em;
   margin-inline-start: var(--space8);
   vertical-align: middle;
-  background: var(--colorBackgroundPrimaryDefault);
-  border-radius: var(--borderRadiusSmall);
-  outline: var(--borderWidth1) solid var(--colorBorderPrimary);
-  outline-offset: calc(-1 * var(--borderWidth1));
-  text-decoration: none;
   opacity: 0;
 }
 
-.bookmark-link::before {
-  content: '';
-  width: var(--fontSizeLarge);
-  height: var(--fontSizeLarge);
-  /* ::before is a flex item here and would otherwise shrink. */
-  flex: none;
-  /* A mask uses the file's alpha channel, so its fill attribute is ignored and
-     the icon takes the color declared here. The anchor's own color comes from
-     .page-content a:not(.link), which outranks this rule and would render the
-     icon blue. */
+.copy-heading-url__icon {
   background-color: var(--colorIconPrimary);
-  -webkit-mask: url('../assets/icons/link-on.svg') center / contain no-repeat;
   mask: url('../assets/icons/link-on.svg') center / contain no-repeat;
 }
 
-h2:hover .bookmark-link,
-h3:hover .bookmark-link,
-h4:hover .bookmark-link,
-h5:hover .bookmark-link,
-h6:hover .bookmark-link,
-.bookmark-link:focus {
+.copy-heading-url[data-copied] .copy-heading-url__icon {
+  mask: url('../assets/icons/check.svg') center / contain no-repeat;
+}
+
+/* The tooltip bubble. */
+.copy-heading-url::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  inset-block-end: calc(100% + 10px + var(--borderWidth1));
+  translate: -50% 0;
+  padding: var(--space4) var(--space8);
+  border-radius: var(--borderRadiusSmall);
+  background: var(--colorBackgroundInversePrimary);
+  color: var(--colorTextInversePrimary);
+  font: var(--textBodyRegularXSmall);
+  text-align: center;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+}
+
+/* The tooltip arrow. A border triangle, on ::before so the bubble paints over
+   it, and raised 1px so it doesn't show a line. */
+.copy-heading-url::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  inset-block-end: calc(100% + 4px + var(--borderWidth1));
+  translate: -50% 0;
+  width: 0;
+  height: 0;
+  border-block-start: 7px solid var(--colorBackgroundInversePrimary);
+  border-inline: 7px solid transparent;
+  pointer-events: none;
+  opacity: 0;
+}
+
+:is(h2, h3, h4, h5, h6):hover .copy-heading-url,
+.copy-heading-url:focus-visible,
+.copy-heading-url[data-copied] {
+  opacity: 1;
+}
+
+.copy-heading-url:is(:hover, :focus-visible, [data-copied])::before,
+.copy-heading-url:is(:hover, :focus-visible, [data-copied])::after {
   opacity: 1;
 }
 
@@ -1947,8 +1965,10 @@ li.has-children .sub-nav ul li:focus > a {
   content: '\f02d'; /* fa-book */
 }
 
-/* Visually hidden live region for copy-markdown.js status announcements. */
-.octo-copy-md__sr-status {
+/* Live regions for announcing the result of an action, such as copying a URL or
+   a code block. Read by screen readers, never shown. */
+.octo-copy-md__sr-status,
+.copy-heading-url-status {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -392,9 +392,10 @@ strong {
   font: var(--textHeadingLarge);
 }
 
-.copy-heading-url {
+.copy-heading-url.btn {
   position: relative;
   top: -0.1em;
+  font-size: inherit; /* make sure button is centered */
   margin-inline-start: var(--space8);
   vertical-align: middle;
   opacity: 0;
@@ -414,7 +415,7 @@ strong {
   content: attr(data-tooltip);
   position: absolute;
   left: 50%;
-  inset-block-end: calc(100% + 10px + var(--borderWidth1));
+  inset-block-end: calc(100% + var(--space8) + var(--borderWidth1));
   translate: -50% 0;
   padding: var(--space4) var(--space8);
   border-radius: var(--borderRadiusSmall);
@@ -427,13 +428,12 @@ strong {
   opacity: 0;
 }
 
-/* The tooltip arrow. A border triangle, on ::before so the bubble paints over
-   it, and raised 1px so it doesn't show a line. */
+/* The tooltip arrow. A border triangle */
 .copy-heading-url::before {
   content: '';
   position: absolute;
   left: 50%;
-  inset-block-end: calc(100% + 4px + var(--borderWidth1));
+  inset-block-end: calc(100% + var(--space2) + var(--borderWidth1));
   translate: -50% 0;
   width: 0;
   height: 0;


### PR DESCRIPTION
[NES-282](https://linear.app/octopus/issue/NES-282/component-copy-url-button) · [CopyHeadingUrl design](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1749-15176)

Add the copy-url-button to all headings in `.page-content` as per spec:
<img width="2294" height="773" alt="image" src="https://github.com/user-attachments/assets/58126f8c-8ba9-4736-bbfa-045a03391a5f" />

## Results

`scripts/modules/headers.js` already created these elements on load, so it keeps doing that and now wires the behaviour as well:

```js
function enhanceHeaders() {
  addCopyButtons();   // one per heading
  addCopyListener();  // one delegated click handler for the page
}
```

Both glyphs come from `design-system-icons` and are byte-identical to `LinkOnIcon.tsx` and `CheckIcon.tsx`, on the `0 0 40 40` viewBox its `IconWrapper` uses. 

Example:
<img width="618" height="132" alt="image" src="https://github.com/user-attachments/assets/e66b88b6-6a74-4dd2-8dc7-574fd4d74330" />
<img width="611" height="166" alt="image" src="https://github.com/user-attachments/assets/59128f1d-e2c0-4d56-ba54-d1e108bebd24" />

## Accessibility

Each heading gets an `aria-label` of its own text. A heading is named from its contents, and those contents include a nested control's accessible name, so every heading was otherwise announced with the button's label appended:

```
before   heading "Install Octopus Server Copy link to this section"
after    heading "Install Octopus Server"
```

That was true of the old anchor too, with `Link to this section`, so this closes a pre-existing defect.

## Also

Removes the heading samples from `index.md`. They existed to show the button in a forced-visible state, which is unnecessary now that it is interactive.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
