### PR TITLE
Use code.regular.small for pre in table cells

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -140,7 +140,10 @@ pre code {
   padding: unset;
 }
 
-table code {
+/* <pre> is included so a block in a cell lands on the same size as the inline
+   code beside it — without it the <code> inside shrinks and its wrapper does
+   not. */
+table :is(code, pre) {
   font: var(--textCodeRegularSmall);
 }
 


### PR DESCRIPTION
Closes [DPT-3123](https://linear.app/octopus/issue/DPT-3123/fix-css-class-for-code-elements-in-tables).

Inline `<code>` in tables already used `text.code.regular.small` (added in #3311). A bare `<pre>` in a table cell was missed by that selector and kept the medium code size, and a fenced block in a cell would have shrunk its `<code>` inside an unchanged wrapper. The selector now covers both.

Verified on [permissions](https://stoctodocspr3353.z22.web.core.windows.net/docs/kubernetes/targets/kubernetes-agent/permissions/), whose table has both: inline code and the `<pre>` cell both compute to 13px/20px (the `<pre>` was 14px before).

before:
[permissions](https://octopus.com/docs/kubernetes/targets/kubernetes-agent/permissions/)
After:
[permissions](https://stoctodocspr3353.z22.web.core.windows.net/docs/kubernetes/targets/kubernetes-agent/permissions/)

<img width="3825" height="1989" alt="image" src="https://github.com/user-attachments/assets/665e97a6-480a-4ac5-9f37-2fe2c9a37b01" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
