### PR TITLE
Add profile menu to the top nav (when logged in)

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -1,0 +1,354 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+
+type ItemData = Record<string, string | undefined>;
+
+export type MenuAction = {
+  // link gets visibly decorated with color/underline, action remains as plain text
+  kind?: 'action' | 'link';
+  label: string;
+  description?: string;
+  href?: string | URL;
+  icon?: string; // URL to an SVG, or a class name, as Button takes
+  iconEnd?: string;
+  target?: string;
+  rel?: string;
+  data?: ItemData;
+};
+
+export type MenuDetail = {
+  kind: 'detail';
+  label: string;
+  description?: string;
+  data?: ItemData;
+};
+
+export type MenuDivider = { kind: 'divider' };
+
+export type MenuItem = MenuAction | MenuDetail | MenuDivider;
+
+type Props = HTMLAttributes<'details'> & {
+  label: string; // accessible name for the list, which has no heading
+  items: MenuItem[];
+  align?: 'start' | 'end';
+  density?: 'default' | 'compact';
+  width?: string;
+};
+
+const {
+  label,
+  items,
+  align = 'start',
+  density = 'default',
+  width,
+  class: className,
+  ...rest
+} = Astro.props satisfies Props;
+
+if (items.length === 0) {
+  throw new Error('A Menu needs at least one item');
+}
+
+if (!Astro.slots.has('trigger')) {
+  throw new Error('A Menu needs a <summary> in its trigger slot to open it');
+}
+
+// An asset import carries a query in dev (`...svg?origWidth=16`) and none in a
+// build, so the extension is matched where it sits rather than at the end.
+const isSvgUrl = (name: string) => /\.svg(\?|#|$)/.test(name);
+
+const iconDetails = (name: string | undefined) => {
+  if (!name) return null;
+  return isSvgUrl(name)
+    ? {
+        tag: 'img' as const,
+        props: { src: name, alt: '', class: 'menu__icon' },
+      }
+    : { tag: 'span' as const, props: { class: `${name} menu__icon` } };
+};
+---
+
+<details
+  class:list={[
+    'menu',
+    `menu--${align}`,
+    density === 'compact' && 'menu--compact',
+    className,
+  ]}
+  style={width ? `--menu-width: ${width}` : undefined}
+  data-menu
+  {...rest}
+>
+  <slot name="trigger" />
+  <ul class="menu__list" role="menu" aria-label={label}>
+    {
+      items.map((item) => {
+        if (item.kind === 'divider') {
+          return <li class="menu__divider" role="separator" />;
+        }
+
+        if (item.kind === 'detail') {
+          return (
+            <li
+              class="menu__item menu__item--detail"
+              role="presentation"
+              {...item.data}
+            >
+              <span class="menu__label" data-menu-label>
+                {item.label}
+              </span>
+              {item.description !== undefined && (
+                <span class="menu__description" data-menu-description>
+                  {item.description}
+                </span>
+              )}
+            </li>
+          );
+        }
+
+        const leading = iconDetails(item.icon);
+        const trailing = iconDetails(item.iconEnd);
+        const Leading = leading?.tag;
+        const Trailing = trailing?.tag;
+
+        const Action = item.href ? 'a' : 'button';
+        const actionProps = item.href
+          ? { href: item.href, target: item.target, rel: item.rel }
+          : { type: 'button' as const };
+        const actionClass = `menu__item menu__action${item.kind === 'link' ? ' menu__action--link' : ''}`;
+
+        return (
+          // The list is the menu, so the items between it and the actions are
+          // not part of that structure; `menuitem` goes on the action so it is
+          // the thing announced and the thing arrow keys move between.
+          <li role="none">
+            <Action
+              class={actionClass}
+              role="menuitem"
+              tabindex="-1"
+              {...actionProps}
+              {...item.data}
+            >
+              {Leading && <Leading {...leading!.props} aria-hidden="true" />}
+              <span class="menu__labels">
+                <span class="menu__label" data-menu-label>
+                  {item.label}
+                </span>
+                {item.description !== undefined && (
+                  <span class="menu__description" data-menu-description>
+                    {item.description}
+                  </span>
+                )}
+              </span>
+              {Trailing && <Trailing {...trailing!.props} aria-hidden="true" />}
+            </Action>
+          </li>
+        );
+      })
+    }
+  </ul>
+</details>
+
+<script>
+  import '../scripts/menu';
+</script>
+
+<style>
+  .menu {
+    position: relative;
+    /* The easing the design system's menu animates on. */
+    --menu-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .menu__list {
+    position: absolute;
+    z-index: 10;
+    inset-block-start: calc(100% + var(--space4));
+    inset-inline-start: 0;
+    box-sizing: border-box;
+    /* Sized by its content unless a width is specified, with a floor of the
+       184px its items hold themselves to so a short list still reads as a menu,
+       and a ceiling so a long label wraps rather than running the list off the
+       side of the page. */
+    width: var(--menu-width, max-content);
+    min-width: var(--menu-min-width, 11.5rem);
+    max-width: var(--menu-max-width, 20rem);
+    margin: 0;
+    padding: var(--space8) 0;
+    list-style: none;
+    background: var(--colorMenuListBackgroundDefault);
+    border-radius: var(--borderRadiusSmall);
+    box-shadow: var(--shadowMedium);
+    opacity: 0;
+    transform: scale(0.75, 0.5625);
+    transform-origin: top left;
+    transition:
+      opacity var(--duration-default) var(--menu-easing),
+      transform calc(var(--duration-default) * 0.66) var(--menu-easing);
+  }
+
+  .menu--end .menu__list {
+    inset-inline-start: auto;
+    inset-inline-end: 0;
+    transform-origin: top right;
+  }
+
+  .menu[open] .menu__list {
+    opacity: 1;
+    transform: none;
+  }
+
+  /* A closed disclosure skips its contents, so the list has no rendered state
+     for the opening transition to start from until it is given one. */
+  @starting-style {
+    .menu[open] .menu__list {
+      opacity: 0;
+      transform: scale(0.75, 0.5625);
+    }
+  }
+
+  /* The menu this is modelled on grows in rather than arriving. Measured on its
+     own story, it fades while a shorter transform runs from three quarters of
+     the width and the square of that in height, out of the corner the list
+     hangs off. The disclosure keeps its content on screen for the length of
+     that so the closing half has something left to animate; the transform goes
+     on the list rather than the disclosure because a transformed ancestor would
+     become the containing block the anchored position is measured against. */
+  .menu:not([open])::details-content {
+    transition: content-visibility var(--duration-default) allow-discrete;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .menu__list,
+    .menu:not([open])::details-content {
+      transition: none;
+    }
+  }
+
+  /* Let the browser pick which direction the menu will fit */
+  @supports (anchor-scope: --a) {
+    .menu {
+      anchor-name: --menu;
+      /* An anchor name is page-wide, so a second menu would leave every list on
+         the page hanging off the last one. `anchor-scope` keeps each name inside
+         the menu that declares it. The block is guarded on `anchor-scope` rather
+         than `anchor-name` so a browser with anchors but no scoping takes the
+         absolute rules above, which measure from each list's own parent. */
+      anchor-scope: --menu;
+    }
+
+    /* Fixed so the viewport is what the browser measures the room against; the
+       anchor keeps it tracking the control through a scroll. */
+    .menu__list {
+      position: fixed;
+      position-anchor: --menu;
+      position-area: block-end span-inline-end;
+      position-try-fallbacks: flip-inline;
+      /* Fixed to the viewport, the list would otherwise hold its place while the
+         control it belongs to scrolls away, leaving it stranded over whatever
+         the page has scrolled to. */
+      position-visibility: anchors-visible;
+      inset: auto;
+      margin-block-start: var(--space4);
+    }
+
+    .menu--end .menu__list {
+      position-area: block-end span-inline-start;
+    }
+  }
+
+  .menu__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space4);
+    /* The page has no universal border-box rule, so the padding would otherwise
+       sit outside a row measured by its content. */
+    box-sizing: border-box;
+    min-height: 3rem;
+    padding: var(--space6) var(--space16);
+    color: var(--colorTextPrimary);
+    font: var(--textBodyRegularLarge);
+    /* Long labels wrap rather than widening the list past the width it is given. */
+    overflow-wrap: anywhere;
+  }
+
+  /* The compact MenuItem: no floor under the row, so it stands at its padding
+     and a line of text. */
+  .menu--compact .menu__item {
+    min-height: 0;
+  }
+
+  .menu__item--detail {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+  }
+
+  .menu__labels {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .menu__description {
+    color: var(--colorTextSecondary);
+    font: var(--textBodyRegularSmall);
+  }
+
+  .menu__action {
+    width: 100%;
+    border: 0;
+    background: none;
+    color: var(--colorTextPrimary);
+    text-align: start;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .menu__action--link {
+    color: var(--colorTextLinkDefault);
+  }
+
+  .menu__action--link .menu__label {
+    text-decoration: underline;
+  }
+
+  /* The MenuItem takes the primary text color under the pointer, leaving the
+     link color to say the row is a link when it is at rest. */
+  .menu__action:hover {
+    background: var(--colorMenuListBackgroundHover);
+    color: var(--colorTextPrimary);
+  }
+
+  .menu__action:focus-visible {
+    background: var(--colorMenuListBackgroundActive);
+    color: var(--colorTextPrimary);
+  }
+
+  .menu__divider {
+    margin-block: var(--space8);
+    border-block-start: var(--borderWidth1) solid var(--colorBorderPrimary);
+  }
+
+  /* Centred and contained the way `.btn__icon` is. An icon font draws its glyph
+     on its own advance width rather than inside this box, so a wide one spills
+     over the gap and sits against the label; an SVG needs the same box to be
+     scaled into rather than laid out at its intrinsic size. */
+  .menu__icon {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    font-size: var(--fontSizeBase);
+    line-height: 1;
+    /* Inherited so the glyph turns over with the label it sits beside; the icon
+       and text link tokens carry the same value at rest. */
+    color: inherit;
+  }
+
+  img.menu__icon {
+    object-fit: contain;
+  }
+</style>

--- a/src/components/ProfileMenu.astro
+++ b/src/components/ProfileMenu.astro
@@ -1,0 +1,93 @@
+---
+import type { HTMLAttributes } from 'astro/types';
+import Avatar from './Avatar.astro';
+import Menu, { type MenuItem } from './Menu.astro';
+
+type Props = HTMLAttributes<'div'> & {
+  label?: string;
+  controlCenterHref?: string;
+  profileHref?: string;
+  signOutHref?: string;
+};
+
+const {
+  label = 'Account',
+  controlCenterHref = 'https://billing.octopus.com',
+  profileHref = 'https://id.octopus.com/profile',
+  signOutHref = 'https://octopus.com/signout',
+  class: className,
+  ...rest
+} = Astro.props satisfies Props;
+
+const leaving = {
+  kind: 'link' as const,
+  iconEnd: 'profile-menu__icon--external',
+  target: '_blank',
+  rel: 'noopener noreferrer',
+};
+
+const items: MenuItem[] = [
+  {
+    // Details start out empty, signed-in-user.ts fills things in through Menu's hooks
+    kind: 'detail',
+    label: '',
+    description: '',
+    data: { 'data-user-details': '' },
+  },
+  { label: 'Control Center', href: controlCenterHref, ...leaving },
+  { label: 'Profile', href: profileHref, ...leaving },
+  { kind: 'divider' },
+  { label: 'Sign out', href: signOutHref },
+];
+---
+
+<div class:list={['profile-menu', className]} {...rest}>
+  <Menu label={label} items={items} align="end" width="16rem">
+    <summary
+      slot="trigger"
+      class="profile-menu__trigger"
+      aria-label={label}
+      aria-haspopup="menu"
+    >
+      <Avatar size="medium" shape="circle" alt="" data-user-avatar>
+        <span data-user-initials></span>
+      </Avatar>
+    </summary>
+  </Menu>
+</div>
+
+<style>
+  .profile-menu {
+    display: flex;
+  }
+
+  .profile-menu[hidden] {
+    display: none;
+  }
+
+  .profile-menu__trigger {
+    display: flex;
+    border-radius: var(--borderRadiusCircle);
+    list-style: none;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .profile-menu__trigger::-webkit-details-marker {
+    display: none;
+  }
+
+  .profile-menu__trigger:focus-visible {
+    outline: var(--borderWidth2) solid var(--colorBorderSelected);
+    outline-offset: var(--borderWidth2);
+  }
+
+  .profile-menu__trigger:hover :global(.avatar) {
+    background: var(--colorAvatarBackgroundUserHover);
+  }
+
+  .profile-menu :global(.profile-menu__icon--external) {
+    background-color: currentColor;
+    mask: url('../assets/icons/external-link.svg') center / 80% no-repeat;
+  }
+</style>

--- a/src/components/SplitButton.astro
+++ b/src/components/SplitButton.astro
@@ -1,6 +1,7 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 import Button from './Button.astro';
+import Menu from './Menu.astro';
 
 export type SplitButtonItem = {
   label: string;
@@ -39,10 +40,12 @@ if (items.length === 0) {
   throw new Error('A SplitButton with no menu items should just be a Button');
 }
 
-// An asset import carries a query in dev (`...svg?origWidth=16`) and none in a
-// build, so the extension is matched where it sits rather than at the end.
-const iconTag = (name: string | undefined) =>
-  !name ? null : /\.svg(\?|#|$)/.test(name) ? 'img' : 'span';
+const menuItems = items.map((item) => ({
+  ...item,
+  kind: 'link' as const,
+  target,
+  rel,
+}));
 ---
 
 <div class:list={['split-btn', className]} {...rest}>
@@ -56,8 +59,14 @@ const iconTag = (name: string | undefined) =>
     target={target}
     rel={rel}
   />
-  <details class="split-btn__menu" data-split-menu>
+  <Menu
+    class="split-btn__menu"
+    label={menuLabel}
+    items={menuItems}
+    density="compact"
+  >
     <Button
+      slot="trigger"
       as="summary"
       class="split-btn__toggle"
       icon="split-btn__caret"
@@ -65,67 +74,9 @@ const iconTag = (name: string | undefined) =>
       importance={importance}
       aria-label={menuLabel}
       aria-haspopup="menu"
-      data-split-trigger
     />
-    <ul class="split-btn__options" role="menu" aria-label={menuLabel}>
-      {
-        items.map((item) => {
-          const Leading = iconTag(item.icon);
-          const Trailing = iconTag(item.iconEnd);
-          return (
-            // The list is the menu, so the items between it and the actions are
-            // not part of that structure; `menuitem` goes on the link so it is
-            // the thing announced and the thing arrow keys move between.
-            <li role="none">
-              <a
-                class="split-btn__option"
-                role="menuitem"
-                tabindex="-1"
-                href={item.href}
-                target={target}
-                rel={rel}
-              >
-                {Leading &&
-                  (Leading === 'img' ? (
-                    <img
-                      src={item.icon}
-                      alt=""
-                      class="split-btn__option-icon"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <span
-                      class={`${item.icon} split-btn__option-icon`}
-                      aria-hidden="true"
-                    />
-                  ))}
-                <span class="split-btn__option-label">{item.label}</span>
-                {Trailing &&
-                  (Trailing === 'img' ? (
-                    <img
-                      src={item.iconEnd}
-                      alt=""
-                      class="split-btn__option-icon"
-                      aria-hidden="true"
-                    />
-                  ) : (
-                    <span
-                      class={`${item.iconEnd} split-btn__option-icon`}
-                      aria-hidden="true"
-                    />
-                  ))}
-              </a>
-            </li>
-          );
-        })
-      }
-    </ul>
-  </details>
+  </Menu>
 </div>
-
-<script>
-  import '../scripts/split-button';
-</script>
 
 <style>
   .split-btn {
@@ -139,16 +90,10 @@ const iconTag = (name: string | undefined) =>
   /* Both halves keep the border `.btn` gives them so nothing clips their focus
      rings; the negative margin collapses the touching pair into the single
      divider the design asks for. */
-  .split-btn__menu {
-    position: relative;
+  .split-btn :global(.split-btn__menu) {
     margin-inline-start: calc(var(--borderWidth1) * -1);
-    /* The easing the design system's menu animates on. */
-    --split-btn-menu-easing: cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  /* Both halves are Buttons, so this markup belongs to Button's scope and
-     `:global()` is Astro's documented way into it; the `.split-btn` prefix keeps
-     the reach contained. */
   .split-btn :global(.split-btn__primary) {
     border-start-end-radius: 0;
     border-end-end-radius: 0;
@@ -174,160 +119,13 @@ const iconTag = (name: string | undefined) =>
      half they overlap. */
   .split-btn :global(.split-btn__primary:hover),
   .split-btn :global(.split-btn__primary:focus-visible),
-  .split-btn__menu:has(:hover),
-  .split-btn__menu:has(:focus-visible),
-  .split-btn__menu[open] {
+  .split-btn :global(.split-btn__menu:has(:hover)),
+  .split-btn :global(.split-btn__menu:has(:focus-visible)),
+  .split-btn :global(.split-btn__menu[open]) {
     z-index: 1;
   }
 
-  .split-btn__menu[open] > :global(.split-btn__toggle) {
+  .split-btn :global(.split-btn__menu[open] > .split-btn__toggle) {
     background: var(--colorBackgroundPrimaryPressed);
-  }
-
-  .split-btn__options {
-    position: absolute;
-    z-index: 10;
-    inset-block-start: calc(100% + var(--space4));
-    inset-inline-start: 0;
-    box-sizing: border-box;
-    /* Sized by its content, as the design system's menu is, with a floor of the
-       184px its items hold themselves to so a short list still reads as a menu,
-       and a ceiling so a long label wraps rather than running the list off the
-       side of the page. */
-    width: max-content;
-    min-width: var(--split-btn-menu-min-width, 11.5rem);
-    max-width: var(--split-btn-menu-max-width, 20rem);
-    margin: 0;
-    padding: var(--space8) 0;
-    list-style: none;
-    background: var(--colorMenuListBackgroundDefault);
-    border-radius: var(--borderRadiusSmall);
-    box-shadow: var(--shadowMedium);
-    opacity: 0;
-    transform: scale(0.75, 0.5625);
-    transform-origin: top left;
-    transition:
-      opacity var(--duration-default) var(--split-btn-menu-easing),
-      transform calc(var(--duration-default) * 0.66)
-        var(--split-btn-menu-easing);
-  }
-
-  .split-btn__menu[open] .split-btn__options {
-    opacity: 1;
-    transform: none;
-  }
-
-  /* A closed disclosure skips its contents, so the list has no rendered state
-     for the opening transition to start from until it is given one. */
-  @starting-style {
-    .split-btn__menu[open] .split-btn__options {
-      opacity: 0;
-      transform: scale(0.75, 0.5625);
-    }
-  }
-
-  /* The menu this is modelled on grows in rather than arriving. Measured on its
-     own story, it fades while a shorter transform runs from three quarters of
-     the width and the square of that in height, out of the corner the list
-     hangs off. The disclosure keeps its content on screen for the length of
-     that so the closing half has something left to animate; the transform goes
-     on the list rather than the disclosure because a transformed ancestor would
-     become the containing block the anchored position is measured against. */
-  .split-btn__menu::details-content {
-    transition: content-visibility var(--duration-default) allow-discrete;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .split-btn__options,
-    .split-btn__menu::details-content {
-      transition: none;
-    }
-  }
-
-  /* The design hangs the list from the menu half and lets it run past the end of
-     the control, which the page has room for wherever the control sits. Anchored
-     so a viewport too narrow for that can still flip it to the other side, which
-     a width breakpoint cannot judge. */
-  @supports (anchor-scope: --a) {
-    .split-btn__menu {
-      anchor-name: --split-btn;
-      /* An anchor name is page-wide, so a second split button would leave every
-         menu on the page hanging off the last one. `anchor-scope` keeps each
-         name inside the half that declares it. The block is guarded on
-         `anchor-scope` rather than `anchor-name` so a browser with anchors but
-         no scoping keeps the absolute rule above, which measures from each
-         menu's own parent. */
-      anchor-scope: --split-btn;
-    }
-
-    /* Fixed so the viewport is what the browser measures the room against; the
-       anchor keeps it tracking the button through a scroll. */
-    .split-btn__options {
-      position: fixed;
-      position-anchor: --split-btn;
-      position-area: block-end span-inline-end;
-      position-try-fallbacks: flip-inline;
-      /* Fixed to the viewport, the list would otherwise hold its place while the
-         button it belongs to scrolls away, leaving it stranded over whatever the
-         page has scrolled to. */
-      position-visibility: anchors-visible;
-      inset: auto;
-      margin-block-start: var(--space4);
-    }
-  }
-
-  .split-btn__option {
-    display: flex;
-    align-items: center;
-    gap: var(--space4);
-    /* The page has no universal border-box rule, so the padding would otherwise
-       sit outside a row measured by its content. */
-    box-sizing: border-box;
-    /* The compact MenuItem, which is the one the design settled on: no floor
-       under the row, so it stands at its padding and a line of text. The roomier
-       one holds itself open to 48px. */
-    padding: var(--space6) var(--space16);
-    color: var(--colorTextLinkDefault);
-    font: var(--textBodyRegularLarge);
-    /* Long labels wrap rather than widening the list past the width it is given. */
-    overflow-wrap: anywhere;
-  }
-
-  /* The MenuItem takes the primary text color under the pointer, leaving the
-     link color to say the row is a link when it is at rest. */
-  .split-btn__option:hover {
-    background: var(--colorMenuListBackgroundHover);
-    color: var(--colorTextPrimary);
-  }
-
-  .split-btn__option:focus-visible {
-    background: var(--colorMenuListBackgroundActive);
-    color: var(--colorTextPrimary);
-  }
-
-  /* Centred and contained the way `.btn__icon` is. An icon font draws its glyph
-     on its own advance width rather than inside this box, so a wide one spills
-     over the gap and sits against the label; an SVG needs the same box to be
-     scaled into rather than laid out at its intrinsic size. */
-  .split-btn__option-icon {
-    display: inline-flex;
-    flex-shrink: 0;
-    align-items: center;
-    justify-content: center;
-    width: 1rem;
-    height: 1rem;
-    font-size: var(--fontSizeBase);
-    line-height: 1;
-    /* Inherited so the glyph turns over with the label it sits beside; the icon
-       and text link tokens carry the same value at rest. */
-    color: inherit;
-  }
-
-  img.split-btn__option-icon {
-    object-fit: contain;
-  }
-
-  .split-btn__option-label {
-    text-decoration: underline;
   }
 </style>

--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -1,7 +1,7 @@
 ---
 import Logo from '../assets/octopus-logo-v2.svg';
-import Avatar from './Avatar.astro';
 import Button from './Button.astro';
+import ProfileMenu from './ProfileMenu.astro';
 import { SITE } from '../config';
 
 type Props = {
@@ -68,16 +68,7 @@ const signInHref = `${SITE.url}/signin?ReturnUrl=${encodeURIComponent(Astro.url.
       importance="loud"
       data-signed-out-only
     />
-    <Avatar
-      size="medium"
-      shape="circle"
-      alt=""
-      data-signed-in-only
-      data-user-avatar
-      hidden
-    >
-      <span data-user-initials></span>
-    </Avatar>
+    <ProfileMenu data-signed-in-only hidden />
   </div>
 </header>
 

--- a/src/scripts/menu.ts
+++ b/src/scripts/menu.ts
@@ -1,0 +1,90 @@
+const MENU_SELECTOR = '[data-menu]';
+const ITEM_SELECTOR = '[role="menuitem"]';
+
+function openMenus() {
+  return document.querySelectorAll<HTMLDetailsElement>(
+    `${MENU_SELECTOR}[open]`
+  );
+}
+
+function triggerOf(menu: HTMLDetailsElement) {
+  return menu.querySelector<HTMLElement>(':scope > summary');
+}
+
+document.addEventListener('click', (event) => {
+  const target = event.target;
+
+  openMenus().forEach((menu) => {
+    if (target instanceof Node && menu.contains(target)) return;
+    menu.open = false;
+  });
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+
+  openMenus().forEach((menu) => {
+    // Hand focus back only when it was inside the menu being closed
+    const menuHadFocus = menu.contains(document.activeElement);
+    menu.open = false;
+    if (menuHadFocus) triggerOf(menu)?.focus();
+  });
+});
+
+document.addEventListener('keydown', (event) => {
+  const steps: Record<string, (last: number, at: number) => number> = {
+    ArrowDown: (last, at) => (at >= last ? 0 : at + 1),
+    ArrowUp: (last, at) => (at <= 0 ? last : at - 1),
+    Home: () => 0,
+    End: (last) => last,
+  };
+
+  const step = steps[event.key];
+  if (!step || !(event.target instanceof Element)) return;
+
+  const menu = event.target.closest<HTMLDetailsElement>(MENU_SELECTOR);
+  if (!menu) return;
+
+  const items = [...menu.querySelectorAll<HTMLElement>(ITEM_SELECTOR)];
+  if (items.length === 0) return;
+
+  // Down off the trigger opens the menu on its first item
+  event.preventDefault();
+  menu.open = true;
+
+  const at = items.indexOf(document.activeElement as HTMLElement);
+  const from = at === -1 && event.key === 'ArrowUp' ? 0 : at;
+  const target = items[step(items.length - 1, from)];
+
+  // The open is applied immediately, but the list only becomes focusable once it has been drawn
+  // one frame later
+  target.focus({ preventScroll: true });
+  if (document.activeElement !== target) {
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => target.focus({ preventScroll: true }))
+    );
+  }
+});
+
+// Hide the menu when scrolling
+['wheel', 'touchmove'].forEach((gesture) => {
+  window.addEventListener(
+    gesture,
+    () => {
+      openMenus().forEach((menu) => {
+        menu.open = false;
+      });
+    },
+    { passive: true }
+  );
+});
+
+document.addEventListener('focusout', (event) => {
+  const next = event.relatedTarget;
+
+  openMenus().forEach((menu) => {
+    if (!(event.target instanceof Node) || !menu.contains(event.target)) return;
+    if (next === null || (next instanceof Node && menu.contains(next))) return;
+    menu.open = false;
+  });
+});

--- a/src/scripts/signed-in-user.ts
+++ b/src/scripts/signed-in-user.ts
@@ -15,6 +15,9 @@ const SIGNED_OUT_ONLY_SELECTOR = '[data-signed-out-only]';
 const SIGNED_IN_ONLY_SELECTOR = '[data-signed-in-only]';
 const USER_AVATAR_SELECTOR = '[data-user-avatar]';
 const USER_INITIALS_SELECTOR = '[data-user-initials]';
+const USER_DETAILS_SELECTOR = '[data-user-details]';
+const MENU_LABEL_SELECTOR = '[data-menu-label]';
+const MENU_DESCRIPTION_SELECTOR = '[data-menu-description]';
 
 function displayName(user: SignedInUser): string {
   return user.fullName?.trim() || user.email?.trim() || '';
@@ -40,6 +43,26 @@ function apply() {
   if (user) {
     const name = displayName(user);
     const imageUrl = safeImageUrl(user.profileImageUrl);
+
+    const emailTrimmed = user.email?.trim() ?? '';
+    document
+      .querySelectorAll<HTMLElement>(USER_DETAILS_SELECTOR)
+      .forEach((row) => {
+        const nameTarget = row.querySelector<HTMLElement>(MENU_LABEL_SELECTOR);
+        const emailTarget = row.querySelector<HTMLElement>(
+          MENU_DESCRIPTION_SELECTOR
+        );
+
+        if (nameTarget) nameTarget.textContent = name;
+
+        // As displayName falls back to the email when there is no name, drop the second line in
+        // that scenario rather than repeating the email.
+        if (emailTarget) {
+          const shouldHideEmail = !emailTrimmed || emailTrimmed === name;
+          emailTarget.textContent = shouldHideEmail ? '' : emailTrimmed;
+          emailTarget.hidden = shouldHideEmail;
+        }
+      });
 
     document
       .querySelectorAll<HTMLElement>(USER_AVATAR_SELECTOR)

--- a/tests/profile-menu.spec.ts
+++ b/tests/profile-menu.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const showcase = '/components';
+
+const profile = '.top-nav-showcase .top-nav .profile-menu';
+const trigger = `${profile} summary`;
+const list = `${profile} .menu__list`;
+
+async function signIn(
+  page: Page,
+  baseURL: string | undefined,
+  user: Record<string, string>
+) {
+  await page.context().addCookies([
+    {
+      name: 'OctopusSignedInUser',
+      value: encodeURIComponent(JSON.stringify(user)),
+      url: new URL(showcase, baseURL).toString(),
+    },
+  ]);
+}
+
+async function signedIn(page: Page, baseURL: string | undefined) {
+  await signIn(page, baseURL, {
+    fullName: 'John Doe',
+    email: 'jd@example.com',
+  });
+  await page.goto(showcase);
+}
+
+test('there is no profile menu until someone is signed in', async ({
+  page,
+}) => {
+  await page.goto(showcase);
+
+  await expect(page.locator(profile)).toBeHidden();
+});
+
+test('the avatar opens the menu', async ({
+  page,
+  baseURL,
+}) => {
+  await signedIn(page, baseURL);
+
+  await expect(page.locator(list)).toBeHidden();
+
+  await page.locator(trigger).click();
+
+  const menu = page.locator(list);
+  await expect(menu).toBeVisible();
+
+  await expect(menu.locator('[data-user-details]')).toContainText('John Doe');
+  await expect(menu.locator('[data-user-details]')).toContainText(
+    'jd@example.com'
+  );
+
+  const items = menu.locator('[role="menuitem"]');
+  await expect(items).toHaveText(['Control Center', 'Profile', 'Sign out']);
+  await expect(items.nth(0)).toHaveAttribute(
+    'href',
+    'https://billing.octopus.com'
+  );
+  await expect(items.nth(1)).toHaveAttribute(
+    'href',
+    'https://id.octopus.com/profile'
+  );
+  await expect(items.nth(2)).toHaveAttribute(
+    'href',
+    'https://octopus.com/signout'
+  );
+
+  await expect(menu.locator('[role="separator"]')).toHaveCount(1);
+});
+
+test('the external links carry the external link indicator', async ({
+  page,
+  baseURL,
+}) => {
+  await signedIn(page, baseURL);
+  await page.locator(trigger).click();
+
+  const external1 = page.locator(`${list} [role="menuitem"]`).nth(0);
+  await expect(external1.locator('.menu__icon')).toBeVisible();
+
+  const external2 = page.locator(`${list} [role="menuitem"]`).nth(1);
+  await expect(external2.locator('.menu__icon')).toBeVisible();
+
+  const signOut = page.locator(`${list} [role="menuitem"]`).nth(2);
+  await expect(signOut.locator('.menu__icon')).toHaveCount(0);
+});
+
+test('sign out is drawn as plain text rather than as a link', async ({
+  page,
+  baseURL,
+}) => {
+  await signedIn(page, baseURL);
+  await page.locator(trigger).click();
+
+  const paint = (item: number) =>
+    page
+      .locator(`${list} [role="menuitem"]`)
+      .nth(item)
+      .evaluate((el) => ({
+        color: getComputedStyle(el).color,
+        underline: getComputedStyle(el.querySelector('[data-menu-label]')!)
+          .textDecorationLine,
+      }));
+
+  const controlCenter = await paint(0);
+  expect(controlCenter.underline, 'an ordinary link row keeps its underline').toBe(
+    'underline'
+  );
+
+  const signOut = await paint(2);
+  expect(signOut.underline, 'sign out should not be underlined').toBe('none');
+  expect(signOut.color, 'sign out should not take the link color').not.toBe(
+    controlCenter.color
+  );
+});
+
+test('the avatar initials are not underlined', async ({ page, baseURL }) => {
+  await signedIn(page, baseURL);
+
+  await expect(page.locator(trigger)).toHaveCSS('text-decoration-line', 'none');
+});
+
+test('the email line is dropped when there is no name', async ({
+  page,
+  baseURL,
+}) => {
+  await signIn(page, baseURL, { email: 'jd@example.com' });
+  await page.goto(showcase);
+  await page.locator(trigger).click();
+
+  const details = page.locator(`${list} [data-user-details]`);
+
+  await expect(details.locator('[data-menu-label]')).toHaveText(
+    'jd@example.com'
+  );
+
+  // `displayName` falls back to the email when there is no name, so the email shouldn't be repeated
+  await expect(details.locator('[data-menu-description]')).toBeHidden();
+});
+
+test('the escape key closes the menu and returns focus to the avatar', async ({
+  page,
+  baseURL,
+}) => {
+  await signedIn(page, baseURL);
+
+  await page.locator(trigger).click();
+  await expect(page.locator(list)).toBeVisible();
+
+  await page.keyboard.press('Escape');
+
+  await expect(page.locator(list)).toBeHidden();
+  await expect(page.locator(trigger)).toBeFocused();
+});
+
+test('the arrow keys open the menu and move between its items', async ({
+  page,
+  baseURL,
+}) => {
+  await signedIn(page, baseURL);
+
+  const items = page.locator(`${list} [role="menuitem"]`);
+
+  await page.locator(trigger).focus();
+  await page.keyboard.press('ArrowDown');
+
+  await expect(page.locator(list)).toBeVisible();
+  await expect(items.first()).toBeFocused();
+
+  await page.keyboard.press('End');
+  await expect(items.nth(2)).toBeFocused();
+});
+
+test('the menu right edge lines up with the avatar right edge', async ({
+  page,
+  baseURL,
+}) => {
+  await signedIn(page, baseURL);
+
+  await page.locator(trigger).click();
+
+  const menu = page.locator(list);
+  await expect(menu).toBeVisible();
+  await menu.evaluate((el) =>
+    Promise.all(el.getAnimations().map((animation) => animation.finished))
+  );
+
+  const avatar = (await page.locator(trigger).boundingBox())!;
+  const box = (await menu.boundingBox())!;
+
+  expect(Math.round(box.width)).toBe(256);
+  expect(
+    Math.round(box.x + box.width - (avatar.x + avatar.width)),
+    "the menu's right edge should line up with the avatar's right edge"
+  ).toBeLessThanOrEqual(1);
+});

--- a/tests/split-button.spec.ts
+++ b/tests/split-button.spec.ts
@@ -17,21 +17,21 @@ async function opened(options: Locator) {
 test('the menu is closed until the caret is clicked', async ({ page }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
-  const options = menu.locator('.split-btn__options');
+  const menu = page.locator('.split-btn [data-menu]').first();
+  const options = menu.locator('.menu__list');
 
   await expect(options).toBeHidden();
 
-  await menu.locator('[data-split-trigger]').click();
+  await menu.locator('summary').click();
 
   await expect(options).toBeVisible();
-  await expect(options.locator('.split-btn__option')).toHaveCount(2);
+  await expect(options.locator('.menu__action')).toHaveCount(2);
 });
 
 test('the caret has an accessible name of its own', async ({ page }) => {
   await page.goto(PAGE);
 
-  const trigger = page.locator('[data-split-trigger]').first();
+  const trigger = page.locator('.split-btn summary').first();
 
   await expect(trigger).toHaveAccessibleName('Open in another assistant');
 });
@@ -41,29 +41,29 @@ test('Escape closes the menu and returns focus to the caret', async ({
 }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
-  const trigger = menu.locator('[data-split-trigger]');
+  const menu = page.locator('.split-btn [data-menu]').first();
+  const trigger = menu.locator('summary');
 
   await trigger.click();
-  await expect(menu.locator('.split-btn__options')).toBeVisible();
+  await expect(menu.locator('.menu__list')).toBeVisible();
 
   await page.keyboard.press('Escape');
 
-  await expect(menu.locator('.split-btn__options')).toBeHidden();
+  await expect(menu.locator('.menu__list')).toBeHidden();
   await expect(trigger).toBeFocused();
 });
 
 test('a click outside closes the menu', async ({ page }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
+  const menu = page.locator('.split-btn [data-menu]').first();
 
-  await menu.locator('[data-split-trigger]').click();
-  await expect(menu.locator('.split-btn__options')).toBeVisible();
+  await menu.locator('summary').click();
+  await expect(menu.locator('.menu__list')).toBeVisible();
 
   await page.locator('h1').first().click();
 
-  await expect(menu.locator('.split-btn__options')).toBeHidden();
+  await expect(menu.locator('.menu__list')).toBeHidden();
 });
 
 // A menu left open behind the reader is one the page keeps positioning against a
@@ -72,10 +72,10 @@ test('a click outside closes the menu', async ({ page }) => {
 test('tabbing off the menu closes it', async ({ page }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
-  const options = menu.locator('.split-btn__options');
+  const menu = page.locator('.split-btn [data-menu]').first();
+  const options = menu.locator('.menu__list');
 
-  await menu.locator('[data-split-trigger]').click();
+  await menu.locator('summary').click();
   await expect(options).toBeVisible();
 
   // The items are out of the tab order, so one press leaves the whole control
@@ -91,11 +91,11 @@ test('tabbing off the menu closes it', async ({ page }) => {
 test('scrolling the page closes the menu', async ({ page }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
-  const options = menu.locator('.split-btn__options');
+  const menu = page.locator('.split-btn [data-menu]').first();
+  const options = menu.locator('.menu__list');
 
   // Keyed onto an item first: focus inside the menu is what kept it alive.
-  await menu.locator('[data-split-trigger]').focus();
+  await menu.locator('summary').focus();
   await page.keyboard.press('ArrowDown');
   await expect(options).toBeVisible();
   await expect(options.locator('[role="menuitem"]').first()).toBeFocused();
@@ -112,11 +112,11 @@ test('the arrow keys open the menu and move between its items', async ({
 }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
-  const options = menu.locator('.split-btn__options');
+  const menu = page.locator('.split-btn [data-menu]').first();
+  const options = menu.locator('.menu__list');
   const items = options.locator('[role="menuitem"]');
 
-  await menu.locator('[data-split-trigger]').focus();
+  await menu.locator('summary').focus();
   await page.keyboard.press('ArrowDown');
 
   await expect(options).toBeVisible();
@@ -140,13 +140,13 @@ test('the arrow keys open the menu and move between its items', async ({
 test('each menu opens independently of the others', async ({ page }) => {
   await page.goto(PAGE);
 
-  const menus = page.locator('[data-split-menu]');
+  const menus = page.locator('.split-btn [data-menu]');
   await expect(menus).toHaveCount(2);
 
-  await menus.nth(1).locator('[data-split-trigger]').click();
+  await menus.nth(1).locator('summary').click();
 
-  await expect(menus.nth(1).locator('.split-btn__options')).toBeVisible();
-  await expect(menus.nth(0).locator('.split-btn__options')).toBeHidden();
+  await expect(menus.nth(1).locator('.menu__list')).toBeVisible();
+  await expect(menus.nth(0).locator('.menu__list')).toBeHidden();
 });
 
 // A design system asset is drawn in `currentColor`, so handing one to an `<img>`
@@ -157,10 +157,10 @@ test('menu item icons take the color of the item they sit in', async ({
 }) => {
   await page.goto(PAGE);
 
-  const menu = page.locator('[data-split-menu]').first();
-  await menu.locator('[data-split-trigger]').click();
+  const menu = page.locator('.split-btn [data-menu]').first();
+  await menu.locator('summary').click();
 
-  const icon = menu.locator('.split-btn__option-icon').first();
+  const icon = menu.locator('.menu__icon').first();
   await expect(icon).toBeVisible();
 
   const paint = await icon.evaluate((el) => {
@@ -192,12 +192,12 @@ test('each menu hangs off the control it belongs to', async ({ page }) => {
 
   for (const index of [0, 1]) {
     const control = controls.nth(index);
-    const options = control.locator('.split-btn__options');
+    const options = control.locator('.menu__list');
 
-    await control.locator('[data-split-trigger]').click();
+    await control.locator('summary').click();
     await opened(options);
 
-    const half = (await control.locator('[data-split-trigger]').boundingBox())!;
+    const half = (await control.locator('summary').boundingBox())!;
     const menu = (await options.boundingBox())!;
 
     // The design hangs the list from the menu half, so its start edge lines up
@@ -227,10 +227,10 @@ for (const width of [1200, 700, 430]) {
     await page.setViewportSize({ width, height: 800 });
     await page.goto(PAGE);
 
-    const menu = page.locator('[data-split-menu]').first();
-    await menu.locator('[data-split-trigger]').click();
+    const menu = page.locator('.split-btn [data-menu]').first();
+    await menu.locator('summary').click();
 
-    const options = menu.locator('.split-btn__options');
+    const options = menu.locator('.menu__list');
     await opened(options);
 
     const box = (await options.boundingBox())!;


### PR DESCRIPTION
# Summary

When logged in, you can now click your avatar to open a profile menu. I extracted a `Menu` component out of `SplitButton` to accomplish this (based on our design system's `Menu`), as it was originally hardcoded as the only way to get a menu, and didn't have all of our design system's `Menu` component's features.


# Results

Light theme:
<img width="280" height="295" alt="image" src="https://github.com/user-attachments/assets/4f8c95c1-5169-40cc-913a-28da5a13ac29" />

https://github.com/user-attachments/assets/51842978-b198-4afe-9386-5b3e6995c5b2

Dark theme:
<img width="280" height="295" alt="image" src="https://github.com/user-attachments/assets/5097117c-8c7a-43ac-8d56-d62423f681db" />

Try it out at https://stoctodocspr3352.z22.web.core.windows.net/docs?newnav

Because this isn't actually live on octopus.com yet, you can't actually sign in on the staging site. However, you can test the logged in state on the staging site by populating the cookie with fake data, by running the following JS via the browser console:
```js
document.cookie = 'OctopusSignedInUser=' + encodeURIComponent(JSON.stringify({fullName: 'John Doe', email: 'jd@example.com'})) + ';path=/';
window.dispatchEvent(new CustomEvent('octopus:user-changed'));
```

To reset:
```js
document.cookie = 'OctopusSignedInUser=;path=/;max-age=0';
window.dispatchEvent(new CustomEvent('octopus:user-changed'));
```

Verify I haven't broken split buttons here: https://stoctodocspr3352.z22.web.core.windows.net/components#splitbutton