### PR TITLE
Keep content images on a white plate in dark mode

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -231,6 +231,17 @@ img {
   background-color: var(--color-base-primary);
 }
 
+/* Content screenshots and diagrams are captured against a light UI and exported
+   with transparency, so the theme plate shows through in dark mode and swallows
+   their dark labels. --white is a scale token, invariant across both themes.
+   Component icons keep the theme plate: they are drawn to sit on either
+   surface. */
+.page-content
+  img:not(.avatar__image, .card__image, .icon-tile__icon, .link__icon),
+.zoom-lightbox img {
+  background-color: var(--white);
+}
+
 figure img {
   display: block;
   /* Only html is border-box, so without this the border pushes the image


### PR DESCRIPTION
Docs screenshots and diagrams are exported with transparency. In dark mode the page background showed through them, and their dark labels washed out. The diagram on [/docs/security](https://octopus.com/docs/security/) is the clearest case.

Content images in `.page-content` and in the zoom lightbox now paint `--white`, which is a scale token and so is the same in both themes. Component icons (card, icon tile, link, avatar) keep the theme background.

## Before / after

[Dark mode, `/docs/security`:](https://stoctodocspr3359.z22.web.core.windows.net/docs/security)

| Before | After |
| --- | --- |
| <img width="1578" height="962" alt="image" src="https://github.com/user-attachments/assets/56e99b87-cad8-4247-88ae-f04e59ca8958" />| <img width="1517" height="925" alt="image" src="https://github.com/user-attachments/assets/3febcce2-efe2-492e-9a75-ddbb5a0255ce" /> |

Light mode is byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
