### PR TITLE
Give the markdown emitter posix paths

### DIFF
--- a/src/integrations/llm-md-emitter.ts
+++ b/src/integrations/llm-md-emitter.ts
@@ -31,6 +31,7 @@ function buildSharedContentLookup(): SharedContentLookup {
   const files = globSync('**/*.{md,mdx}', {
     cwd: SHARED_CONTENT_ROOT,
     nodir: true,
+    posix: true,
   });
   for (const f of files) {
     const abs = path.join(SHARED_CONTENT_ROOT, f);
@@ -66,6 +67,7 @@ export default function llmMdEmitter(): AstroIntegration {
         const files = globSync('**/*.{md,mdx}', {
           cwd: PAGES_ROOT,
           nodir: true,
+          posix: true,
         });
 
         const seenSlugs = new Map<string, string>();


### PR DESCRIPTION
`globSync` returns backslash-separated paths on Windows, and `llm-md-emitter.ts` feeds them into forward-slash logic in two places. Two lines of `posix: true`.

## What was broken

**Pages written to the wrong path.** `pathToSlug` strips a trailing `/index` with a forward-slash regex, so `argo-cd\index` kept its suffix and the page landed at `dist/docs/argo-cd/index.md` instead of `dist/docs/argo-cd.md`. Every request for `/docs/argo-cd.md` 404d.

**Pages silently dropped.** The shared content lookup builds keys with `path.posix.join`, which leaves a backslash mid-key and never matches the include paths written in the source files. A page whose include failed to resolve was judged ineligible for markdown, so it got no `.md` companion, no entry in `llms.txt`, and nothing advertising it.

That second one is the bigger of the two:

```
before:  emitted  846 .md files, skipped 1815 ineligible
after:   emitted 1253 .md files, skipped 1409 ineligible
```

**407 pages** were being excluded.

Linux is unaffected — `globSync` returns forward slashes there — which is why this survived. It only bites a Windows checkout, where it also makes `tests/llm-endpoints.spec.ts` unusable.

## Testing

`astro build` from a clean `dist`: exit 0, 2673 pages, 1253 `.md` emitted, `dist/docs/argo-cd.md` present.

`tests/llm-endpoints.spec.ts`: 11 passed, 0 failed. Four of these fail on a Windows checkout of `main`, all on this one cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
