### PR TITLE
Deprecate F# docs 

### DIFF
--- a/src/pages/docs/deployments/custom-scripts/error-handling.md
+++ b/src/pages/docs/deployments/custom-scripts/error-handling.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Error handling
 description: Error handling for scripts in Octopus.
 icon: fa-solid fa-circle-exclamation
@@ -78,14 +78,6 @@ FailStep("A friendly message");
 
 ```bash
 fail_step "A friendly message"
-```
-
-</details>
-<details data-group="error-handling">
-<summary>F#</summary>
-
-```fsharp
-Octopus.failStep "A friendly message"
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/index.md
+++ b/src/pages/docs/deployments/custom-scripts/index.md
@@ -1,9 +1,9 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Custom scripts
-description: Custom scripts allows you to script anything you want using PowerShell, Dotnet Script, F#, Python, or Bash.
+description: Custom scripts allows you to script anything you want using PowerShell, Dotnet Script, Python, or Bash.
 icon: fa-solid fa-file-code
 navOrder: 150
 ---
@@ -18,7 +18,6 @@ Octopus supports the following scripting environments:
 - Bash scripts (.sh)
 - Python scripts (.py)
 - C# scripts (.csx) using [dotnet-script](https://github.com/dotnet-script/dotnet-script)
-- F# scripts (.fsx)
 
  Octopus can run these scripts on almost any operating system as long as the script runtime is installed and configured correctly.
 

--- a/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/logging-messages-in-scripts.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-08-06
+modDate: 2026-08-11
 title: Logging messages from scripts
 description: When your scripts emit messages Octopus will display the messages in the Task Logs at the most appropriate level for the message.
 icon: fa-solid fa-clock-rotate-left
@@ -50,19 +50,6 @@ write_warning "Warning"
 >&2 echo "This will be logged as an Error"
 echoerror() { echo "$@" 1>&2; }
 echoerror "You can even define your own function to echo an error!"
-```
-
-</details>
-<details data-group="logging-messages-in-scripts">
-<summary>F#</summary>
-
-```fsharp
-printfn "This will be logged as Information"
-writeVerbose "Verbose!!"
-writeHighlight "This is a highlight"
-writeWait "Deployment is waiting on something"
-writeWarning "Warning"
-eprintfn "This will be logged as Error"
 ```
 
 </details>
@@ -136,15 +123,6 @@ update_progress 50 "We're halfway there!"
 
 </details>
 <details data-group="deployments-custom-scripts-logging-messages">
-<summary>F#</summary>
-
-```fsharp
-Octopus.updateProgress 10
-Octopus.updateProgress 50 "We're halfway there!"
-```
-
-</details>
-<details data-group="deployments-custom-scripts-logging-messages">
 <summary>Python3</summary>
 
 ```python
@@ -167,20 +145,6 @@ private static string EncodeServiceMessageValue(string value)
 }
 
 Console.WriteLine("##octopus[progress percentage='{0}' message='{1}']", EncodeServiceMessageValue(percentage.ToString()), EncodeServiceMessageValue(message));
-```
-
-</details>
-<details data-group="deployments-custom-scripts-progress-service-message">
-<summary>F#</summary>
-
-```fsharp
-let private encode (value:string) = System.Text.Encoding.UTF8.GetBytes(value) |> Convert.ToBase64String
-let private writeServiceMessage name content =  printfn "##octopus[%s %s]" name content
-let updateProgress (percentage: int) message =
-    let encodedMessage = message |> encode
-    let encodedPercentage = percentage.ToString() |> encode
-    let content = sprintf "percentage='%s' message='%s'" encodedPercentage encodedMessage
-    writeServiceMessage "progress" content
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/output-variables.md
+++ b/src/pages/docs/deployments/custom-scripts/output-variables.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Output variables
 description: Your scripts can emit variables that are available in subsequent deployment steps.
 icon: fa-solid fa-file-export
@@ -37,14 +37,6 @@ set_octopusvariable "AppInstanceName" "MyAppInstance"
 
 </details>
 <details data-group="creating-an-output-variable">
-<summary>F#</summary>
-
-```fsharp
-Octopus.setVariable "AppInstanceName" "MyAppInstance"
-```
-
-</details>
-<details data-group="creating-an-output-variable">
 <summary>Python3</summary>
 
 ```python
@@ -76,21 +68,6 @@ var appInstanceName = OctopusParameters["Octopus.Action[Determine App Instance N
 
 ```bash
 appInstanceName=$(get_octopusvariable "Octopus.Action[Determine App Instance Name].Output.AppInstanceName")
-```
-
-</details>
-<details data-group="using-variable-in-another-step">
-<summary>F#</summary>
-
-```fsharp
-//throw if not found
-let appInstanceName1 = Octopus.findVariable "Octopus.Action[Determine App Instance Name].Output.AppInstanceName"
-
-//supply a default value to use if not found
-let appInstanceName2 = Octopus.findVariableOrDefault "Value if not found" "Octopus.Action[Determine App Instance Name].Output.AppInstanceName"
-
-//return an Option type
-let appInstanceName3 = Octopus.tryFindVariable "Octopus.Action[Determine App Instance Name].Output.AppInstanceName"
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/passing-parameters-to-scripts.mdx
+++ b/src/pages/docs/deployments/custom-scripts/passing-parameters-to-scripts.mdx
@@ -14,21 +14,17 @@ Octopus can pass parameters to your custom script files for any of the supported
 
 Consider this example PowerShell script:
 
-**PowerShell script using Octopus Variables**
-
-```powershell
+```powershell PowerShell script using Octopus Variables
 $environment = $OctopusParameters["Octopus.Environment.Name"]
 Write-Host "Environment: $environment"
 ```
 
 You can parameterize this script making it easier to test outside of Octopus:
 
-**PowerShell script using parameters**
-
-```powershell
+```powershell PowerShell script using parameters
 param (
-	[Parameter(Mandatory=$True)]
-	[string]$Environment
+    [Parameter(Mandatory=$True)]
+    [string]$Environment
 )
 Write-Host "Environment: $Environment"
 ```
@@ -50,20 +46,16 @@ Don't forget to correctly delimit your parameters correctly for the scripting en
 
 You can pass parameters to PowerShell scripts as if you were calling the script yourself from PowerShell, using positional or named parameters.
 
-**Script Parameters in Octopus**
-
-```bash
+```bash Script Parameters in Octopus
 -Environment "#{Octopus.Environment.Name}" -StoragePath "#{MyApplication.Storage.Path}"
 ```
 
-**Usage in PowerShell script**
-
-```powershell
+```powershell Usage in PowerShell script
 Param (
-	[Parameter(Mandatory=$True)]
-	[string]$Environment,
-	[Parameter(Mandatory=$True)]
-	[string]$StoragePath
+    [Parameter(Mandatory=$True)]
+    [string]$Environment,
+    [Parameter(Mandatory=$True)]
+    [string]$StoragePath
 )
  
 Write-Host "$Environment storage path: $StoragePath"
@@ -73,15 +65,11 @@ Write-Host "$Environment storage path: $StoragePath"
 
 You can pass parameters to C# scripts [as described here for the dotnet-script engine](https://github.com/dotnet-script/dotnet-script#passing-arguments-to-scripts).
 
-**Script Parameters in Octopus**
-
-```bash
+```bash Script Parameters in Octopus
 -- "#{Octopus.Environment.Name}" "#{MyApplication.Storage.Path}"
 ```
 
-**Usage in C# script**
-
-```csharp
+```csharp Usage in C# script
 var environment = Args[0]
 var storagePath = Args[1]
 Console.WriteLine("{0} storage path: {1}", environment, storagePath);
@@ -91,15 +79,11 @@ Console.WriteLine("{0} storage path: {1}", environment, storagePath);
 
 You can pass parameters to Bash scripts [as described in Bash manual.](https://www.gnu.org/software/bash/manual/bash.html#Positional-Parameters)
 
-**Script Parameters in Octopus**
-
-```powershell
+```powershell Script Parameters in Octopus
 "#{Octopus.Environment.Name}" "#{MyApplication.Storage.Path}"
 ```
 
-**Usage in Bash script**
-
-```bash
+```bash Usage in Bash script
 environment="$1"
 storagePath="$2"
 echo "$environment storage path: $storagePath"
@@ -109,18 +93,16 @@ echo "$environment storage path: $storagePath"
 
 You can pass parameters to python scripts [as described by the python documentation.](https://docs.python.org/3/tutorial/interpreter.html#argument-passing)
 
-**Script Parameters in Octopus**
-
-```python
+```python Script Parameters in Octopus
 '#{Octopus.Environment.Name}' '#{MyApplication.Storage.Path}'
 ```
-**Usage in Python3 script**
 
-```python
+```python Usage in Python3 script
 environment=sys.argv[1]
 storagePath=sys.argv[2]
 print("Parameters {} {}".format(environment, storagePath))
 ```
+
 :::div{.hint}
 **Note:** If your python scripts make use of [argparse](https://docs.python.org/3/library/argparse.html), it's possible you might encounter an error at execution time, as Calamari bootstraps the execution of the python script as part of the deployment or runbook run.
 :::

--- a/src/pages/docs/deployments/custom-scripts/passing-parameters-to-scripts.mdx
+++ b/src/pages/docs/deployments/custom-scripts/passing-parameters-to-scripts.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Passing parameters to scripts
 description: Octopus can pass parameters to your custom script files for any of the supported scripting languages.
 icon: fa-solid fa-arrow-right-to-bracket
@@ -103,24 +103,6 @@ You can pass parameters to Bash scripts [as described in Bash manual.](https://w
 environment="$1"
 storagePath="$2"
 echo "$environment storage path: $storagePath"
-```
-
-## Passing parameters to F# scripts \{#passing-parameters-fsharp}
-
-You can pass parameters to FSharp scripts [as described by the F# documentation.](https://docs.microsoft.com/en-us/dotnet/fsharp/tools/fsharp-interactive/#using-the-fsi-object-in-f-code)
-
-**Script Parameters in Octopus**
-
-```powershell
-"#{Octopus.Environment.Name}" "#{MyApplication.Storage.Path}"
-```
-
-**Usage in F# script**
-
-```fsharp
-let environment = fsi.CommandLineArgs.[1]
-let storagePath = fsi.CommandLineArgs.[2]
-printfn "$s storage path: $s" environment storagePath
 ```
 
 ## Passing parameters to Python3 scripts \{#passing-parameters-python}

--- a/src/pages/docs/deployments/custom-scripts/script-modules.md
+++ b/src/pages/docs/deployments/custom-scripts/script-modules.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2026-04-27
+modDate: 2026-08-11
 title: Script modules in Octopus
 navTitle: Script modules
 description: Script modules allow users to create collections of functions that can be used in deployment processes across multiple projects.
@@ -95,7 +95,6 @@ Each language has a slightly different syntax for using the Script Module. Pleas
 - [PowerShell](#powershell)
 - [Bash](#bash)
 - [C#](#csharp-script-modules)
-- [F#](#fsharp-script-modules)
 - [Python](#python-script-modules)
 
 ## PowerShell script modules {#powershell}
@@ -175,44 +174,6 @@ Call it from your Script Step with:
 ```csharp
 #load "CSharpScriptModule.csx"
 SayHello("George");
-```
-
-## F# script modules {#fsharp-script-modules}
-
-F# Script Modules are written as an `.fsx` file next to your script. Import them
-via `#load "MyScriptModule.fsx"`, where `MyScriptModule` is the name of your Script
-Module with invalid characters removed. The help text above the Script Module body
-will show the filename that will be created.
-
-F# script modules need to declare a module name at the top of the Script Module body with `module MyModule`.
-
-Once the Script Module file is loaded, you can either use the functions from the Script Module by prefixing the functions with the module name, or by "opening" the Script Module with `open MyModule`:
-
-```fsharp
-#load "MyScriptModule.fsx"
-// call the function in the module directly
-let result = MyModule.add 1 3
-// Or, open the module, and import the functions into scope
-open MyModule
-let result = add 1 3
-```
-
-The `#load` statement must be at the top of your script.
-
-Given an F# Script Module called `FSharp Script Module`:
-
-```fsharp
-module MyFSharpScriptModule
-let sayHello name =
-    printfn "Hello %s. Welcome to Octopus!" name;
-```
-
-Call it from your Script Step with:
-
-```fsharp
-#load "FSharpScriptModule.fsx"
-open MyFSharpScriptModule
-sayHello "George";
 ```
 
 ## Python script modules {#python-script-modules}

--- a/src/pages/docs/deployments/custom-scripts/scripts-in-packages/index.md
+++ b/src/pages/docs/deployments/custom-scripts/scripts-in-packages/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-08-28
+modDate: 2026-08-11
 title: Scripts in packages
 description: Octopus will run scripts included in your package when the script matches a naming convention.
 icon: fa-solid fa-cubes
@@ -82,8 +82,8 @@ If you are deploying the same package to multiple platforms, you can:
 
 The platform-specific priority order Octopus uses to select scripts is:
 
-- Linux: Bash, Python, C#, F#, PowerShell
-- Windows: PowerShell, Python, C#, F#, Bash
+- Linux: Bash, Python, C#, PowerShell
+- Windows: PowerShell, Python, C#, Bash
 
 Example: You are deploying an application to both Windows and Linux. You can write a single `PreDeploy.py` python script, making sure the python runtime is installed on both platforms. Alternatively, you can write both `PreDeploy.sh` and `PreDeploy.ps1`, and Octopus will run the Bash script on Linux and the PowerShell script on Windows.
 

--- a/src/pages/docs/deployments/custom-scripts/scripts-in-packages/index.md
+++ b/src/pages/docs/deployments/custom-scripts/scripts-in-packages/index.md
@@ -104,13 +104,13 @@ Make sure the scripts are located in the root of your package.
 Make sure the scripts are actually included in your package. Extract your package and inspect the contents to make sure the scripts are included as you expect. For example, if you are using OctoPack for an ASP.NET web application, you'll need to make sure the file is marked as **Build Action = Content**.
 
 :::figure
-![](/docs/img/deployments/custom-scripts/scripts-in-packages/3277766.png)
+![The Visual Studio file properties pane for Deploy.ps1, with Build Action set to Content](/docs/img/deployments/custom-scripts/scripts-in-packages/3277766.png)
 :::
 
 If you are using OctoPack to package a Windows Service or console application, set **Copy to Output Directory** = **Copy if newer**.
 
 :::figure
-![](/docs/img/deployments/custom-scripts/scripts-in-packages/3277765.png)
+![The Visual Studio file properties pane for Deploy.ps1, with Copy to Output Directory set to Copy if newer](/docs/img/deployments/custom-scripts/scripts-in-packages/3277765.png)
 :::
 
 Read more about [using OctoPack](/docs/packaging-applications/create-packages/octopack).

--- a/src/pages/docs/deployments/custom-scripts/scripts-in-packages/reference-files-within-a-package.md
+++ b/src/pages/docs/deployments/custom-scripts/scripts-in-packages/reference-files-within-a-package.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Reference files within a package
 description: How to reference files within a package.
 icon: fa-solid fa-cubes
@@ -86,29 +86,6 @@ cat "$customPath/subfolder/file.txt"
 #   in pre-deploy this will be the original extract folder
 #   in post-deploy this will be the custom install directory (if specified), otherwise the original extract folder
 cat "./subfolder/file.txt"
-```
-
-</details>
-<details data-group="deployments-custom-scripts-reference-files-within-package">
-<summary>F#</summary>
-
-```fsharp
-open System
-open System.IO
-
-// in pre-deploy, in post-deploy if custom installation directory has not been defined
-let extractPath = Octopus.findVariable "Octopus.Action.Package.InstallationDirectoryPath"
-// if a custom installation directory has been defined
-let customPath = Octopus.findVariable "Octopus.Action.Package.CustomInstallationDirectory"
-//original extract path,
-printfn "%s" (File.ReadAllText(extractPath + @"\subfolder\file.txt"))
-// or when a custom installation directory has been defined,
-printfn "%s" (File.ReadAllText(customPath + @"\subfolder\file.txt"))
-
-// or as a relative path from the Tentacle's working directory, 
-//   in pre-deploy this will be the original extract folder
-//   in post-deploy this will be the custom install directory (if specified), otherwise the original extract folder
-printfn "%s" (File.ReadAllText(@".\subfolder\file.txt"))
 ```
 
 </details>

--- a/src/pages/docs/deployments/custom-scripts/using-variables-in-scripts.md
+++ b/src/pages/docs/deployments/custom-scripts/using-variables-in-scripts.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Using variables in scripts
 description: With Octopus you can define variables for use with your custom scripts.
 icon: fa-solid fa-file-code
@@ -48,30 +48,6 @@ echo "Connection string is: $connectionString"
 
 </details>
 <details data-group="using-variables-in-scripts">
-<summary>F#</summary>
-
-```fsharp
-// It's a good idea to copy the value into a variable to avoid quoting issues
-
-// tryFindVariable : name:string -> string option
-let connectionString = Octopus.tryFindVariable "MyApp.ConnectionString"
-match connectionString with
-    | Some x -> printf "Connection string is: %s" x
-    | None -> printf "Connection string not found"
- 
-// Or one of the simplified versions
-
-// Throws KeyNotFoundException when variable does not exist
-// findVariable : name:string -> string
-let connectionString = Octopus.findVariable "MyApp.ConnectionString"
-
-// Returns default value when variable does not exist
-// findVariableOrDefault : defaultValue:string -> name:string -> string
-let connectionString = Octopus.findVariableOrDefault "Default Value" "MyApp.ConnectionString"
-```
-
-</details>
-<details data-group="using-variables-in-scripts">
 <summary>Python3</summary>
 
 ```python
@@ -80,10 +56,6 @@ print(connectionString)
 ```
 
 </details>
-
-:::div{.success}
-To see the F# API available to your F# scripts, take a look at our [F# signature file](https://github.com/OctopusDeploy/Calamari/tree/master/source/Calamari.Common/Features/Scripting/FSharp/Bootstrap.fsi).
-:::
 
 ## Variables in PowerShell scripts {#variables-in-powershell}
 

--- a/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/tentacle/linux/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Linux Tentacle
 description: How to install and configure Octopus Tentacles on Linux Servers in either listening or polling mode.
 navOrder: 20
@@ -25,12 +25,6 @@ Linux Tentacle is a .NET application distributed as a [self-contained deployment
 ### Git-based steps \{#git-based-steps}
 
 Git-based steps (steps that clone or fetch from a git repository as part of a deployment or runbook) require OpenSSL **1.1** or **3** on the host. Tentacles running with other OpenSSL versions will fail when running these steps.
-
-## Known limitations
-
-Support for F# scripts are only available with **Mono 4** and above. While they require mono installed, they will still execute with the self-contained Calamari.
-
-Similarly, the F# interpreter has also not yet been ported for .NET Core ([GitHub issue](https://github.com/Microsoft/visualfsharp/issues/2407)).
 
 ## Downloads
 

--- a/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-container.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-container.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Migrate Octopus Windows Container to Linux
 description: Move Octopus Server from the Windows container image to the Linux container. Follow the migration guide to transfer your database backup and configuration.
 navOrder: 20
@@ -22,7 +22,6 @@ This guide is designed to address the differences between the Windows and Linux 
 
 - **Folder Paths:** Windows Containers follow the Windows folder structure with `\` slashes, for example, `C:\Octopus\Tasklogs`.  Linux Containers follow a Linux folder structure, including `/` slashes.
 - **Pre-installed software:** Windows Containers include PowerShell and .NET 4.7.2 (or 4.8) but not Bash.  Linux Containers typically include PowerShell Core and Bash but not .NET.
-- **Software support:** The Linux Container doesn't support running F# scripts directly on the server.
 - **Authentication:** The Octopus Server Linux Container doesn't support Active Directory authentication.  Some users have had success using Active Directory with the Octopus Server Windows Container, but any workarounds won't work with the Linux Container.  If you want to use Active Directory, you must connect to it via the [LDAP authentication provider](/docs/security/authentication/ldap).
 
 :::div{.hint}

--- a/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-server.mdx
+++ b/src/pages/docs/installation/octopus-server-linux-container/migration/migrate-to-server-container-linux-from-windows-server.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Migrate from Windows Server to Linux Container
 description: Move Octopus Server from a Windows Server installation to the Linux container image. Follow the step-by-step migration guide to transfer your data and config.
 navOrder: 10
@@ -24,7 +24,6 @@ The differences between running Octopus Server on Windows Server and Linux Conta
 
 - **Folder Paths:** Windows uses a folder structure with `\` slashes, for example, `C:\Octopus\Tasklogs`.  Linux Containers follow a Linux folder structure, including `/` slashes.
 - **Pre-installed software:** Linux Containers typically include PowerShell Core and Bash but not .NET.  You cannot pre-install any other software on the Octopus Linux Container.
-- **Software support:** The Linux Container doesn't support running F# scripts directly on the server.
 - **Authentication:** The Octopus Server Linux Container doesn't support Active Directory authentication.  If you want to use Active Directory, you must connect to it via the [LDAP authentication provider](/docs/security/authentication/ldap).
 
 :::div{.hint}

--- a/src/pages/docs/installation/troubleshooting.md
+++ b/src/pages/docs/installation/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2026-08-11
 title: Troubleshoot Octopus installation issues
 description: Fix common Octopus Server installation errors. Find solutions for database connection failures, port conflicts, Windows service issues, and permission problems.
 navOrder: 7
@@ -35,7 +35,7 @@ Once this option is on, PowerShell scripts automatically support long file names
 
 ## Limitations
 
-- C# and F# scripts do not support long filenames.
+- C# scripts do not support long filenames.
 - Windows limits the each component of the path to 255 characters.
 - Due to how we store and transfer packages, PackageIDs are limited to 100 characters and Package ID and Version combined to 216 characters.
 - The package extraction path (`<TentacleApplicationDirectory>\<PackageId>\<Version>`) must be less than 256 characters long.

--- a/src/pages/docs/octopus-rest-api/calamari.md
+++ b/src/pages/docs/octopus-rest-api/calamari.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-12-11
+modDate: 2026-08-11
 title: Calamari
 navOrder: 70
 description: Calamari is the command-line tool invoked by Tentacle during a deployment. It knows how to deploy to Kubernetes, extract and install packages, run scripts and conventions, modify configuration files, and all the other things that happen during a deployment.
@@ -17,7 +17,7 @@ Calamari has commands to support:
 
 - Deploying to Kubernetes via Helm/Kustomize/Yaml.
 - Deploying NuGet packages.
-- Running scripts (PowerShell, ScriptCS, Bash, F#).
+- Running scripts (PowerShell, Bash, C#, Python).
 - Deploying packages to Cloud services (WebApps, Functions etc.).
 - Various other deployment related activities.
 

--- a/src/pages/docs/octopus-rest-api/calamari.md
+++ b/src/pages/docs/octopus-rest-api/calamari.md
@@ -66,4 +66,4 @@ var conventions = new List<IConvention>
 };
 ```
 
-Calamari is published under the Apache license, you can find the source code [here](https://github.com/OctopusDeploy/Calamari).
+Calamari is published under the Apache license. You can find the [Calamari source code on GitHub](https://github.com/OctopusDeploy/Calamari).

--- a/src/pages/docs/projects/deployment-process/artifacts.mdx
+++ b/src/pages/docs/projects/deployment-process/artifacts.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Artifacts
 icon: fa-solid fa-file-lines
 description: Artifacts in Octopus provide a convenient way to collect files from remote machines during deployments.
@@ -65,19 +65,6 @@ new_octopusartifact output.log
 # Collect the hosts file but using a custom name for each machine so you can differentiate between them
 # Note: to collect this artifact would require the SSH user account to be elevated as a high privileged user account
 new_octopusartifact /etc/hosts $(hostname)-hosts.txt
-```
-
-</details>
-<details data-group="deployment-process-artifacts">
-<summary>F#</summary>
-
-```fsharp
-// Collect a custom log file from the current working directory using the file name as the name of the artifact
-Octopus.createArtifact "output.log"
-
-// Collect the hosts file but using a custom name for each machine so you can differentiate between them
-// Note: to collect this artifact would require the Tentacle process to be elevated as a high privileged user account
-Octopus.createArtifact @"C:\Windows\System32\drivers\etc\hosts" (Some (System.Environment.MachineName + "-hosts.txt"))
 ```
 
 </details>

--- a/src/pages/docs/projects/deployment-process/artifacts.mdx
+++ b/src/pages/docs/projects/deployment-process/artifacts.mdx
@@ -19,7 +19,7 @@ Artifacts can be collected from anywhere Octopus runs scripts - for example, the
 Artifacts are uploaded to the Octopus Server after a script runs. You can download them from the task output or via the [Octopus API](/docs/octopus-rest-api).
 
 :::figure
-![](/docs/img/projects/deployment-process/images/artifacts-access.png)
+![The Task Summary tab of a deployment, showing collected artifacts listed under each step and in the Artifacts panel](/docs/img/projects/deployment-process/images/artifacts-access.png)
 :::
 
 ## Collecting artifacts using scripts

--- a/src/pages/docs/projects/variables/output-variables.mdx
+++ b/src/pages/docs/projects/variables/output-variables.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2025-05-19
+modDate: 2026-08-11
 title: Output variables
 icon: fa-solid fa-diagram-next
 description: Output variables allow you to set dynamic variables in one step that can be used in subsequent steps.
@@ -40,14 +40,6 @@ SetVariable("TestResult", "Passed");
 
 ```bash
 set_octopusvariable "TestResult" "Passed"
-```
-
-</details>
-<details data-group="output-variables">
-<summary>F#</summary>
-
-```fsharp
-Octopus.setVariable "TestResult" "Passed"
 ```
 
 </details>
@@ -93,14 +85,6 @@ testResult=$(get_octopusvariable "Octopus.Action[StepA].Output.TestResult")
 
 </details>
 <details data-group="output-variables-use-in-other-steps">
-<summary>F#</summary>
-
-```fsharp
-let testResult = Octopus.findVariable "Octopus.Action[StepA].Output.TestResult"
-```
-
-</details>
-<details data-group="output-variables-use-in-other-steps">
 <summary>Python3</summary>
 
 ```python
@@ -132,14 +116,6 @@ SetVariable("Password", "correct horse battery staple", true);
 
 ```bash
 set_octopusvariable "Password" "correct horse battery staple" -sensitive
-```
-
-</details>
-<details data-group="sensitive-output-variables">
-<summary>F#</summary>
-
-```fsharp
-Octopus.setSensitiveVariable "Password" "correct horse battery staple"
 ```
 
 </details>
@@ -240,15 +216,11 @@ In a Bash script you can use the `set_octopusvariable` function to set the name 
 set_octopusvariable "TestResult" "Passed"
 ```
 
-### F# \{#fsharp}
+### Python \{#python}
 
-[FSharp Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/main/source/Calamari.Common/Features/Scripting/FSharp)
+[Python Bootstrapping](https://github.com/OctopusDeploy/Calamari/tree/main/source/Calamari.Common/Features/Scripting/Python)
 
-From a F# script, you can use the `setVariable : name:string -> value:string -> unit` function to collect artifacts. The function takes two parameters with the same purpose as the PowerShell CmdLet.
-
-```fsharp Set an output variable
-Octopus.setVariable "TestResult" "Passed"
-```
+In a Python script you can use the `set_octopusvariable` function to set the name and value of an output variable. This function takes two positional parameters with the same purpose as the PowerShell CmdLet.
 
 ```python Set an output variable
 set_octopusvariable("TestResult", "Passed")

--- a/src/plugins/shiki-code-block.js
+++ b/src/plugins/shiki-code-block.js
@@ -15,7 +15,6 @@ const LANGUAGE_NAMES = {
   csharp: 'C#',
   docker: 'Docker',
   dockerfile: 'Dockerfile',
-  fsharp: 'F#',
   go: 'Go',
   hcl: 'HCL',
   html: 'HTML',


### PR DESCRIPTION
Deprecate F# docs as F# script steps was [deprecated in `2024.1`](https://octopus.com/docs/deprecations) 