### PR TITLE
Extract the clipboard write shared by the copy features

### DIFF
--- a/src/scripts/modules/clipboard.js
+++ b/src/scripts/modules/clipboard.js
@@ -1,0 +1,57 @@
+// @ts-check
+
+/**
+ * Copies text to the clipboard, reporting whether it worked.
+ *
+ * navigator.clipboard needs a secure context, so this falls back to the
+ * deprecated execCommand path for HTTP and older browsers.
+ *
+ * @param {string} text
+ * @returns {Promise<boolean>}
+ */
+async function writeToClipboard(text) {
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === 'function' &&
+    (typeof window === 'undefined' || window.isSecureContext !== false)
+  ) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (err) {
+      console.warn('[clipboard] navigator.clipboard failed, falling back', err);
+    }
+  }
+
+  return execCommandCopyFallback(text);
+}
+
+/**
+ * @param {string} text
+ * @returns {boolean}
+ */
+function execCommandCopyFallback(text) {
+  if (typeof document === 'undefined') return false;
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '0';
+  ta.style.left = '0';
+  ta.style.opacity = '0';
+  ta.style.pointerEvents = 'none';
+  document.body.appendChild(ta);
+  ta.select();
+  let ok = false;
+  try {
+    ok = document.execCommand('copy');
+  } catch (err) {
+    console.warn('[clipboard] execCommand fallback threw', err);
+    ok = false;
+  }
+  document.body.removeChild(ta);
+  return ok;
+}
+
+export { writeToClipboard };

--- a/src/scripts/modules/copy-markdown.js
+++ b/src/scripts/modules/copy-markdown.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { qs, qsa } from './query.js';
+import { writeToClipboard } from './clipboard.js';
 
 class CopyMarkdown {
   constructor(menu) {
@@ -29,49 +30,6 @@ class CopyMarkdown {
     }
   }
 
-  // navigator.clipboard requires a secure context; falls back to
-  // execCommand for HTTP and older browsers.
-  async writeToClipboard(text) {
-    if (
-      typeof navigator !== 'undefined' &&
-      navigator.clipboard &&
-      typeof navigator.clipboard.writeText === 'function' &&
-      (typeof window === 'undefined' || window.isSecureContext !== false)
-    ) {
-      try {
-        await navigator.clipboard.writeText(text);
-        return true;
-      } catch (err) {
-        console.warn('[copy-md] navigator.clipboard failed, falling back', err);
-      }
-    }
-
-    return this.execCommandCopyFallback(text);
-  }
-
-  execCommandCopyFallback(text) {
-    if (typeof document === 'undefined') return false;
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.setAttribute('readonly', '');
-    ta.style.position = 'fixed';
-    ta.style.top = '0';
-    ta.style.left = '0';
-    ta.style.opacity = '0';
-    ta.style.pointerEvents = 'none';
-    document.body.appendChild(ta);
-    ta.select();
-    let ok = false;
-    try {
-      ok = document.execCommand('copy');
-    } catch (err) {
-      console.warn('[copy-md] execCommand fallback threw', err);
-      ok = false;
-    }
-    document.body.removeChild(ta);
-    return ok;
-  }
-
   async handleCopy(btn) {
     const url = btn.dataset.copyMdUrl;
     const success = btn.dataset.copyMdSuccess ?? '';
@@ -81,7 +39,7 @@ class CopyMarkdown {
       const res = await fetch(url);
       if (!res.ok) throw new Error('HTTP ' + res.status);
       const text = await res.text();
-      const ok = await this.writeToClipboard(text);
+      const ok = await writeToClipboard(text);
       if (!ok) throw new Error('clipboard-write-failed');
       this.announce(btn, success);
     } catch (err) {


### PR DESCRIPTION
Pure extraction, split out of #3303 so the heading work reviews on its own.

`copy-markdown.js` carries a clipboard write with two code paths: `navigator.clipboard.writeText` where a secure context allows it, falling back to a hidden textarea plus `document.execCommand('copy')` for HTTP and older browsers. The heading copy button in #3303 needs exactly the same logic, so it moves to `src/scripts/modules/clipboard.js` rather than becoming a second copy.

## What changed

- `writeToClipboard` and `execCommandCopyFallback` move out of the `CopyMarkdown` class into a module, unchanged apart from the warning prefix (`[copy-md]` → `[clipboard]`) and JSDoc types.
- `copy-markdown.js` imports it and calls `writeToClipboard(text)` in place of `this.writeToClipboard(text)`.

No behavior change: the same two paths are tried in the same order, and the return contract (`true` on success) is the same.

`code-blocks.js` has its own simpler inline version. It is bound up in a larger icon-swapping flow, so it is left alone — worth a follow-up if this module proves out.

## Verification

- `pnpm build` exits 0, 2697 pages, on this branch alone.
- The extracted code is bundled into the page script (`[clipboard]` appears in `dist/docs/_astro/Default.astro_astro_type_script_index_0_lang.*.js`), so the import resolves rather than being tree-shaken away.
- `prettier --check` and `cspell` on both files: clean.

Stacked on #3301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
