### PR TITLE
Update table styles for new design

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -103,16 +103,14 @@ blockquote cite {
   font-size: var(--fontSizeBase);
 }
 
-/* TODO: Refactor code snippets. This needs to be a component. */
 code {
-  font-family: var(--fontFamilyCode);
   border-radius: var(--borderRadiusSmall);
   border: var(--borderWidth1) solid var(--colorBorderPrimary);
   background: var(--colorBackgroundSecondaryDefault);
   white-space: pre-wrap;
   overflow-wrap: break-word;
   padding: 0 var(--space4);
-  font-size: var(--fontSizeMedium);
+  font: var(--textCodeRegularMedium);
 }
 
 pre {
@@ -121,13 +119,18 @@ pre {
   background: var(--colorBackgroundSecondaryDefault) !important;
   border: var(--borderWidth1) solid var(--colorBorderPrimary);
   border-radius: var(--borderRadiusLarge);
-  font-family: var(--fontFamilyCode);
+  font: var(--textCodeRegularMedium);
   color: var(--color-text);
 }
 
 pre code {
   background-color: unset;
   border: unset;
+  padding: unset;
+}
+
+table code {
+  font: var(--textCodeRegularSmall);
 }
 
 /* TODO: Also will be removed once component is implemented */
@@ -445,26 +448,25 @@ h6:hover .bookmark-link,
 
 table {
   border-collapse: collapse;
+  font-size: var(--fontSizeMedium);
 }
 
 table thead {
+  border-bottom: var(--borderWidth1, 1px) solid var(--colorBorderPrimary);
   font-weight: var(--fontWeight700);
 }
 
 table tr {
-  border-bottom: 1px solid var(--octo-blue);
+  border-bottom: var(--borderWidth1, 1px) solid var(--colorBorderPrimary);
 }
 
 table td {
-  padding: 0.8rem 1rem;
-}
-
-table tr td:first-child {
-  background-color: var(--bg-color-hint);
+  padding: var(--space-16) var(--space-24) var(--space-16) 0;
 }
 
 table th {
-  padding: 0.8rem 1rem;
+  text-align: start;
+  padding: var(--space-12) var(--space-24) var(--space-12) 0;
 }
 
 .table-full-width table {


### PR DESCRIPTION
Also updates code blocks to use correct styling; code inside tables is smaller than code outside, and fix a small styling bug which padded the first line more than it should

# Before

<img width="916" height="295" alt="image" src="https://github.com/user-attachments/assets/351acd37-d97c-421a-9816-63ce72f44115" />

----

<img width="792" height="309" alt="image" src="https://github.com/user-attachments/assets/847c5550-5872-4f7e-9a0b-1a07bca7d8a6" />


# After

<img width="916" height="295" alt="image" src="https://github.com/user-attachments/assets/e666abdc-8d0f-4605-9509-ebbf885938fb" />

----

<img width="792" height="288" alt="image" src="https://github.com/user-attachments/assets/9f762ae2-1ea1-429a-b4cf-66760a95760e" />

