### PR TITLE
Return to the page you were on after signing in

### DIFF
--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -2,6 +2,7 @@
 import Logo from '../assets/octopus-logo-v2.svg';
 import Avatar from './Avatar.astro';
 import Button from './Button.astro';
+import { SITE } from '../config';
 
 type Props = {
   links?: { label: string; href: string }[];
@@ -20,6 +21,8 @@ const pathname = Astro.url.pathname.replace(/\/+$/, '') || '/';
 const currentLabel = links
   .filter(({ href }) => pathname === href || pathname.startsWith(`${href}/`))
   .sort((a, b) => b.href.length - a.href.length)[0]?.label;
+
+const signInHref = `${SITE.url}/signin?ReturnUrl=${encodeURIComponent(Astro.url.pathname)}`;
 ---
 
 <header class="top-nav">
@@ -58,11 +61,7 @@ const currentLabel = links
     />
     <!-- TODO: Make this a real link -->
     <Button label="Changelog" href="#" />
-    <Button
-      label="Sign in"
-      href="https://octopus.com/signin"
-      data-signed-out-only
-    />
+    <Button label="Sign in" href={signInHref} data-signed-out-only />
     <Button
       label="Start for free"
       href="https://octopus.com/free-signup"


### PR DESCRIPTION
octopus.com/signin will take you to the billing page by default. With this change users will be returned back to wherever they just were in the docs after signing in.