### PR TITLE
Add logged-in state to WIP new top nav

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
     "src/pages/report/**",
     "src/fallback/**",
     "src/scripts/**",
+    "tests/**",
     "node_modules/**",
     "public/docs/css/fa/**",
     "assets/diagrams/**"

--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -6,7 +6,6 @@ advfirewall
 agentic
 allatclaims
 ALLUSERSPROFILE
-andré
 anglin
 anotherdir
 Antiforgery
@@ -60,7 +59,6 @@ buildevent
 buildinfo
 buildmetadata
 CAIQ
-çelik
 Ceph
 certkeyName
 Certstore
@@ -184,7 +182,6 @@ fontawesome
 frontmatter
 functionapp
 g3662re9njtelsyfhm7t
-García
 gcloud
 gcore
 getenv
@@ -249,7 +246,6 @@ ITSM
 javac
 jdbc
 jjones
-José
 journalctl
 jsondecode
 JSSE
@@ -313,7 +309,6 @@ msiexec
 mssqldb
 MSSQLSERVER
 MTTR
-Müller
 multifactor
 Multipath
 multistep

--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -6,6 +6,7 @@ advfirewall
 agentic
 allatclaims
 ALLUSERSPROFILE
+andré
 anglin
 anotherdir
 Antiforgery
@@ -59,6 +60,7 @@ buildevent
 buildinfo
 buildmetadata
 CAIQ
+çelik
 Ceph
 certkeyName
 Certstore
@@ -182,6 +184,7 @@ fontawesome
 frontmatter
 functionapp
 g3662re9njtelsyfhm7t
+García
 gcloud
 gcore
 getenv
@@ -246,6 +249,7 @@ ITSM
 javac
 jdbc
 jjones
+José
 journalctl
 jsondecode
 JSSE
@@ -309,6 +313,7 @@ msiexec
 mssqldb
 MSSQLSERVER
 MTTR
+Müller
 multifactor
 Multipath
 multistep

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -1,0 +1,143 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import type { AvatarShape, AvatarSize } from '../lib/avatar';
+
+type SharedProps = {
+  size: AvatarSize;
+  shape: AvatarShape;
+  src?: string;
+  srcSet?: string;
+  alt?: string;
+  isMuted?: boolean;
+  title?: string;
+};
+
+type Props =
+  | (HTMLAttributes<'div'> & SharedProps & { href?: never })
+  | (HTMLAttributes<'a'> & SharedProps & { href: string | URL });
+
+const {
+  size,
+  shape,
+  src,
+  srcSet,
+  alt = '',
+  isMuted = false,
+  title,
+  href,
+  class: className,
+  ...rest
+} = Astro.props satisfies Props;
+
+const classes = `avatar avatar--${size} avatar--${shape}${isMuted ? ' avatar--muted' : ''}${className ? ` ${className}` : ''}`;
+
+const Tag = href ? 'a' : 'div';
+---
+
+<Tag
+  class={classes}
+  title={title}
+  {...href ? { href } : {}}
+  {...rest}
+  data-avatar
+  data-avatar-size={size}
+>
+  <span class="avatar__fallback" data-avatar-fallback><slot /></span>
+  <img
+    class="avatar__image"
+    src={src}
+    srcset={srcSet}
+    alt={alt}
+    data-avatar-image
+    hidden
+  />
+</Tag>
+
+<script>
+  import '../scripts/avatar';
+</script>
+
+<style>
+  .avatar {
+    position: relative;
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    container-type: inline-size;
+    background: var(--colorAvatarBackgroundUserDefault);
+    color: var(--colorAvatarText);
+    font-weight: 400;
+    text-decoration: none;
+    text-transform: uppercase;
+    user-select: none;
+    transition: background-color 150ms ease-in-out;
+  }
+
+  .avatar[hidden] {
+    display: none;
+  }
+
+  .avatar--small {
+    width: 20px;
+    height: 20px;
+  }
+
+  .avatar--medium {
+    width: 36px;
+    height: 36px;
+  }
+
+  .avatar--large {
+    width: 48px;
+    height: 48px;
+  }
+
+  .avatar--circle {
+    border-radius: var(--borderRadiusCircle);
+  }
+
+  .avatar--rounded {
+    border-radius: var(--borderRadiusSmall);
+  }
+
+  .avatar--muted {
+    opacity: 0.4;
+  }
+
+  .avatar__fallback {
+    display: block;
+    margin: 0;
+    color: var(--colorAvatarText);
+    font-size: 44cqi;
+  }
+
+  .avatar__fallback[hidden] {
+    display: none;
+  }
+
+  .avatar__image {
+    width: 100%;
+    height: 100%;
+    aspect-ratio: 1 / 1;
+    background: var(--colorAvatarBackgroundImageDefault);
+    object-fit: scale-down;
+    transition: background-color 150ms ease-in-out;
+  }
+
+  a.avatar:hover,
+  a.avatar:focus-visible {
+    background: var(--colorAvatarBackgroundUserHover);
+    color: var(--colorAvatarText);
+  }
+
+  a.avatar:focus-visible {
+    outline: var(--borderWidth2) solid var(--colorBorderSelected);
+    outline-offset: var(--borderWidth2);
+  }
+
+  a.avatar:hover .avatar__image {
+    background: var(--colorAvatarBackgroundImageHover);
+  }
+</style>

--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,5 +1,6 @@
 ---
 import Logo from '../assets/octopus-logo-v2.svg';
+import Avatar from './Avatar.astro';
 import Button from './Button.astro';
 
 type Props = {
@@ -50,7 +51,26 @@ const {
     <Button icon="fa-regular fa-moon" aria-label="Switch to dark theme" />
     <!-- TODO: Make these real links -->
     <Button label="Changelog" href="#" />
-    <Button label="Sign in" href="#" />
-    <Button label="Start for free" href="#" importance="loud" />
+    <Button label="Sign in" href="#" data-signed-out-only />
+    <Button
+      label="Start for free"
+      href="#"
+      importance="loud"
+      data-signed-out-only
+    />
+    <Avatar
+      size="medium"
+      shape="circle"
+      alt=""
+      data-signed-in-only
+      data-user-avatar
+      hidden
+    >
+      <span data-user-initials></span>
+    </Avatar>
   </div>
 </header>
+
+<script>
+  import '../scripts/signed-in-user';
+</script>

--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,59 @@
+export type AvatarSize = 'large' | 'medium' | 'small';
+export type AvatarShape = 'circle' | 'rounded';
+
+export const avatarSizeMap: Record<AvatarSize, number> = {
+  small: 20,
+  medium: 36,
+  large: 48,
+};
+
+export function isAvatarSize(value: unknown): value is AvatarSize {
+  return value === 'small' || value === 'medium' || value === 'large';
+}
+
+export function generateFallbackText(text: string): string {
+  const trimmedText = text.trim();
+  if (!trimmedText) return '';
+
+  const words = trimmedText.split(/\s+/);
+
+  if (words.length > 1) {
+    const firstWord = words[0] ?? '';
+    const lastWord = words[words.length - 1] ?? '';
+
+    return [firstWord, lastWord]
+      .map((word) => Array.from(word.trim())[0])
+      .filter((character): character is string => !!character)
+      .join('')
+      .toUpperCase();
+  }
+
+  return Array.from(trimmedText).slice(0, 2).join('').toUpperCase();
+}
+
+export function getAvatarImageUrls(
+  src: string,
+  size: AvatarSize
+): { avatarImageUrl: string; srcSet: string } {
+  const avatarImageSize = avatarSizeMap[size];
+
+  try {
+    const url = new URL(src);
+
+    url.searchParams.set('d', '404');
+    url.searchParams.set('s', avatarImageSize.toString());
+    const avatarImageUrl = url.toString();
+
+    const srcSet = [1, 2, 3]
+      .map((scale) => {
+        const scaledUrl = new URL(url.toString());
+        scaledUrl.searchParams.set('s', (avatarImageSize * scale).toString());
+        return `${scaledUrl.toString()} ${scale}x`;
+      })
+      .join(', ');
+
+    return { avatarImageUrl, srcSet };
+  } catch {
+    return { avatarImageUrl: src, srcSet: '' };
+  }
+}

--- a/src/lib/signedInUser.ts
+++ b/src/lib/signedInUser.ts
@@ -1,0 +1,68 @@
+export const USER_COOKIE = 'OctopusSignedInUser';
+export const USER_CHANGED_EVENT = 'octopus:user-changed';
+
+export type SignedInUser = {
+  email?: string;
+  fullName?: string;
+  profileImageUrl?: string;
+  userHash?: string;
+};
+
+function isSignedInUser(value: unknown): value is SignedInUser {
+  if (!value || typeof value !== 'object') return false;
+  const user = value as SignedInUser;
+  const hasEmail = typeof user.email === 'string' && user.email.length > 0;
+  const hasName = typeof user.fullName === 'string' && user.fullName.length > 0;
+  return hasEmail || hasName;
+}
+
+function readCookie(): string | null {
+  const match = document.cookie.match(
+    new RegExp(`(^|;\\s*)${USER_COOKIE}=([^;]+)`)
+  );
+  return match ? decodeURIComponent(match[2]) : null;
+}
+
+export function getSignedInUser(): SignedInUser | null {
+  const cookie = readCookie();
+  if (!cookie) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cookie);
+  } catch {
+    return null;
+  }
+
+  return isSignedInUser(parsed) ? parsed : null;
+}
+
+export function safeImageUrl(value: unknown): string {
+  if (typeof value !== 'string' || !value) return '';
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.protocol === 'https:' || url.protocol === 'http:'
+      ? url.href
+      : '';
+  } catch {
+    return '';
+  }
+}
+
+export function addSignedInUserChangedListener(callback: () => void) {
+  const cookieStore = (window as Window & { cookieStore?: EventTarget })
+    .cookieStore;
+
+  if (cookieStore) {
+    cookieStore.addEventListener('change', (event) => {
+      const { changed = [], deleted = [] } = event;
+      if (
+        [...changed, ...deleted].some((cookie) => cookie.name === USER_COOKIE)
+      ) {
+        callback();
+      }
+    });
+  }
+
+  window.addEventListener(USER_CHANGED_EVENT, callback);
+}

--- a/src/pages/components.mdx
+++ b/src/pages/components.mdx
@@ -13,6 +13,7 @@ robots: noindex, follow
 listable: false # stop the oldest-content report from listing this page
 ---
 
+import Avatar from 'src/components/Avatar.astro';
 import Button from 'src/components/Button.astro';
 import Card from 'src/components/Card.astro';
 import IconTile from 'src/components/IconTile.astro';
@@ -161,6 +162,28 @@ An icon-only button has no visible text, so include an `aria-label` to give it a
     />
     <Button label="Label" size="small" disabled={true} />
     <Button label="Label" size="xSmall" disabled={true} />
+    ```
+  </div>
+</div>
+
+### Avatar
+
+<div class="docs-home simple-grid">
+  <div class="btn-row">
+    <Avatar size="small" shape="circle">JD</Avatar>
+    <Avatar size="medium" shape="circle">JD</Avatar>
+    <Avatar size="large" shape="circle">JD</Avatar>
+    <Avatar size="medium" shape="rounded">JD</Avatar>
+    <Avatar size="medium" shape="circle" isMuted={true}>JD</Avatar>
+    <Avatar size="medium" shape="circle" src="/docs/img/octopus-deploy-logo.png" alt="">JD</Avatar>
+    <Avatar size="medium" shape="circle" src="/docs/img/does-not-exist.png" alt="">JD</Avatar>
+  </div>
+  <div>
+    ```
+    <Avatar size="medium" shape="circle">JD</Avatar>
+    <Avatar size="medium" shape="rounded">JD</Avatar>
+    <Avatar size="medium" shape="circle" isMuted={true}>JD</Avatar>
+    <Avatar size="medium" shape="circle" src="/path/to/image.png" alt="">JD</Avatar>
     ```
   </div>
 </div>

--- a/src/scripts/avatar.ts
+++ b/src/scripts/avatar.ts
@@ -1,0 +1,71 @@
+const AVATAR_SELECTOR = '[data-avatar]';
+const IMAGE_SELECTOR = '[data-avatar-image]';
+const FALLBACK_SELECTOR = '[data-avatar-fallback]';
+
+function showImage(avatar: HTMLElement, image: HTMLImageElement) {
+  const fallback = avatar.querySelector<HTMLElement>(FALLBACK_SELECTOR);
+  if (fallback) fallback.hidden = true;
+  image.hidden = false;
+}
+
+function showFallback(avatar: HTMLElement, image: HTMLImageElement) {
+  const fallback = avatar.querySelector<HTMLElement>(FALLBACK_SELECTOR);
+  if (fallback) fallback.hidden = false;
+  image.hidden = true;
+}
+
+function watch(avatar: HTMLElement, image: HTMLImageElement) {
+  if (image.complete) {
+    if (image.naturalWidth > 0) showImage(avatar, image);
+    return;
+  }
+
+  image.addEventListener('load', () => showImage(avatar, image), {
+    once: true,
+  });
+}
+
+export function setAvatarImage(
+  avatar: HTMLElement,
+  src: string,
+  srcSet: string = ''
+) {
+  const image = avatar.querySelector<HTMLImageElement>(IMAGE_SELECTOR);
+  if (!image) return;
+
+  if (!src) {
+    image.removeAttribute('srcset');
+    image.removeAttribute('src');
+    showFallback(avatar, image);
+    return;
+  }
+
+  if (
+    image.getAttribute('src') !== src ||
+    (image.getAttribute('srcset') ?? '') !== srcSet
+  ) {
+    showFallback(avatar, image);
+    if (srcSet) {
+      image.srcset = srcSet;
+    } else {
+      image.removeAttribute('srcset');
+    }
+    image.src = src;
+  }
+
+  watch(avatar, image);
+}
+
+function bind(avatar: HTMLElement) {
+  const image = avatar.querySelector<HTMLImageElement>(IMAGE_SELECTOR);
+  if (!image || !image.getAttribute('src')) return;
+  watch(avatar, image);
+}
+
+function bindAll() {
+  document.querySelectorAll<HTMLElement>(AVATAR_SELECTOR).forEach(bind);
+}
+
+bindAll();
+
+document.addEventListener('astro:after-swap', bindAll);

--- a/src/scripts/signed-in-user.ts
+++ b/src/scripts/signed-in-user.ts
@@ -1,0 +1,74 @@
+import {
+  getSignedInUser,
+  addSignedInUserChangedListener,
+  safeImageUrl,
+  type SignedInUser,
+} from '../lib/signedInUser';
+import {
+  generateFallbackText,
+  getAvatarImageUrls,
+  isAvatarSize,
+} from '../lib/avatar';
+import { setAvatarImage } from './avatar';
+
+const SIGNED_OUT_ONLY_SELECTOR = '[data-signed-out-only]';
+const SIGNED_IN_ONLY_SELECTOR = '[data-signed-in-only]';
+const USER_AVATAR_SELECTOR = '[data-user-avatar]';
+const USER_INITIALS_SELECTOR = '[data-user-initials]';
+
+function displayName(user: SignedInUser): string {
+  return user.fullName?.trim() || user.email?.trim() || '';
+}
+
+function avatarSize(avatar: HTMLElement) {
+  const size = avatar.dataset.avatarSize;
+  return isAvatarSize(size) ? size : 'medium';
+}
+
+function toggle(selector: string, hidden: boolean) {
+  document.querySelectorAll<HTMLElement>(selector).forEach((el) => {
+    el.hidden = hidden;
+  });
+}
+
+function apply() {
+  const user = getSignedInUser();
+
+  toggle(SIGNED_OUT_ONLY_SELECTOR, user !== null);
+  toggle(SIGNED_IN_ONLY_SELECTOR, user === null);
+
+  if (user) {
+    const name = displayName(user);
+    const imageUrl = safeImageUrl(user.profileImageUrl);
+
+    document
+      .querySelectorAll<HTMLElement>(USER_AVATAR_SELECTOR)
+      .forEach((avatar) => {
+        const target = avatar.querySelector<HTMLElement>(
+          USER_INITIALS_SELECTOR
+        );
+        if (target) {
+          target.textContent = generateFallbackText(name);
+          if (name) target.title = name;
+        }
+
+        if (name) avatar.title = name;
+
+        if (!imageUrl) {
+          setAvatarImage(avatar, '');
+          return;
+        }
+
+        const { avatarImageUrl, srcSet } = getAvatarImageUrls(
+          imageUrl,
+          avatarSize(avatar)
+        );
+        setAvatarImage(avatar, avatarImageUrl, srcSet);
+      });
+  }
+}
+
+apply();
+addSignedInUserChangedListener(apply);
+
+document.addEventListener('astro:after-swap', apply);

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -21,6 +21,10 @@
   text-decoration: none;
 }
 
+.btn[hidden] {
+  display: none;
+}
+
 .btn--medium {
   --btn-min-size: 2.25rem;
   --btn-padding-block: var(--space8);

--- a/tests/avatar-fallback-text.spec.ts
+++ b/tests/avatar-fallback-text.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { generateFallbackText } from '../src/lib/avatar';
+
+const cases: [string, string][] = [
+  ['', ''],
+  ['   ', ''],
+  ['\t', ''],
+  ['A', 'A'],
+  ['a', 'A'],
+  ['John', 'JO'],
+  ['alice', 'AL'],
+  ['ADMIN', 'AD'],
+  ['jOhN', 'JO'],
+  ['John Doe', 'JD'],
+  ['john doe', 'JD'],
+  ['John Michael Doe', 'JD'],
+  ['Mary Jane Watson Smith', 'MS'],
+  ['John   Doe', 'JD'],
+  ['  John  \n  Doe  ', 'JD'],
+  ['😀', '😀'],
+  ['😀A', '😀A'],
+  ['😀John', '😀J'],
+  ['John😀', 'JO'],
+  ['😀John 😀Doe', '😀😀'],
+  ['@john', '@J'],
+  ['user123', 'US'],
+  ['user-name', 'US'],
+  ['José', 'JO'],
+  ['Müller', 'MÜ'],
+  ['北京', '北京'],
+  ['José García', 'JG'],
+  ['andré çelik', 'AÇ'],
+  ['王 Wei', '王W'],
+  ['123', '12'],
+  ['123 456', '14'],
+  ['ß', 'SS'],
+  ['ø', 'Ø'],
+  ['Smith, John', 'SJ'],
+  ['Dr. John Smith', 'DS'],
+  ['john.doe@company.com', 'JO'],
+  ['test.user+tag@domain.org', 'TE'],
+];
+
+test('generateFallbackText returns expected fallback string', () => {
+  for (const [input, expected] of cases) {
+    expect(generateFallbackText(input), `input: ${JSON.stringify(input)}`).toBe(
+      expected
+    );
+  }
+});

--- a/tests/topnav-signedin.spec.ts
+++ b/tests/topnav-signedin.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const showcase = '/components';
+
+const nav = '.top-nav';
+const trailing = '.top-nav__trailing';
+const avatar = `${nav} [data-user-avatar]`;
+
+async function signIn(
+  page: Page,
+  baseURL: string | undefined,
+  user: Record<string, string>
+) {
+  await page.context().addCookies([
+    {
+      name: 'OctopusSignedInUser',
+      value: encodeURIComponent(JSON.stringify(user)),
+      url: new URL(showcase, baseURL).toString(),
+    },
+  ]);
+}
+
+test.describe('top nav signed-in state', () => {
+  test('shows the sign in and sign up buttons when signed out', async ({
+    page,
+  }) => {
+    await page.goto(showcase);
+
+    await expect(page.locator(trailing).getByText('Sign in')).toBeVisible();
+    await expect(
+      page.locator(trailing).getByText('Start for free')
+    ).toBeVisible();
+    await expect(page.locator(avatar)).toBeHidden();
+  });
+
+  test('swaps those buttons for an initials avatar when signed in', async ({
+    page,
+    baseURL,
+  }) => {
+    await signIn(page, baseURL, {
+      fullName: 'John Doe',
+      email: 'jd@example.com',
+    });
+    await page.goto(showcase);
+
+    await expect(page.locator(trailing).getByText('Sign in')).toBeHidden();
+    await expect(
+      page.locator(trailing).getByText('Start for free')
+    ).toBeHidden();
+    await expect(page.locator(trailing).getByText('Changelog')).toBeVisible();
+
+    await expect(page.locator(avatar)).toBeVisible();
+    await expect(page.locator(`${avatar} [data-user-initials]`)).toHaveText(
+      'JD'
+    );
+    await expect(page.locator(avatar)).toHaveAttribute(
+      'title',
+      'John Doe'
+    );
+  });
+
+  test('takes the first two characters of a single-word name', async ({
+    page,
+    baseURL,
+  }) => {
+    await signIn(page, baseURL, { fullName: 'John' });
+    await page.goto(showcase);
+
+    await expect(page.locator(`${avatar} [data-user-initials]`)).toHaveText(
+      'JO'
+    );
+  });
+
+  test('falls back to the email when there is no name', async ({
+    page,
+    baseURL,
+  }) => {
+    await signIn(page, baseURL, { email: 'jd@example.com' });
+    await page.goto(showcase);
+
+    await expect(page.locator(`${avatar} [data-user-initials]`)).toHaveText(
+      'JD'
+    );
+  });
+
+  test('requests the image at the avatar size and 404s rather than defaulting', async ({
+    page,
+    baseURL,
+  }) => {
+    await signIn(page, baseURL, {
+      fullName: 'John Doe',
+      profileImageUrl: new URL(
+        '/docs/img/octopus-deploy-logo.png',
+        baseURL
+      ).toString(),
+    });
+    await page.goto(showcase);
+
+    const image = page.locator(`${avatar} [data-avatar-image]`);
+    const src = new URL((await image.getAttribute('src')) ?? '', baseURL);
+    expect(src.searchParams.get('d')).toBe('404');
+    expect(src.searchParams.get('s')).toBe('36');
+
+    const srcSet = (await image.getAttribute('srcset')) ?? '';
+    expect(srcSet).toContain('s=36 1x');
+    expect(srcSet).toContain('s=72 2x');
+    expect(srcSet).toContain('s=108 3x');
+  });
+
+  test('shows the profile image when one loads', async ({ page, baseURL }) => {
+    await signIn(page, baseURL, {
+      fullName: 'John Doe',
+      profileImageUrl: new URL(
+        '/docs/img/octopus-deploy-logo.png',
+        baseURL
+      ).toString(),
+    });
+    await page.goto(showcase);
+
+    await expect(page.locator(`${avatar} [data-avatar-image]`)).toBeVisible();
+    await expect(page.locator(`${avatar} [data-avatar-fallback]`)).toBeHidden();
+  });
+
+  test('keeps the initials when the profile image fails to load', async ({
+    page,
+    baseURL,
+  }) => {
+    await signIn(page, baseURL, {
+      fullName: 'John Doe',
+      profileImageUrl: new URL(
+        '/docs/img/no-such-image.png',
+        baseURL
+      ).toString(),
+    });
+    await page.goto(showcase);
+
+    await expect(
+      page.locator(`${avatar} [data-avatar-fallback]`)
+    ).toBeVisible();
+    await expect(page.locator(`${avatar} [data-avatar-image]`)).toBeHidden();
+  });
+
+  test('rejects a non-http profile image url', async ({ page, baseURL }) => {
+    await signIn(page, baseURL, {
+      fullName: 'John Doe',
+      profileImageUrl: 'javascript:alert(1)',
+    });
+    await page.goto(showcase);
+
+    await expect(
+      page.locator(`${avatar} [data-avatar-fallback]`)
+    ).toBeVisible();
+    await expect(
+      page.locator(`${avatar} [data-avatar-image]`)
+    ).not.toHaveAttribute('src');
+  });
+});


### PR DESCRIPTION
# Summary

This PR adds an avatar component from our design system ported to Astro, and displays it in the new TopNav (in place of the _Sign in_ and _Start for free_ buttons) when the user is signed in on octopus.com.


# Results

When signed in:

Light mode
<img width="1453" height="89" alt="image" src="https://github.com/user-attachments/assets/35e5b743-c6fa-457b-b864-b295178bcc8b" />

Dark mode
<img width="1453" height="89" alt="image" src="https://github.com/user-attachments/assets/b03daf0f-504b-476b-b8f3-ea10536fc5ea" />

(In production, if you have an avatar image set up, that should be displayed in place of the placeholder initials.)

See in action at https://stoctodocspr3332.z22.web.core.windows.net/components#avatar. Because this isn't actually live on octopus.com yet, you can't actually sign in on the staging site. However, you can test the logged in state on the staging site by populating the cookie with fake data, by running the following JS via the browser console:
```js
document.cookie = 'OctopusSignedInUser=' + encodeURIComponent(JSON.stringify({fullName: 'John Doe'})) + ';path=/';
window.dispatchEvent(new CustomEvent('octopus:user-changed'));
```

To reset:
```js
document.cookie = 'OctopusSignedInUser=;path=/;max-age=0';
window.dispatchEvent(new CustomEvent('octopus:user-changed'));
```
