### PR TITLE
Keep the bookmark tests on the build under test

### DIFF
--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -89,12 +89,30 @@ const bookmarks = [
   '/docs/security/users-and-teams/auditing#accessing-archived-logs',
 ];
 
+// A bookmark whose page is a Redirect.astro stub follows a meta refresh to an absolute
+// octopus.com URL, so the assertion lands on the live site and the test fails whenever
+// production is slow or unreachable. Serve those from the build under test instead.
+test.beforeEach(async ({ page }) => {
+  await page.route('https://octopus.com/**', (route) =>
+    route.fulfill({
+      status: 302,
+      headers: {
+        location: route.request().url().replace('https://octopus.com', baseUrl),
+      },
+    })
+  );
+});
+
 for (let bookmark of bookmarks) {
   const url = new URL(bookmark, baseUrl);
-  
+
   test(`Check bookmark for ${bookmark}`, async ({ page }) => {
     await page.goto(url.href);
 
     await expect(page.locator(url.hash)).toBeVisible()
+
+    // The anchor only exists on the destination, so reaching here means navigation has
+    // settled. Fail if it settled somewhere other than the build under test.
+    expect(new URL(page.url()).origin).toBe(new URL(baseUrl).origin);
   });
 }

--- a/tests/bookmark.spec.ts
+++ b/tests/bookmark.spec.ts
@@ -92,8 +92,10 @@ const bookmarks = [
 // A bookmark whose page is a Redirect.astro stub follows a meta refresh to an absolute
 // octopus.com URL, so the assertion lands on the live site and the test fails whenever
 // production is slow or unreachable. Serve those from the build under test instead.
+// Scoped to /docs because that is the only prefix this app is proxied under, and eight
+// stubs point at /devops pages it cannot serve — those have to stay absolute.
 test.beforeEach(async ({ page }) => {
-  await page.route('https://octopus.com/**', (route) =>
+  await page.route('https://octopus.com/docs/**', (route) =>
     route.fulfill({
       status: 302,
       headers: {


### PR DESCRIPTION
Two of the 78 bookmarks in `tests/bookmark.spec.ts` were asserting against live production instead of the build under test. That is what failed #3337, whose diff is two `posix: true` lines that glob documents as a no-op on posix systems — the CI runner is ubuntu-24.04, so it could not have been the cause. A re-run of #3337 with no code change went green.

## What was happening

`/docs/infrastructure/deployment-targets/kubernetes/kubernetes-api` is a `Redirect.astro` stub. The layout copies its frontmatter target into a meta refresh, and that is what ships in `dist`:

```
dist/docs/infrastructure/deployment-targets/kubernetes/kubernetes-api/index.html
  content="0; URL=https://octopus.com/docs/kubernetes/targets/kubernetes-api"
```

The browser followed it, left `localhost:3000`, and checked the anchor on the real octopus.com. So those two tests depended on the public internet.

It shows in the timings: on `main` they took 1.6s and 925ms against ~200ms for their neighbours — real network round trips. On the failing run they hit the 5s timeout three times each inside one ~30 second window.

## The fix

Route `octopus.com/docs` back to the local origin. This is the same host-to-local mapping `redirect.spec.ts:24` already applies:

```js
url = redirectMatches[1].replace('https://octopus.com/', '/');
```

Done as a `route.fulfill` 302 rather than `route.continue({ url })`, because continue requires the protocol to match and the local server is `http`.

Scoped to `/docs` deliberately. The app is proxied under that prefix only (see the comment in `astro.config.mjs`) and `pruneDist` strips the rest. Eight stubs point at `/devops` pages this build does not contain, so those have to keep their absolute URL rather than be rewritten to a local path that would 404. No bookmark traverses one today; the narrow pattern keeps it that way if one is added.

I kept the two bookmark entries pointing at the old paths. The file's header comment says the list mirrors short.io links, so rewriting them to `/docs/kubernetes/targets/kubernetes-api` would delete the thing the test guards. This keeps the whole chain under test — old bookmark, stub, meta refresh, anchor exists — with the destination served from `dist`.

Each test now also asserts it settled on the local origin. Worth having, because a passing test proved nothing before: production serves those anchors too, so the assertion succeeded either way.

The net effect is a **stricter** test than the one it replaces. If an anchor is deleted from the local page, or a stub points at a path missing from the build, this now fails. Both cases previously passed by checking production.

## Testing

`tests/bookmark.spec.ts`: **78 passed** (20.8s).

To confirm the interception is what does the work, I gated the route behind an env var and re-ran the two affected tests. Both landed on `https://octopus.com` and the new assertion caught it:

```
Expected: "http://[::1]:3000"
Received: "https://octopus.com"
```

`toBeVisible()` still passed in that run, which confirms these two were previously green only because production happened to serve the anchors.

## On the absolute redirect targets

1394 of the 1397 redirect stubs name an absolute `https://octopus.com` target. In production that is redundant rather than wrong — the app is served at `octopus.com/docs/*`, so an absolute target and a relative one resolve to the same place. The difference only shows on a host that isn't octopus.com, which is why this test was reaching production, and why the fix belongs in the test rather than in `Redirect.astro`.

The one consequence worth knowing: a redirect cannot be verified on an ephemeral deploy, because the stub sends you to production. Whether that is worth changing the built output of 1389 pages is a #website-requests call. I am not proposing it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
