### PR TITLE
Remove heading icons example and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,26 +240,6 @@ the article column above it.
 
 ## Docs page layout guidelines
 
-### Title icons
-
-If you are updating a page in Docs which doesn't already have a title icon, please add one. Title icons can be added in the frontmatter for each page by adding a Font Awesome class in the `icon` entry:
-
-```yaml
----
-layout: src/layouts/Default.astro
-pubDate: 2023-01-01
-modDate: 2024-05-24
-title: Octopus Cloud
-subtitle: We host Octopus for you
-icon: fa-solid fa-cloud
-navTitle: Overview
-navSection: Octopus Cloud
-navOrder: 10
-description: How to work with Octopus Cloud.
-hideInThisSectionHeader: true
----
-```
-
 ### Product screenshots
 
 Product screenshots used in Docs should reflect the UI in the latest version of Octopus. The `figure` component will automatically add a curved border and outline to your image:

--- a/src/pages/components.mdx
+++ b/src/pages/components.mdx
@@ -4,7 +4,6 @@ pubDate: 2024-05-21
 modDate: 2024-05-21
 title: Component Usage Guide
 subtitle: Detailed guide on the new interactive components for documentation articles
-icon: fa-solid fa-code
 description: This guide provides detailed instructions on how to use the newly introduced components in your documentation articles.
 navSearch: false
 navSitemap: false

--- a/src/pages/ui-update-sample.mdx
+++ b/src/pages/ui-update-sample.mdx
@@ -4,7 +4,6 @@ pubDate: 2024-05-10
 modDate: 2024-05-10
 title: Tenant variables
 description: Tenant variables allow you to specify variables that can have different values for each tenant.
-icon: fa-solid fa-sliders
 navSearch: false
 navSitemap: false
 navMenu: false


### PR DESCRIPTION
Closes NES-278.

The header component and its styles were removed in #3312. This drops the now-dead `icon` frontmatter from 2 pages and the README section telling authors to add it.

The remainder 160+ MD files should have the icon removed after they have all been formatted / spell checked to pass the linters that were added after the docs were already written (this will be a separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)