### PR TITLE
Add link support to Button component

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -3,8 +3,8 @@ import type { HTMLAttributes } from 'astro/types';
 
 type SharedProps = {
   label?: string;
-  icon?: string; // URL to an SVG or a FontAwesome class
-  iconEnd?: string; // URL to an SVG or a FontAwesome class
+  icon?: string; // URL to an SVG, or a class name e.g. a FontAwesome icon class name
+  iconEnd?: string; // URL to an SVG, or a class name
   size?: 'xSmall' | 'small' | 'medium';
   importance?: 'default' | 'loud';
   disabled?: boolean;
@@ -43,25 +43,140 @@ const tagSpecificProps = href
     }
   : { type, disabled };
 
+const iconDetails = (name: string | undefined) => {
+  if (!name) return null;
+  return name.endsWith('.svg')
+    ? { tag: 'img' as const, props: { src: name, alt: '', class: 'btn__icon' } }
+    : { tag: 'span' as const, props: { class: `${name} btn__icon` } };
+};
+
+const startIcon = iconDetails(icon);
+const endIcon = iconDetails(iconEnd);
+const StartIconTag = startIcon?.tag;
+const EndIconTag = endIcon?.tag;
+
 const Tag = href ? 'a' : 'button';
 ---
 
 <Tag class={classes} {...tagSpecificProps} {...rest}>
-  {
-    icon &&
-      (icon.startsWith('fa-') ? (
-        <i class={`${icon} btn__icon`} aria-hidden="true" />
-      ) : (
-        <img src={icon} alt="" class="btn__icon" aria-hidden="true" />
-      ))
-  }
+  {StartIconTag && <StartIconTag {...startIcon!.props} aria-hidden="true" />}
   {label && <span class="btn__label">{label}</span>}
-  {
-    iconEnd &&
-      (iconEnd.startsWith('fa-') ? (
-        <i class={`${iconEnd} btn__icon`} aria-hidden="true" />
-      ) : (
-        <img src={iconEnd} alt="" class="btn__icon" aria-hidden="true" />
-      ))
-  }
+  {EndIconTag && <EndIconTag {...endIcon!.props} aria-hidden="true" />}
 </Tag>
+
+<style>
+  .btn {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space0);
+    min-width: var(--btn-min-size, 2.25rem);
+    min-height: var(--btn-min-size, 2.25rem);
+    padding: calc(var(--btn-padding-block, var(--space8)) - var(--borderWidth1))
+      calc(var(--btn-padding-inline, var(--space6)) - var(--borderWidth1));
+    border: var(--borderWidth1) solid var(--colorBorderPrimary);
+    border-radius: var(--borderRadiusSmall);
+    background: var(--colorBackgroundPrimaryDefault);
+    color: var(--colorTextPrimary);
+    font: var(--textBodyRegularMedium);
+    max-width: fit-content;
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+  }
+
+  .btn--medium {
+    --btn-min-size: 2.25rem;
+    --btn-padding-block: var(--space8);
+    --btn-padding-inline: var(--space6);
+  }
+
+  .btn--small {
+    --btn-min-size: 2rem;
+    --btn-padding-block: var(--space6);
+    --btn-padding-inline: var(--space6);
+  }
+
+  .btn--xsmall {
+    --btn-min-size: 1.75rem;
+    --btn-padding-block: var(--space4);
+    --btn-padding-inline: var(--space4);
+  }
+
+  .btn__label {
+    padding-inline: var(--space4);
+  }
+
+  /* Qualified with .btn to ensure greater specificity than fontawesome.css */
+  .btn .btn__icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: var(--fontSizeBase);
+    line-height: 1;
+    color: var(--colorIconPrimary);
+  }
+
+  img.btn__icon {
+    object-fit: contain;
+  }
+
+  /* Nudge the FontAwesome caret-down slightly so it looks right as part of a dropdown button */
+  .btn .btn__icon.fa-caret-down {
+    transform: translateY(-0.0625rem);
+  }
+
+  /* Button states (links can't be `:disabled`, so they use `aria-disabled` instead) */
+  .btn:hover:not(:disabled, [aria-disabled='true']) {
+    background: var(--colorBackgroundPrimaryHover);
+  }
+
+  .btn:focus-visible {
+    background: var(--colorBackgroundPrimaryHover);
+    outline: var(--borderWidth2) solid var(--colorBorderSelected);
+    outline-offset: var(--borderWidth1);
+  }
+
+  .btn:active:not(:disabled, [aria-disabled='true']) {
+    background: var(--colorBackgroundPrimaryPressed);
+  }
+
+  .btn:is(:disabled, [aria-disabled='true']) {
+    background: var(--colorButtonBackgroundDisabled);
+    border-color: var(--colorButtonBorderDisabled);
+    color: var(--colorButtonTextDisabled);
+    cursor: not-allowed;
+  }
+
+  .btn:is(:disabled, [aria-disabled='true']) .btn__icon {
+    color: var(--colorButtonIconDisabled);
+  }
+
+  /* Loud importance */
+  .btn--loud {
+    background: var(--colorButtonBackgroundLoudDefault);
+    /* Keep the border there but transparent as an easy way to ensure the geometry is exactly preserved */
+    border-color: transparent;
+    color: var(--colorButtonTextLoud);
+    font: var(--textBodyBoldMedium);
+  }
+
+  .btn--loud .btn__icon {
+    color: var(--colorButtonIconLoud);
+  }
+
+  .btn--loud:hover:not(:disabled, [aria-disabled='true']),
+  .btn--loud:focus-visible {
+    background: var(--colorButtonBackgroundLoudHover);
+  }
+
+  .btn--loud:active:not(:disabled, [aria-disabled='true']) {
+    background: var(--colorButtonBackgroundLoudPressed);
+  }
+</style>

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,14 +1,19 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 
-// Extend the native button attributes
-type Props = HTMLAttributes<'button'> & {
+type SharedProps = {
   label?: string;
   icon?: string; // URL to an SVG or a FontAwesome class
   iconEnd?: string; // URL to an SVG or a FontAwesome class
   size?: 'xSmall' | 'small' | 'medium';
   importance?: 'default' | 'loud';
+  disabled?: boolean;
 };
+
+// Extend the native button attributes, or the anchor ones when an href is given
+type Props =
+  | (HTMLAttributes<'button'> & SharedProps & { href?: never })
+  | (HTMLAttributes<'a'> & SharedProps & { href: string | URL });
 
 const {
   label,
@@ -17,6 +22,7 @@ const {
   size = 'medium',
   importance = 'default',
   disabled = false,
+  href,
   type = 'button',
   class: className,
   ...rest
@@ -27,9 +33,20 @@ if (!label && !rest['aria-label'] && !rest['aria-labelledby']) {
 }
 
 const classes = `btn btn--${size.toLowerCase()}${importance === 'loud' ? ' btn--loud' : ''}${className ? ` ${className}` : ''}`;
+
+const tagSpecificProps = href
+  ? {
+      href: disabled ? undefined : href,
+      role: disabled ? 'link' : undefined,
+      'aria-disabled': disabled ? 'true' : undefined,
+      tabindex: disabled ? -1 : undefined,
+    }
+  : { type, disabled };
+
+const Tag = href ? 'a' : 'button';
 ---
 
-<button class={classes} type={type} disabled={disabled} {...rest}>
+<Tag class={classes} {...tagSpecificProps} {...rest}>
   {
     icon &&
       (icon.startsWith('fa-') ? (
@@ -47,4 +64,4 @@ const classes = `btn btn--${size.toLowerCase()}${importance === 'loud' ? ' btn--
         <img src={iconEnd} alt="" class="btn__icon" aria-hidden="true" />
       ))
   }
-</button>
+</Tag>

--- a/src/components/EditOnGithub.astro
+++ b/src/components/EditOnGithub.astro
@@ -3,6 +3,7 @@ import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Lang, Translations } from '@util/Languages';
+import Button from './Button.astro';
 
 const stats = new accelerator.statistics(
   'octopus/components/ArticleList.astro'
@@ -38,11 +39,12 @@ stats.stop();
 
 {
   gitHubUrl && (
-    <a class="btn btn--small octo-github-edit" href={gitHubUrl}>
-      <span class="btn__icon octo-github-edit__icon" aria-hidden="true" />
-      <span class="btn__label">
-        {_(Translations.octopus_github.edit_on_github)}
-      </span>
-    </a>
+    <Button
+      class="octo-github-edit"
+      href={gitHubUrl}
+      icon="octo-github-edit__icon"
+      label={_(Translations.octopus_github.edit_on_github)}
+      size="small"
+    />
   )
 }

--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -48,9 +48,9 @@ const {
   <div class="top-nav__trailing">
     <!-- All of these are just non-functional and for visual/presentation only at this stage -->
     <Button icon="fa-regular fa-moon" aria-label="Switch to dark theme" />
-    <!-- TODO: Presumably at least some of these buttons should be <a> rather than <button> in practice, which isn't possible just yet -->
-    <Button label="Changelog" />
-    <Button label="Sign in" />
-    <Button label="Start for free" importance="loud" />
+    <!-- TODO: Make these real links -->
+    <Button label="Changelog" href="#" />
+    <Button label="Sign in" href="#" />
+    <Button label="Start for free" href="#" importance="loud" />
   </div>
 </header>

--- a/src/integrations/prune-dist.ts
+++ b/src/integrations/prune-dist.ts
@@ -5,12 +5,13 @@ import { fileURLToPath } from 'node:url';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
-// For things not in this list such as /components, run locally with `pnpm dev` to access. They are not reachable on octopus.com, so we don't want to ship them in the build output.
+// For things not in this list, run locally with `pnpm dev` to access. They are not reachable on octopus.com, so we don't want to ship them in the build output.
 const KEEP = new Set([
   'docs', // This is the main site content, which is served under /docs/ on octopus.com.
   'index.html', // index.html is the entrypoint for the staging site, so we want to keep it.
   'report', // index.html links to some reports, so we keep them to avoid dead links, plus they can be useful on staging sites.
   'css', // report pages have their own css in this folder
+  'components', // the component showcase is useful for sharing components in staging sites.
 ]);
 
 export default function pruneDist(): AstroIntegration {

--- a/src/pages/components.mdx
+++ b/src/pages/components.mdx
@@ -42,14 +42,15 @@ import Separator from 'src/components/Separator.astro';
 
 ### Button
 
-The Button component renders an HTML `<button>`.
+The Button component renders an HTML `<button>`, or an `<a>` when given an `href`.
 
 1. **label**: Optional text label. Omit for an icon-only button.
 2. **icon** / **iconEnd**: Optional leading and/or trailing icon. Accepts a FontAwesome class (e.g. `iconEnd="fa-solid fa-caret-down"` for a dropdown button) or a URL to an SVG.
 3. **size**: Optional: `medium` (default), `small`, or `xSmall`.
 4. **importance**: Optional: `default` or `loud`
 5. **disabled**: Optional `true`/`false`
-6. **type**: Optional: `button` (default), `submit`, or `reset`.
+6. **href**: Optional. When set, the button renders as a link rather than a `<button>`.
+7. **type**: Optional: `button` (default), `submit`, or `reset`. Ignored when `href` is set.
 
 An icon-only button has no visible text, so include an `aria-label` to give it an accessible name.
 
@@ -119,6 +120,25 @@ An icon-only button has no visible text, so include an `aria-label` to give it a
   </div>
 </div>
 
+#### Links
+
+<div class="docs-home simple-grid">
+  <div class="btn-row">
+    <Button label="Docs" href="/docs" />
+    <Button label="Docs" href="/docs" disabled={true} />
+    <Button label="Next" href="/docs" iconEnd="fa-solid fa-arrow-right" />
+    <Button label="Start" href="/docs" importance="loud" />
+  </div>
+  <div>
+    ```
+    <Button label="Docs" href="/docs" />
+    <Button label="Docs" href="/docs" disabled={true} />
+    <Button label="Next" href="/docs" iconEnd="fa-solid fa-arrow-right" />
+    <Button label="Start" href="/docs" importance="loud" />
+    ```
+  </div>
+</div>
+
 #### Disabled
 
 <div class="docs-home simple-grid">
@@ -154,6 +174,7 @@ Temporary showcase for the new, work-in-progress TopNav component.
 // Temporary hack: the nav needs more width than the cap on this page's main column, so the column takes the grid's
 // leftover space and everything except the nav is held back at the width the column normally maxes out at
 }
+
 <style>{`
   @media (min-width: 1131px) {
     .content-group {

--- a/src/pages/components.mdx
+++ b/src/pages/components.mdx
@@ -45,7 +45,7 @@ import Separator from 'src/components/Separator.astro';
 The Button component renders an HTML `<button>`, or an `<a>` when given an `href`.
 
 1. **label**: Optional text label. Omit for an icon-only button.
-2. **icon** / **iconEnd**: Optional leading and/or trailing icon. Accepts a FontAwesome class (e.g. `iconEnd="fa-solid fa-caret-down"` for a dropdown button) or a URL to an SVG.
+2. **icon** / **iconEnd**: Optional leading and/or trailing icon. Accepts a class name (e.g. `iconEnd="fa-solid fa-caret-down"` for a dropdown button) or a URL to an SVG.
 3. **size**: Optional: `medium` (default), `small`, or `xSmall`.
 4. **importance**: Optional: `default` or `loud`
 5. **disabled**: Optional `true`/`false`

--- a/src/scripts/modules/headers.js
+++ b/src/scripts/modules/headers.js
@@ -28,13 +28,13 @@ function addCopyButtons() {
 
     const button = document.createElement('button');
     button.type = 'button';
-    button.className = 'copy-heading-url btn btn--xsmall';
+    button.className = 'copy-heading-url';
     button.dataset.tooltip = REST;
     button.setAttribute('aria-label', 'Copy link to this section');
 
     // Empty: the glyph is a CSS mask on the span itself.
     const icon = document.createElement('span');
-    icon.className = 'copy-heading-url__icon btn__icon';
+    icon.className = 'copy-heading-url__icon';
 
     button.appendChild(icon);
     heading.appendChild(button);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -58,8 +58,8 @@ summary > * {
   color: var(--body-link-alt);
 }
 
-a:hover,
-a:focus,
+a:hover:not(.btn),
+a:focus:not(.btn),
 summary:hover,
 summary:focus,
 dt[data-destination]:hover {
@@ -77,12 +77,12 @@ hr {
   border-bottom: 1px solid var(--header-separator-color);
 }
 
-.page-content a:not(.link):not(.top-nav__link) {
+.page-content a:not(.link):not(.top-nav__link):not(.btn) {
   color: var(--octo-blue);
 }
 
-.page-content a:hover:not(.top-nav__link),
-.page-content a:focus:not(.top-nav__link) {
+.page-content a:hover:not(.top-nav__link):not(.btn),
+.page-content a:focus:not(.top-nav__link):not(.btn) {
   color: var(--body-link-color);
 }
 
@@ -2881,8 +2881,8 @@ img.btn__icon {
   transform: translateY(-0.0625rem);
 }
 
-/* Button states */
-.btn:hover:not(:disabled) {
+/* Button states (links can't be `:disabled`, so they use `aria-disabled` instead) */
+.btn:hover:not(:disabled, [aria-disabled='true']) {
   background: var(--colorBackgroundPrimaryHover);
 }
 
@@ -2892,18 +2892,18 @@ img.btn__icon {
   outline-offset: var(--borderWidth1);
 }
 
-.btn:active:not(:disabled) {
+.btn:active:not(:disabled, [aria-disabled='true']) {
   background: var(--colorBackgroundPrimaryPressed);
 }
 
-.btn:disabled {
+.btn:is(:disabled, [aria-disabled='true']) {
   background: var(--colorButtonBackgroundDisabled);
   border-color: var(--colorButtonBorderDisabled);
   color: var(--colorButtonTextDisabled);
   cursor: not-allowed;
 }
 
-.btn:disabled .btn__icon {
+.btn:is(:disabled, [aria-disabled='true']) .btn__icon {
   color: var(--colorButtonIconDisabled);
 }
 
@@ -2920,12 +2920,12 @@ img.btn__icon {
   color: var(--colorButtonIconLoud);
 }
 
-.btn--loud:hover:not(:disabled),
+.btn--loud:hover:not(:disabled, [aria-disabled='true']),
 .btn--loud:focus-visible {
   background: var(--colorButtonBackgroundLoudHover);
 }
 
-.btn--loud:active:not(:disabled) {
+.btn--loud:active:not(:disabled, [aria-disabled='true']) {
   background: var(--colorButtonBackgroundLoudPressed);
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -58,8 +58,8 @@ summary > * {
   color: var(--body-link-alt);
 }
 
-a:hover:not(.btn),
-a:focus:not(.btn),
+a:hover,
+a:focus,
 summary:hover,
 summary:focus,
 dt[data-destination]:hover {
@@ -77,12 +77,11 @@ hr {
   border-bottom: 1px solid var(--header-separator-color);
 }
 
-.page-content a:not(.link):not(.top-nav__link):not(.btn) {
+.page-content :where(a) {
   color: var(--octo-blue);
 }
 
-.page-content a:hover:not(.top-nav__link):not(.btn),
-.page-content a:focus:not(.top-nav__link):not(.btn) {
+.page-content :where(a:hover, a:focus) {
   color: var(--body-link-color);
 }
 
@@ -429,7 +428,25 @@ strong {
   font: var(--textHeadingLarge);
 }
 
-.copy-heading-url.btn {
+.copy-heading-url {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  min-height: 1.75rem;
+  padding: calc(var(--space4) - var(--borderWidth1));
+  border: var(--borderWidth1) solid var(--colorBorderPrimary);
+  border-radius: var(--borderRadiusSmall);
+  background: var(--colorBackgroundPrimaryDefault);
+  color: var(--colorTextPrimary);
+  font: var(--textBodyRegularMedium);
+  max-width: fit-content;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
   position: relative;
   top: -0.1em;
   font-size: inherit; /* make sure button is centered */
@@ -438,7 +455,29 @@ strong {
   opacity: 0;
 }
 
+.copy-heading-url:hover {
+  background: var(--colorBackgroundPrimaryHover);
+}
+
+.copy-heading-url:focus-visible {
+  background: var(--colorBackgroundPrimaryHover);
+  outline: var(--borderWidth2) solid var(--colorBorderSelected);
+  outline-offset: var(--borderWidth1);
+}
+
+.copy-heading-url:active {
+  background: var(--colorBackgroundPrimaryPressed);
+}
+
 .copy-heading-url__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  font-size: var(--fontSizeBase);
+  line-height: 1;
   background-color: var(--colorIconPrimary);
   mask: url('../assets/icons/link-on.svg') center / contain no-repeat;
 }
@@ -2811,122 +2850,6 @@ a.button.button--primary:active {
 
 .octo-header a.button {
   width: 120px;
-}
-
-/* Button component (namespaced `btn` as `.button` was already taken) */
-.btn {
-  box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space0);
-  min-width: var(--btn-min-size, 2.25rem);
-  min-height: var(--btn-min-size, 2.25rem);
-  padding: calc(var(--btn-padding-block, var(--space8)) - var(--borderWidth1))
-    calc(var(--btn-padding-inline, var(--space6)) - var(--borderWidth1));
-  border: var(--borderWidth1) solid var(--colorBorderPrimary);
-  border-radius: var(--borderRadiusSmall);
-  background: var(--colorBackgroundPrimaryDefault);
-  color: var(--colorTextPrimary);
-  font: var(--textBodyRegularMedium);
-  max-width: fit-content;
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: pointer;
-  text-align: center;
-  text-decoration: none;
-}
-
-.btn--medium {
-  --btn-min-size: 2.25rem;
-  --btn-padding-block: var(--space8);
-  --btn-padding-inline: var(--space6);
-}
-
-.btn--small {
-  --btn-min-size: 2rem;
-  --btn-padding-block: var(--space6);
-  --btn-padding-inline: var(--space6);
-}
-
-.btn--xsmall {
-  --btn-min-size: 1.75rem;
-  --btn-padding-block: var(--space4);
-  --btn-padding-inline: var(--space4);
-}
-
-.btn__label {
-  padding-inline: var(--space4);
-}
-
-/* Qualified with .btn to ensure greater specificity than fontawesome.css */
-.btn .btn__icon {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  font-size: var(--fontSizeBase);
-  line-height: 1;
-  color: var(--colorIconPrimary);
-}
-
-img.btn__icon {
-  object-fit: contain;
-}
-
-/* Nudge the FontAwesome caret-down slightly so it looks right as part of a dropdown button */
-.btn .btn__icon.fa-caret-down {
-  transform: translateY(-0.0625rem);
-}
-
-/* Button states (links can't be `:disabled`, so they use `aria-disabled` instead) */
-.btn:hover:not(:disabled, [aria-disabled='true']) {
-  background: var(--colorBackgroundPrimaryHover);
-}
-
-.btn:focus-visible {
-  background: var(--colorBackgroundPrimaryHover);
-  outline: var(--borderWidth2) solid var(--colorBorderSelected);
-  outline-offset: var(--borderWidth1);
-}
-
-.btn:active:not(:disabled, [aria-disabled='true']) {
-  background: var(--colorBackgroundPrimaryPressed);
-}
-
-.btn:is(:disabled, [aria-disabled='true']) {
-  background: var(--colorButtonBackgroundDisabled);
-  border-color: var(--colorButtonBorderDisabled);
-  color: var(--colorButtonTextDisabled);
-  cursor: not-allowed;
-}
-
-.btn:is(:disabled, [aria-disabled='true']) .btn__icon {
-  color: var(--colorButtonIconDisabled);
-}
-
-/* Loud importance */
-.btn--loud {
-  background: var(--colorButtonBackgroundLoudDefault);
-  /* Keep the border there but transparent as an easy way to ensure the geometry is exactly preserved */
-  border-color: transparent;
-  color: var(--colorButtonTextLoud);
-  font: var(--textBodyBoldMedium);
-}
-
-.btn--loud .btn__icon {
-  color: var(--colorButtonIconLoud);
-}
-
-.btn--loud:hover:not(:disabled, [aria-disabled='true']),
-.btn--loud:focus-visible {
-  background: var(--colorButtonBackgroundLoudHover);
-}
-
-.btn--loud:active:not(:disabled, [aria-disabled='true']) {
-  background: var(--colorButtonBackgroundLoudPressed);
 }
 
 /* Buttons side by side e.g. a toolbar or the component showcase */


### PR DESCRIPTION
# Summary

The new `<Button>` component only supported rendering as a HTML `<button>` in its initial form, but links (`<a href=...>`) are another use case we want it to be able to fulfil; there was one introduced already in the form of the `Edit on GitHub` button, which had to be built up manually rather than making use of `<Button>` prior to this PR.

This PR adds support for that: when a `href` is supplied, it will be rendered as an `<a>` rather than a `<button>` as appropriate, while appearing identical either way.


# Results

No visual changes from existing buttons, just a new capability. See in action at https://stoctodocspr3322.z22.web.core.windows.net/components#links

It's also used by the `Edit on GitHub` button found on any page.