### PR TITLE
Add a Copy as markdown page action

### DIFF
--- a/src/components/CopyAsMarkdown.astro
+++ b/src/components/CopyAsMarkdown.astro
@@ -24,15 +24,3 @@ const pageMdUrl = pageMarkdownUrl(Astro.url.pathname);
     />
   )
 }
-
-<style>
-  /* `:global()` crosses into Button's scope */
-  :global(.octo-copy-as-md__icon) {
-    background-color: var(--colorIconPrimary);
-    mask: url('../assets/icons/copy.svg') center / contain no-repeat;
-  }
-
-  :global(.octo-copy-as-md[data-copied] .octo-copy-as-md__icon) {
-    mask: url('../assets/icons/check.svg') center / contain no-repeat;
-  }
-</style>

--- a/src/components/CopyAsMarkdown.astro
+++ b/src/components/CopyAsMarkdown.astro
@@ -21,6 +21,8 @@ const pageMdUrl = pageMarkdownUrl(Astro.url.pathname);
       label={_(Translations.octopus_copy_as_md.copy)}
       size="small"
       data-copy-md-url={pageMdUrl}
+      data-copied-label={_(Translations.octopus_copy_as_md.copied)}
+      data-error-label={_(Translations.octopus_copy_as_md.error)}
     />
   )
 }

--- a/src/components/CopyAsMarkdown.astro
+++ b/src/components/CopyAsMarkdown.astro
@@ -1,0 +1,38 @@
+---
+import { Lang, Translations } from '@util/Languages';
+import { pageMarkdownUrl } from '@util/mdxContent';
+import Button from './Button.astro';
+
+type Props = {
+  lang: string;
+};
+const { lang } = Astro.props satisfies Props;
+
+const _ = Lang(lang);
+
+const pageMdUrl = pageMarkdownUrl(Astro.url.pathname);
+---
+
+{
+  pageMdUrl && (
+    <Button
+      class="octo-copy-as-md"
+      icon="octo-copy-as-md__icon"
+      label={_(Translations.octopus_copy_as_md.copy)}
+      size="small"
+      data-copy-md-url={pageMdUrl}
+    />
+  )
+}
+
+<style>
+  /* `:global()` crosses into Button's scope */
+  :global(.octo-copy-as-md__icon) {
+    background-color: var(--colorIconPrimary);
+    mask: url('../assets/icons/copy.svg') center / contain no-repeat;
+  }
+
+  :global(.octo-copy-as-md[data-copied] .octo-copy-as-md__icon) {
+    mask: url('../assets/icons/check.svg') center / contain no-repeat;
+  }
+</style>

--- a/src/components/CopyMarkdown.astro
+++ b/src/components/CopyMarkdown.astro
@@ -1,7 +1,7 @@
 ---
 import { SITE } from '@config';
 import { Lang, Translations } from '@util/Languages';
-import { getEligibleSlugs } from '@util/mdxContent';
+import { pageMarkdownUrl } from '@util/mdxContent';
 
 type Props = {
   lang: string;
@@ -10,14 +10,7 @@ const { lang } = Astro.props satisfies Props;
 
 const _ = Lang(lang);
 
-const docsPath = Astro.url.pathname.replace(/\/$/, '');
-const subfolderPrefix = SITE.subfolder.replace(/\/$/, '') + '/';
-const docsSlug = docsPath.startsWith(subfolderPrefix)
-  ? docsPath.slice(subfolderPrefix.length)
-  : null;
-const eligibleSlugs = getEligibleSlugs();
-const pageMdUrl =
-  docsSlug && eligibleSlugs.has(docsSlug) ? docsPath + '.md' : null;
+const pageMdUrl = pageMarkdownUrl(Astro.url.pathname);
 const allDocsUrl = SITE.subfolder.replace(/\/$/, '') + '/llms-full.txt';
 ---
 

--- a/src/data/language.json
+++ b/src/data/language.json
@@ -36,6 +36,12 @@
     "octopus_copy_as_md": {
         "copy": {
             "en": "Copy as markdown"
+        },
+        "copied": {
+            "en": "Copied"
+        },
+        "error": {
+            "en": "Copy failed"
         }
     },
     "octopus_copy_md": {

--- a/src/data/language.json
+++ b/src/data/language.json
@@ -33,6 +33,11 @@
             "en": "Edit on GitHub"
         }
     },
+    "octopus_copy_as_md": {
+        "copy": {
+            "en": "Copy as markdown"
+        }
+    },
     "octopus_copy_md": {
         "label": {
             "en": "Use Octopus docs with AI"

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -22,6 +22,7 @@ import ArticleJourney from '../components/ArticleJourney.astro';
 import Feedback from '../components/Feedback.astro';
 import EditOnGithub from '../components/EditOnGithub.astro';
 import CopyMarkdown from '../components/CopyMarkdown.astro';
+import CopyAsMarkdown from '../components/CopyAsMarkdown.astro';
 import Plausible from 'src/components/Plausible.astro';
 import Footer from 'src/components/Footer.astro';
 
@@ -88,6 +89,7 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
               headings={headings}
               lang={lang}
             />
+            <CopyAsMarkdown lang={lang} />
           </div>
           <div class="page-content anim-show-parent" itemprop="articleBody">
             <slot />

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -6,6 +6,7 @@ import {
 import { addResizedEvent } from './modules/resizing.js';
 import { addStickyNavigation } from './modules/nav-sticky.js';
 import { mobileNav } from './modules/nav-mobile.js';
+import { copyFetchedOnClick } from './modules/copy-button.js';
 import { copyMarkdownMenus } from './modules/copy-markdown.js';
 import { setClickableBlocks } from './modules/click-blocks.js';
 import { setExternalLinkAttributes } from './modules/external-links.js';
@@ -29,6 +30,10 @@ monitorInputType();
 enableSharing();
 highlightCurrentHeading('.page-toc a');
 highlightCurrentHeading('.article-nav a');
+copyFetchedOnClick(
+  '.octo-copy-as-md',
+  (button) => button.dataset.copyMdUrl ?? null
+);
 
 // @ts-ignore
 const f = site_features ?? {};

--- a/src/scripts/modules/copy-button.js
+++ b/src/scripts/modules/copy-button.js
@@ -3,6 +3,10 @@
 // Shared by the heading copy-URL button, the code block copy button and the
 // page action that copies the page as markdown. All swap to a result, revert
 // after a beat, and announce it.
+//
+// One module rather than one per button, because `status` below is the page's
+// only live region. Split this up and a page grows a second announcer, which
+// screen readers treat as a separate status to track.
 
 const REVERT_MS = 2000;
 
@@ -68,6 +72,9 @@ function showResult(button, message) {
     setTimeout(() => {
       write(rest);
       delete button.dataset.copied;
+      // Released so the next copy measures again, in case the text has since
+      // reflowed at a different zoom or font size.
+      button.style.minWidth = '';
       timers.delete(button);
     }, REVERT_MS)
   );

--- a/src/scripts/modules/copy-button.js
+++ b/src/scripts/modules/copy-button.js
@@ -1,7 +1,8 @@
 // @ts-check
 
-// Shared by the heading copy-URL button and the code block copy button. Both
-// swap their tooltip to a result, revert after a beat, and announce it.
+// Shared by the heading copy-URL button, the code block copy button and the
+// page action that copies the page as markdown. All swap to a result, revert
+// after a beat, and announce it.
 
 const REVERT_MS = 2000;
 
@@ -18,33 +19,54 @@ const restLabels = new WeakMap();
 let status = null;
 
 /**
- * A button's own data-tooltip is its resting label, captured before the first
- * result overwrites it.
+ * A labelled button shows the result in its label, an icon-only one in its
+ * tooltip. Captured before the first result overwrites it.
  *
  * @param {HTMLElement} button
+ * @param {Element | null} label
  */
-function restLabel(button) {
+function restLabel(button, label) {
   if (!restLabels.has(button)) {
-    restLabels.set(button, button.dataset.tooltip ?? '');
+    restLabels.set(
+      button,
+      (label ? label.textContent : button.dataset.tooltip) ?? ''
+    );
   }
   return restLabels.get(button) ?? '';
 }
 
 /**
+ * `data-copied` is what swaps the icon, so it is set either way.
+ *
  * @param {HTMLElement} button
  * @param {string} message
  */
 function showResult(button, message) {
-  const rest = restLabel(button);
+  const label = button.querySelector('.btn__label');
+  const rest = restLabel(button, label);
 
-  button.dataset.tooltip = message;
+  const write = (/** @type {string} */ text) => {
+    if (label) label.textContent = text;
+    else button.dataset.tooltip = text;
+  };
+
+  // "Copied" is shorter than the resting label, and a button that narrows for
+  // two seconds shuffles whatever sits beside it. Measured rather than given a
+  // width up front, so it holds for any translation of the label.
+  // Fractional, because offsetWidth rounds and the button would still shift by
+  // the part of a pixel it dropped.
+  if (label) {
+    button.style.minWidth = button.getBoundingClientRect().width + 'px';
+  }
+
+  write(message);
   button.dataset.copied = '';
 
   clearTimeout(timers.get(button));
   timers.set(
     button,
     setTimeout(() => {
-      button.dataset.tooltip = rest;
+      write(rest);
       delete button.dataset.copied;
       timers.delete(button);
     }, REVERT_MS)
@@ -66,7 +88,7 @@ function announce(message) {
   }
 
   // Cleared first, then set on a later task, so copying twice in a row reads as
-  // a change and is announced both times. Same as copy-markdown.js.
+  // a change and is announced both times.
   const region = status;
   region.textContent = '';
   setTimeout(() => {
@@ -79,25 +101,26 @@ function announce(message) {
  * ones a module adds later.
  *
  * @param {string} selector
- * @param {(button: HTMLElement) => string | null} read the text to copy. Must
- *   return synchronously: Safari spends the click's user activation on the
- *   first await, and the clipboard write then fails.
+ * @param {(button: HTMLElement) => Promise<void> | null} write starts the
+ *   clipboard write, or returns null to let the click through. Called before
+ *   the first await, because Safari spends the click's user activation on it
+ *   and every clipboard API refuses once that is gone.
  */
-function copyOnClick(selector, read) {
+function onCopyClick(selector, write) {
   document.addEventListener('click', async (event) => {
     if (!(event.target instanceof Element)) return;
 
     const button = event.target.closest(selector);
     if (!(button instanceof HTMLElement)) return;
 
-    const value = read(button);
-    if (value === null) return;
+    const pending = write(button);
+    if (pending === null) return;
 
     let message = COPIED;
     try {
-      await navigator.clipboard.writeText(value);
+      await pending;
     } catch (error) {
-      console.warn('[copy-button] clipboard write failed', error);
+      console.warn('[copy-button] copy failed', error);
       message = FAILED;
     }
 
@@ -106,4 +129,48 @@ function copyOnClick(selector, read) {
   });
 }
 
-export { copyOnClick };
+/**
+ * @param {string} selector
+ * @param {(button: HTMLElement) => string | null} read the text to copy, read
+ *   off the page and so available synchronously.
+ */
+function copyOnClick(selector, read) {
+  onCopyClick(selector, (button) => {
+    const value = read(button);
+    return value === null ? null : navigator.clipboard.writeText(value);
+  });
+}
+
+/**
+ * Fetched text cannot use writeText, because awaiting the response first spends
+ * the user activation the write needs. Handing ClipboardItem the pending
+ * response instead lets the write start now and settle later. writeText is kept
+ * for the sync case: it is the simpler call and the better supported one.
+ *
+ * @param {string} selector
+ * @param {(button: HTMLElement) => string | null} readUrl
+ */
+function copyFetchedOnClick(selector, readUrl) {
+  onCopyClick(selector, (button) => {
+    const url = readUrl(button);
+    if (url === null) return null;
+
+    const text = fetch(url).then((response) => {
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      return response.text();
+    });
+
+    if (typeof ClipboardItem !== 'function' || !navigator.clipboard.write) {
+      return text.then((value) => navigator.clipboard.writeText(value));
+    }
+
+    const blob = text.then(
+      (value) => new Blob([value], { type: 'text/plain' })
+    );
+    return navigator.clipboard.write([
+      new ClipboardItem({ 'text/plain': blob }),
+    ]);
+  });
+}
+
+export { copyOnClick, copyFetchedOnClick };

--- a/src/scripts/modules/copy-button.js
+++ b/src/scripts/modules/copy-button.js
@@ -10,8 +10,21 @@
 
 const REVERT_MS = 2000;
 
+// Defaults for the icon-only buttons, whose result reaches the user as a
+// tooltip. A button that shows the result as visible text carries its own
+// translated pair instead.
 const COPIED = 'Copied';
 const FAILED = 'Copy failed';
+
+/**
+ * @param {HTMLElement} button
+ */
+function resultLabels(button) {
+  return {
+    copied: button.dataset.copiedLabel || COPIED,
+    failed: button.dataset.errorLabel || FAILED,
+  };
+}
 
 /** @type {WeakMap<HTMLElement, ReturnType<typeof setTimeout>>} */
 const timers = new WeakMap();
@@ -123,12 +136,13 @@ function onCopyClick(selector, write) {
     const pending = write(button);
     if (pending === null) return;
 
-    let message = COPIED;
+    const labels = resultLabels(button);
+    let message = labels.copied;
     try {
       await pending;
     } catch (error) {
       console.warn('[copy-button] copy failed', error);
-      message = FAILED;
+      message = labels.failed;
     }
 
     showResult(button, message);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1799,6 +1799,17 @@ html[data-theme='light'] .theme-switcher__icon--dark svg path {
   mask: url('../assets/icons/github.svg') center / contain no-repeat;
 }
 
+/* Copy as markdown page action */
+
+.octo-copy-as-md__icon {
+  background-color: var(--colorIconPrimary);
+  mask: url('../assets/icons/copy.svg') center / contain no-repeat;
+}
+
+.octo-copy-as-md[data-copied] .octo-copy-as-md__icon {
+  mask: url('../assets/icons/check.svg') center / contain no-repeat;
+}
+
 /* "Use Octopus docs with AI" dropdown */
 .octo-copy-md {
   margin-block-start: var(--block-gap);

--- a/src/themes/octopus/utilities/mdxContent.ts
+++ b/src/themes/octopus/utilities/mdxContent.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter';
+import { SITE } from '@config';
 import {
   eligibleForMarkdownWithLookup,
   pathToSlug as relPathToSlug,
@@ -59,7 +60,7 @@ function globKeyToSlug(globKey: string): string | null {
   return relPathToSlug(m[1]);
 }
 
-// Memoized for builds only: CopyMarkdown.astro calls this on every page, and
+// Memoized for builds only: the page actions call this on every page, and
 // the walk re-parses frontmatter for all ~2,660 docs pages each time (~23ms x
 // ~1,270 pages ≈ 29s of build time). During a build the corpus cannot change,
 // so one pass is enough. In dev it stays uncached so edits to docs frontmatter
@@ -86,4 +87,15 @@ export function getEligibleSlugs(): Set<string> {
   if (import.meta.env.PROD) eligibleSlugsCache = slugs;
 
   return slugs;
+}
+
+// Null when the page has no .md companion, which is what the page actions that
+// hand the markdown to something else key off.
+export function pageMarkdownUrl(pathname: string): string | null {
+  const docsPath = pathname.replace(/\/$/, '');
+  const prefix = SITE.subfolder.replace(/\/$/, '') + '/';
+  if (!docsPath.startsWith(prefix)) return null;
+
+  const slug = docsPath.slice(prefix.length);
+  return getEligibleSlugs().has(slug) ? docsPath + '.md' : null;
 }

--- a/tests/llm-endpoints.spec.ts
+++ b/tests/llm-endpoints.spec.ts
@@ -50,10 +50,9 @@ test('llms.txt is spec-shaped', async ({ request }) => {
 
   const linkRe = /\[[^\]]+\]\((https?:\/\/[^)]+)\)/g;
   const urls = Array.from(body.matchAll(linkRe), (m) => m[1]);
-  expect(
-    urls.length,
-    'expected at least one link in llms.txt'
-  ).toBeGreaterThan(0);
+  expect(urls.length, 'expected at least one link in llms.txt').toBeGreaterThan(
+    0
+  );
   for (const u of urls) {
     expect(u, `URL ${u} should end in .md`).toMatch(/\.md(?:[#?].*)?$/);
   }
@@ -81,6 +80,44 @@ test('llms-full.txt is well-formed: intro, summary, page boundaries, no orphaned
     body,
     'unexpected literal `<Image` JSX tag (not the HTML img) left in output'
   ).not.toMatch(/<Image[\s>]/);
+});
+
+test.describe('Copy as markdown page action', () => {
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test('puts the page markdown on the clipboard and reports it', async ({
+    page,
+  }) => {
+    await page.goto(STABLE_PLAIN_MD_PATH);
+    const button = page.locator('.octo-copy-as-md');
+
+    await expect(button).toHaveAttribute(
+      'data-copy-md-url',
+      STABLE_PLAIN_MD_PATH + '.md'
+    );
+
+    // Locked before the label shortens, so the buttons beside it stay put.
+    const restingWidth = (await button.boundingBox())!.width;
+    await button.click();
+
+    await expect(button).toHaveAttribute('data-copied', '');
+    expect((await button.boundingBox())!.width).toBe(restingWidth);
+
+    // The platform clipboard drops the BOM the .md carries and rewrites the
+    // newlines, so this checks the body rather than matching it byte for byte.
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain('# Argo CD deployments with Octopus');
+
+    await expect(button).not.toHaveAttribute('data-copied', '', {
+      timeout: 4000,
+    });
+  });
+
+  test('is hidden on the ineligible MDX page', async ({ page }) => {
+    await page.goto(STABLE_MDX_PATH);
+    const count = await page.locator('.octo-copy-as-md').count();
+    expect(count, 'expected no copy button on ineligible page').toBe(0);
+  });
 });
 
 test('CopyMarkdown dropdown advertises a working .md URL on the eligible page', async ({


### PR DESCRIPTION
Implements the [Copy to clipboard](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1561-20055&m=dev) design from Documentation vision.

Based on `main`. Part of a four-PR stack.

| PR | What | Base | State |
|----|------|------|-------|
| #3337 | markdown emitter posix paths | `main` | merged |
| **this** | Copy as markdown page action | `main` | |
| #3340 | SplitButton component | `main` | |
| #3330 | Open in Claude, old dropdown removed | `wl/page-actions` | |

## What changed

Under the page header, next to **Edit on GitHub**, there is now a **Copy as markdown** action. It fetches this page's `.md` companion and puts it on the clipboard, swaps to a check icon and "Copied" for two seconds, then reverts.

It is the `Button` component, so borders, radius, hover, pressed and focus states come from the design-system tokens.

Its two icon rules live in `main.css` beside `.octo-github-edit__icon`, which is the same Button-plus-icon-class arrangement. They cannot live in a scoped block in `CopyAsMarkdown.astro`: Astro stamps a component's scope on its own elements and on a child component's root, so the icon `<span>` inside `Button` never receives the parent's scope and a scoped selector cannot match it. Keeping them in the component would mean `:global()` on both, which is global CSS in a file that looks like it owns it.

The existing "Use Octopus docs with AI" dropdown at the foot of the article is left alone, so both offer to copy the page until #3330 replaces that dropdown. Two consequences for that window, both gone once #3330 lands: a page carries two ways to copy its markdown, and because the dropdown ships its own inline `aria-live` region, a page that has been copied from once carries two polite live regions. Renaming or trimming the dropdown here was considered and dropped — #3330 deletes the component, its script and its CSS outright, so the work would not survive the next PR in the stack.

Worth flagging for review: #3330 replaces the dropdown with Open in Claude / Open in ChatGPT and does not carry over its other two options, "Open this page as markdown" and "Open all docs as markdown". Losing those is a product call that belongs on that PR rather than this one, but it is easier to spot from here.

## Reusing the shared copy module

`copy-button.js` (from #3317) grows two things rather than this action reimplementing them:

- `showResult` writes to `.btn__label` when there is one, and falls back to the tooltip otherwise. The design wants the result in the label; the two existing icon-only consumers are unchanged and cannot do this.
- The result text is now translatable. `resultLabels()` reads `data-copied-label` / `data-error-label` off the button and falls back to the module's constants, so this button passes `octopus_copy_as_md.copied` and `.error` while the two icon-only consumers keep the defaults. The dropdown being replaced localized these three strings; the shared module hardcoded them, so a button showing its result as visible text would have regressed on that.
- `copyFetchedOnClick` covers text that has to be fetched. It hands `ClipboardItem` a **pending promise** so the click's user activation survives the request — awaiting the fetch first and then writing loses it in Safari, which is the trap the module's own comment warns about.

The delegated listener, result swap and announcement are shared by both entry points. The two write strategies stay apart on purpose: the promise trick only earns its keep when there is an await to survive, and text read off the page has none, so it keeps the simpler and more widely supported `writeText`.

The button also locks its measured width before the label shortens, so what sits beside it does not shuffle. Measured rather than hardcoded, so it holds for any translation. The lock is released on revert, so a later copy measures again instead of holding a width taken at an older zoom level.

A third button could have had its own module instead. It shouldn't: `status` in `copy-button.js` is the page's only `aria-live` region, and a second module scope means a second announcer for screen readers to track, plus a duplicate of the clear-then-set trick that makes two copies in a row both announce. The module header now records this.

The eligibility check moved to `pageMarkdownUrl()`, and `CopyMarkdown.astro` now calls it too, so the slug is derived in one place rather than two.

## Testing

`astro build` from a clean `dist`: exit 0, 2674 pages, 0 parse or write failures.

Checked that moving the icon rules to `main.css` did not change what ships: in `dist/docs/_astro/*.css` both `.octo-copy-as-md__icon` and the `[data-copied]` swap come out with their SVGs inlined as data URIs, structurally identical to `.octo-github-edit__icon`. `/docs/argo-cd` renders the button with `data-copy-md-url="/docs/argo-cd.md"`; the ineligible `/docs/kubernetes` has no occurrence of the class at all.

`tests/llm-endpoints.spec.ts` gains two tests: one that clicks the copy button and reads the clipboard back to confirm the page markdown actually arrives, and one that the action is absent on an ineligible page.

Note that nothing in `.github/workflows` runs Playwright, so these are local-only. The numbers below are from my machine.

**13 passed / 0 failed**, against a build carrying the emitter posix fix. That fix has since merged as #3337, so `main` has it and this branch picks it up on merge — the earlier caveat about a Windows checkout emitting only 847 of 1253 `.md` companions no longer applies. This branch is not itself rebased onto that commit, so a local run from this branch alone still needs `main` merged in first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

