### PR TITLE
Add an Open in Claude split button to the page actions

### DIFF
--- a/src/components/OpenInLlm.astro
+++ b/src/components/OpenInLlm.astro
@@ -1,0 +1,90 @@
+---
+import { SITE } from '@config';
+import { Lang, Translations } from '@util/Languages';
+import { getPageMarkdownPath } from '@util/mdxContent';
+import SplitButton from './SplitButton.astro';
+
+type Props = {
+  lang: string;
+};
+const { lang } = Astro.props satisfies Props;
+
+const _ = Lang(lang);
+
+const pageMdUrl = getPageMarkdownPath(Astro.url.pathname);
+
+// The assistant fetches the page itself, so the prompt carries an absolute URL
+// rather than the site-relative one the rest of the site links with.
+const prompt = pageMdUrl
+  ? _(Translations.octopus_open_in_llm.prompt).replace(
+      '{url}',
+      new URL(pageMdUrl, SITE.url).href
+    )
+  : '';
+
+const assistants = [
+  {
+    label: _(Translations.octopus_open_in_llm.open_in_claude),
+    href: 'https://claude.ai/new?q=' + encodeURIComponent(prompt),
+    icon: 'octo-llm__icon octo-llm__icon--claude',
+    iconEnd: 'octo-llm__icon octo-llm__icon--external',
+  },
+  {
+    label: _(Translations.octopus_open_in_llm.open_in_chatgpt),
+    href: 'https://chatgpt.com/?hints=search&q=' + encodeURIComponent(prompt),
+    icon: 'octo-llm__icon octo-llm__icon--chatgpt',
+    iconEnd: 'octo-llm__icon octo-llm__icon--external',
+  },
+];
+
+const [primary] = assistants;
+---
+
+{
+  pageMdUrl && (
+    <SplitButton
+      class="octo-llm"
+      label={primary.label}
+      href={primary.href}
+      icon={primary.icon}
+      size="small"
+      items={assistants}
+      menuLabel={_(Translations.octopus_open_in_llm.more_assistants)}
+      target="_blank"
+      rel="noopener"
+    />
+  )
+}
+
+<style>
+  /* `:global()` crosses into SplitButton's scope, which renders every element
+     these land on; the `.octo-llm` prefix keeps them contained. */
+  .octo-llm :global(.octo-llm__icon) {
+    background-color: currentColor;
+  }
+
+  /* The exported glyphs sit inside a box 25% wider than themselves, so the mask
+     is sized rather than left to fill. */
+  .octo-llm :global(.btn .octo-llm__icon) {
+    --octo-llm-glyph-size: 1rem;
+  }
+
+  .octo-llm :global(.split-btn__option-icon) {
+    --octo-llm-glyph-size: 0.8rem;
+  }
+
+  .octo-llm :global(.octo-llm__icon--claude) {
+    mask: url('../assets/icons/claude.svg') center / var(--octo-llm-glyph-size)
+      no-repeat;
+  }
+
+  .octo-llm :global(.octo-llm__icon--chatgpt) {
+    mask: url('../assets/icons/chatgpt.svg') center / var(--octo-llm-glyph-size)
+      no-repeat;
+  }
+
+  .octo-llm :global(.octo-llm__icon--external) {
+    mask: url('../assets/icons/external-link.svg') center /
+      var(--octo-llm-glyph-size) no-repeat;
+  }
+</style>

--- a/src/data/language.json
+++ b/src/data/language.json
@@ -75,6 +75,20 @@
             "en": "Copy failed"
         }
     },
+    "octopus_open_in_llm": {
+        "open_in_claude": {
+            "en": "Open in Claude"
+        },
+        "open_in_chatgpt": {
+            "en": "Open in ChatGPT"
+        },
+        "more_assistants": {
+            "en": "Open in another AI assistant"
+        },
+        "prompt": {
+            "en": "Read {url} so I can ask questions about it."
+        }
+    },
     "post": {
         "written_by": {
             "en": ""

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -23,6 +23,7 @@ import ArticleJourney from '../components/ArticleJourney.astro';
 import EditOnGithub from '../components/EditOnGithub.astro';
 import CopyAsMarkdown from '../components/CopyAsMarkdown.astro';
 import MarkdownLinks from '../components/MarkdownLinks.astro';
+import OpenInLlm from '../components/OpenInLlm.astro';
 import Plausible from 'src/components/Plausible.astro';
 import Footer from 'src/components/Footer.astro';
 
@@ -85,6 +86,7 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
           <ArticleHeader lang={lang} subtitle={subtitle} title={title} />
           <div class="page-actions">
             <CopyAsMarkdown lang={lang} />
+            <OpenInLlm lang={lang} />
             <EditOnGithub
               frontmatter={frontmatter}
               headings={headings}

--- a/tests/open-in-llm.spec.ts
+++ b/tests/open-in-llm.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import type { Locator } from '@playwright/test';
+
+// Runs against `astro preview` (built `dist/`), because the `.md` companion the
+// button points at is written by the build-time integration.
+
+const STABLE_PLAIN_MD_PATH = '/docs/argo-cd';
+const STABLE_MDX_PATH = '/docs/kubernetes';
+
+// The menu scales as it opens, so a box measured before that finishes is the
+// box part way through the animation rather than the one being asserted on.
+async function opened(options: Locator) {
+  await expect(options).toBeVisible();
+  await options.evaluate((el) =>
+    Promise.all(el.getAnimations().map((animation) => animation.finished))
+  );
+}
+
+test('every assistant is handed a working .md URL', async ({
+  page,
+  request,
+}) => {
+  await page.goto(STABLE_PLAIN_MD_PATH);
+
+  const links = await page
+    .locator('.octo-llm a[href]')
+    .evaluateAll((all) => all.map((l) => (l as HTMLAnchorElement).href));
+
+  expect(
+    links.length,
+    'expected the primary button plus two menu options'
+  ).toBe(3);
+
+  // Each assistant carries the page URL inside its own prompt parameter, so the
+  // parameter name varies but the URL it wraps must not.
+  const mdUrls = new Set(
+    links.map((href) => {
+      const params = new URL(href).searchParams;
+      const prompt = params.get('q') ?? params.get('prompt') ?? '';
+      return prompt.match(/https?:\/\/\S+\.md/)?.[0] ?? '';
+    })
+  );
+  expect(mdUrls.size, 'every assistant should be pointed at one .md URL').toBe(
+    1
+  );
+
+  const mdUrl = [...mdUrls][0];
+  expect(mdUrl).toContain(STABLE_PLAIN_MD_PATH + '.md');
+
+  // The prompt URL is absolute to production; test it against the preview host.
+  const target = await request.get(mdUrl.replace(/^https?:\/\/[^/]+/, ''));
+  expect(target.status()).toBe(200);
+});
+
+test('the button is absent on a page with no .md companion', async ({
+  page,
+}) => {
+  await page.goto(STABLE_MDX_PATH);
+  const count = await page.locator('.octo-llm').count();
+  expect(count, 'expected no Open in Claude button on ineligible page').toBe(0);
+});
+
+// Where the menu is actually crowded: 700 puts the control at the end of a
+// single row, 430 wraps it onto its own line at the start. The menu is wider
+// than the control, so those two need it to open towards opposite sides.
+for (const width of [700, 430]) {
+  test(`the menu opens on screen at ${width}px wide`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 800 });
+    await page.goto(STABLE_PLAIN_MD_PATH);
+    await page.locator('.octo-llm [data-split-trigger]').click();
+
+    const menu = page.locator('.octo-llm .split-btn__options');
+    await opened(menu);
+
+    const box = (await menu.boundingBox())!;
+    const viewport = await page.evaluate(() => ({
+      client: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }));
+
+    expect(
+      Math.round(box.x),
+      'menu should not run off the start edge'
+    ).toBeGreaterThanOrEqual(0);
+    expect(
+      Math.round(box.x + box.width),
+      'menu should not run off the end edge'
+    ).toBeLessThanOrEqual(viewport.client);
+    expect(
+      viewport.scroll,
+      'an open menu should not force a horizontal scrollbar'
+    ).toBeLessThanOrEqual(viewport.client);
+  });
+}


### PR DESCRIPTION
Adds an **Open in Claude** split button to the page actions row, between Copy as markdown and Edit on GitHub, per the Figma ordering.

Implements the [Open in LLM](https://www.figma.com/design/DTvlouW1QArI3ZTf1PXs4J/Documentation-vision?node-id=1561-20228&m=dev) design, using the `SplitButton` component from #3340.

Replaces #3330, which carried stack metadata from when it was based on `wl/split-button`. Same branch, same commit, no content change.

The primary half opens Claude with a prompt pointing at the page's `.md` URL. The caret opens a menu with Open in Claude and Open in ChatGPT, as link-styled rows with a provider logo and an external-link icon. The prompt carries an absolute URL, because the assistant fetches the page itself rather than following a link from this site.

Gemini is deliberately absent: `gemini.google.com` ignores prompt parameters, so the entry could only prefill by pointing at AI Studio, which is not where "Open in Gemini" says it is going.

Four files, additions only — the component, its strings, one line in the layout, and its tests. The icons and `getPageMarkdownPath()` both come from what has already landed.

Carried over from #3330: the per-component icon masks here would be better as a global `icons.css`, deliberately left for a follow-up.

## Testing

Clean `astro build`, 2674 pages, 1253 `.md` emitted. 36 passed across `open-in-llm`, `split-button`, `copy-button` and `llm-endpoints`. Playwright is not wired into CI, so that is a local run.

The positioning tests wait for the menu's open animation to settle, the same way `split-button.spec.ts` does — measured mid-animation the icon box reads 12x9 rather than the 16x16 it lands on.

Measured where the menu ends up, to confirm those tests hold something down:

| viewport | menu | opens towards |
|---|---|---|
| 1200 | 641–834 | start edge |
| 700 | 321–514 | start edge |
| 430 | 159–353 | **flips to the end edge** |

430 is where the row wraps and the fallback fires, which is the case `split-button.spec.ts` could not reach on its own: the component gallery gives the control room on both sides at every width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
