### PR TITLE
Return to /docs after signing out

### DIFF
--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -548,6 +548,8 @@ struct
 stylesheet
 subcomponent
 subcontext
+subpath
+subpaths
 sunsetting
 swaggerui
 systemprofile

--- a/src/components/ProfileMenu.astro
+++ b/src/components/ProfileMenu.astro
@@ -14,7 +14,10 @@ const {
   label = 'Account',
   controlCenterHref = 'https://billing.octopus.com',
   profileHref = 'https://id.octopus.com/profile',
-  signOutHref = 'https://octopus.com/signout',
+
+  // Arbitrary subpaths of /docs are blocked on the server side, returning to /docs is the best we can do
+  signOutHref = 'https://octopus.com/signout?ReturnUrl=/docs',
+
   class: className,
   ...rest
 } = Astro.props satisfies Props;

--- a/tests/profile-menu.spec.ts
+++ b/tests/profile-menu.spec.ts
@@ -66,7 +66,7 @@ test('the avatar opens the menu', async ({
   );
   await expect(items.nth(2)).toHaveAttribute(
     'href',
-    'https://octopus.com/signout'
+    'https://octopus.com/signout?ReturnUrl=/docs'
   );
 
   await expect(menu.locator('[role="separator"]')).toHaveCount(1);


### PR DESCRIPTION
Ideally we'd return to whatever page we were actually on like when signing in (#3349) but the signout page has a server side restriction, controlled by a third party (Auth0), that does not support wildcards.

<img width="546" height="109" alt="image" src="https://github.com/user-attachments/assets/9f8e40ce-b168-4058-92c6-0fabd318d184" />

As such, the best we can realistically do is go back to octopus.com/docs.