### PR TITLE
Space and indent embedded components inside lists

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -360,8 +360,70 @@ strong {
   padding-block-start: var(--space6);
 }
 
-.page-content :is(pre, figure) {
+/* The .page-content > * rule only reaches the top level, so blocks stacked
+   inside a list item have no gap at all. The last one is skipped because the
+   space before the next item belongs to the rule above. */
+.page-content :where(ul, ol):not([class]) li > p:not(:last-child) {
+  margin-block-end: var(--space16);
+}
+
+/* A nested list continues the item it hangs off rather than starting a new
+   block, so it keeps list spacing. */
+.page-content :where(ul, ol):not([class]) li > p:has(+ :where(ul, ol)) {
+  margin-block-end: 0;
+}
+
+.page-content :where(ul, ol):not([class]) li > :where(ul, ol) {
+  padding-block-start: var(--space6);
+}
+
+/* Every non-text block embedded in the body carries space/8 above and below on
+   top of the space/16 block gap, so the pair reads as 24px. Inside a list item
+   they need nothing extra: sitting in the li already aligns them to the item
+   text, which is where Figma puts them. */
+.page-content :is(pre, figure, .table-wrap) {
   margin-block: var(--space24);
+}
+
+/* The copy button lives in a zero-height div injected in front of the code
+   block, so the space above the block has to sit on that div - left on the pre
+   it strands the button above the block. */
+.page-content .copy-container:has(+ pre) {
+  margin-block: var(--space24) 0;
+}
+
+.page-content .copy-container + pre {
+  margin-block-start: 0;
+}
+
+/* A callout or quote paints its own padding, so the blocks at either end of one
+   don't add to it. */
+.page-content
+  :is(
+    blockquote,
+    div.hint,
+    div.info,
+    div.success,
+    div.warning,
+    div.problem,
+    div.question
+  )
+  > :first-child {
+  margin-block-start: 0;
+}
+
+.page-content
+  :is(
+    blockquote,
+    div.hint,
+    div.info,
+    div.success,
+    div.warning,
+    div.problem,
+    div.question
+  )
+  > :last-child {
+  margin-block-end: 0;
 }
 
 /* Boxes */
@@ -513,12 +575,12 @@ table tr {
 }
 
 table td {
-  padding: var(--space-16) var(--space-24) var(--space-16) 0;
+  padding: var(--space16) var(--space24) var(--space16) 0;
 }
 
 table th {
   text-align: start;
-  padding: var(--space-12) var(--space-24) var(--space-12) 0;
+  padding: var(--space12) var(--space24) var(--space12) 0;
 }
 
 .table-full-width table {
@@ -2150,12 +2212,6 @@ a[data-youtube] {
      56px above an h2 becomes 72px after a paragraph, 88px after a blockquote. */
   display: flow-root;
   padding-block-start: var(--space32);
-
-  li:has(figure) {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
 }
 
 /* Paging */


### PR DESCRIPTION
Implements the [Embedded component](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1561-20185&m=dev) design.

Figma wraps every non-text block embedded in the body — image, callout, table, code block — in a slot with `space/8` above and below, on top of the `space/16` block gap, and indents it with the list when it sits inside one.

| | Before | After |
|---|---|---|
| Space above/below an embedded component in a list | 0px | 24px |
| Space above/below a table | 16px | 24px |
| Space above/below an image in a list | 40px | 24px |
| Paragraphs stacked in a list item | 0px | 16px |
| Nested list under an item | 0px | 6px |
| Table cell padding | 0px | 16px / 24px |
| Copy button offset from its code block | 24px | 0px |

Indentation is 24px at list level 1 and 48px at level 2, matching the design.

### Verified on the preview

Measured in the browser, light and dark:

- [Code blocks and a callout inside an ordered list](https://stoctodocspr3325.z22.web.core.windows.net/docs/installation/file-storage/windows-nfs) — every block 24px clear of the text above it and indented to 24px, copy buttons flush with their code blocks.
- [Images inside an ordered list](https://stoctodocspr3325.z22.web.core.windows.net/docs/octopus-cloud/inbound-private-links) — figures at 24px, down from 40px.
- [Tables](https://stoctodocspr3325.z22.web.core.windows.net/docs/projects/variables/certificate-variables) — cells padded 16px / 24px instead of 0, and the table sits 24px clear.

### Bugs found along the way

- Table cells referenced `--space-16` / `--space-24` / `--space-12`. Those don't exist — the tokens are `--space16` etc. — so every cell on every page with a markdown table rendered with no padding at all.
- The copy button lives in a zero-height div injected in front of each code block, so the block's own top margin pushed the block away from its button instead of away from the text above it.
- `li:has(figure)` spaced figures in list items with flex `gap`, which stacks with the margin instead of collapsing into it.

### Checked, no change needed

The [leading section](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1092-9509&m=dev) (32px above the first paragraph, 56px above an h2, 12px below it, 16px between paragraphs) and the [list](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1549-15660&m=dev) (24px indent, no top padding on the first item, 6px between items) both already match main.

Out of scope: the code block header bar, which is #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
