### PR TITLE
Fix missing icons after conflict

### DIFF
--- a/src/components/OpenInLlm.astro
+++ b/src/components/OpenInLlm.astro
@@ -69,7 +69,7 @@ const [primary] = assistants;
     --octo-llm-glyph-size: 1rem;
   }
 
-  .octo-llm :global(.split-btn__option-icon) {
+  .octo-llm :global(.menu__icon) {
     --octo-llm-glyph-size: 0.8rem;
   }
 


### PR DESCRIPTION
A conflict between #3350 and #3352 broke the open in LLM menu item icons, this PR sorts that out.

<img width="348" height="139" alt="image" src="https://github.com/user-attachments/assets/4647add6-60fb-4ae8-a70d-a61094b37ed8" />
