### PR TITLE
Stop the current-page breadcrumb changing colour on hover

### DIFF
--- a/src/themes/octopus/components/Breadcrumbs.astro
+++ b/src/themes/octopus/components/Breadcrumbs.astro
@@ -125,4 +125,9 @@ stats.stop();
   a:focus {
     color: var(--color-menu-link-alt);
   }
+
+  a[aria-current]:hover,
+  a[aria-current]:focus {
+    color: var(--color-menu-link);
+  }
 </style>


### PR DESCRIPTION
Follow-up to #3296 ([NES-277](https://linear.app/octopus/issue/NES-277/component-breadcrumbs)).

## The regression

Before the breadcrumb styles moved into the component, `main.css` carried this:

```css
.site-breadcrumbs a[aria-current],
.site-breadcrumbs a[aria-current]:hover,
.site-breadcrumbs a[aria-current]:focus {
  text-decoration: none;
  color: var(--color-text);
}
```

That rule did two things: pinned the current-page crumb to the primary text colour, and suppressed the hover change. Neither was carried into the scoped styles, so on `main` today the crumb for the page you are already on shifts to link colour when you hover it, reading as somewhere to navigate.

## The fix

```css
a[aria-current]:hover,
a[aria-current]:focus {
  color: var(--color-menu-link);
}
```

Restores the hover suppression only. The old primary colour is deliberately not restored — the Figma component shows every crumb in the secondary colour, so the rest state on `main` is already correct and matches the design.

`aria-current="page"` is set by `Navigation.setCurrentPage` on the last crumb of every docs page, and pushed explicitly by the category and tag templates, so this covers all three.

## What I deliberately left out

Three other follow-ups were on the list for this branch. I measured them and they did not hold up:

- **Replacing the `allPages.find()` lookup with a `Map`.** I had described this as O(n·m) → O(n+m), which was wrong. Astro component frontmatter runs on every page render, so a `Map` built inside the component is rebuilt 2673 times — roughly 2673 URL-format calls per page against about 1336 for the short-circuiting `find`. A constant-factor change, not an asymptotic one. Build times bear that out: 3m 12s and 3m 16s with `find`, 3m 7s with the `Map`, which is noise. Only a memo in a separate module would make the lookup genuinely cheap, and nothing in the measurements justifies that.
- **Rendering the current crumb as a `<span>` instead of a self-referential link.** Both forms are valid structured data — Google treats `item` as optional on the final `ListItem` — and `aria-current="page"` already conveys the state to assistive tech. The only concrete problem was the hover, which the four lines above fix without touching the markup.
- **Making the component presentational (`const { items } = Astro.props`).** Deriving data in component frontmatter is the normal Astro pattern, and all 20 components in `src/themes/octopus/components/` take the same `frontmatter / headings / lang` signature. Passing crumbs in would either duplicate the URL-walking and `crumbTitle` resolution across both layouts or reduce the component to a pass-through. The existing optional `breadcrumbs` prop is already the escape hatch for callers that cannot derive from the URL.

## Verification

Confirmed the compiled scoped rule:

```
a[data-astro-cid-cvpdko3c][aria-current]:hover, a[data-astro-cid-cvpdko3c][aria-current]:focus{color:var(--color-menu-link)}
```

CSS-only addition inside an existing scoped block; CI runs the full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
