### PR TITLE
Stabalize scrollbar gutter so the header stops shifting when search opens

### DIFF
--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -138,35 +138,17 @@ function initializeSearch() {
   // Dropdown accessibility controls
   document.addEventListener('keydown', handleDropdownKeyboardNavigation);
 
-  // Locking the page hides the body's overflow, which takes the scrollbar with
-  // it and widens the viewport. The header is fixed, so it is sized to the
-  // viewport and its contents would jump outward. Record the width the
-  // scrollbar was occupying so the CSS can hold that space open.
-  function lockScroll() {
-    const gutter = window.innerWidth - document.documentElement.clientWidth;
-    document.documentElement.style.setProperty(
-      '--scroll-lock-gutter',
-      gutter + 'px'
-    );
-    document.body.classList.add('search-scroll-lock');
-  }
-
-  function unlockScroll() {
-    document.body.classList.remove('search-scroll-lock');
-    document.documentElement.style.removeProperty('--scroll-lock-gutter');
-  }
-
   function activateInput() {
     if (siteSearchWrapper.classList.contains('is-active')) return;
     siteSearchWrapper.classList.add('is-active');
-    lockScroll();
+    document.body.style.overflow = 'hidden';
   }
 
   function deactivateInput() {
     if (!siteSearchWrapper.classList.contains('is-active')) return;
     siteSearchWrapper.classList.remove('is-active');
     siteSearchInput.blur();
-    unlockScroll();
+    document.body.style.overflow = '';
   }
 
   function openDropdown() {
@@ -186,7 +168,7 @@ function initializeSearch() {
         window.innerHeight - siteSearchElementRect.bottom;
 
       if (offsetFromBottomToElement < dropdownHeight) {
-        unlockScroll();
+        document.body.style.overflow = '';
 
         // Scroll to the siteSearchElement
         siteSearchElement.scrollIntoView({
@@ -194,10 +176,9 @@ function initializeSearch() {
           block: 'start',
         });
 
-        // Delay the lock to allow for smooth scrolling. The search can be
-        // dismissed inside those 300ms, which would leave the page locked.
+        // Delay the overflow to allow for smooth scrolling
         setTimeout(() => {
-          if (siteSearchWrapper.classList.contains('is-active')) lockScroll();
+          document.body.style.overflow = 'hidden';
         }, 300);
       }
     });

--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -138,17 +138,35 @@ function initializeSearch() {
   // Dropdown accessibility controls
   document.addEventListener('keydown', handleDropdownKeyboardNavigation);
 
+  // Locking the page hides the body's overflow, which takes the scrollbar with
+  // it and widens the viewport. The header is fixed, so it is sized to the
+  // viewport and its contents would jump outward. Record the width the
+  // scrollbar was occupying so the CSS can hold that space open.
+  function lockScroll() {
+    const gutter = window.innerWidth - document.documentElement.clientWidth;
+    document.documentElement.style.setProperty(
+      '--scroll-lock-gutter',
+      gutter + 'px'
+    );
+    document.body.classList.add('search-scroll-lock');
+  }
+
+  function unlockScroll() {
+    document.body.classList.remove('search-scroll-lock');
+    document.documentElement.style.removeProperty('--scroll-lock-gutter');
+  }
+
   function activateInput() {
     if (siteSearchWrapper.classList.contains('is-active')) return;
     siteSearchWrapper.classList.add('is-active');
-    document.body.style.overflow = 'hidden';
+    lockScroll();
   }
 
   function deactivateInput() {
     if (!siteSearchWrapper.classList.contains('is-active')) return;
     siteSearchWrapper.classList.remove('is-active');
     siteSearchInput.blur();
-    document.body.style.overflow = '';
+    unlockScroll();
   }
 
   function openDropdown() {
@@ -168,7 +186,7 @@ function initializeSearch() {
         window.innerHeight - siteSearchElementRect.bottom;
 
       if (offsetFromBottomToElement < dropdownHeight) {
-        document.body.style.overflow = '';
+        unlockScroll();
 
         // Scroll to the siteSearchElement
         siteSearchElement.scrollIntoView({
@@ -176,9 +194,10 @@ function initializeSearch() {
           block: 'start',
         });
 
-        // Delay the overflow to allow for smooth scrolling
+        // Delay the lock to allow for smooth scrolling. The search can be
+        // dismissed inside those 300ms, which would leave the page locked.
         setTimeout(() => {
-          document.body.style.overflow = 'hidden';
+          if (siteSearchWrapper.classList.contains('is-active')) lockScroll();
         }, 300);
       }
     });

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,6 +13,10 @@ html[data-theme='dark'] {
 html {
   box-sizing: border-box;
   scroll-padding-block-start: var(--scroll-pad);
+  /* Search and the mobile nav lock scrolling by hiding the body's overflow,
+     which takes the scrollbar with it. Holding the gutter open keeps the
+     viewport a constant width, so the fixed header stays put. */
+  scrollbar-gutter: stable;
 }
 
 *,
@@ -50,23 +54,6 @@ body {
 
 body.no-scroll {
   overflow: hidden;
-}
-
-/* Search locks the page while its dropdown is open. Hiding the overflow takes
-   the scrollbar away and widens the viewport, so hold the width it was using
-   open — otherwise the page and the viewport-sized fixed header both grow into
-   it and their contents jump to the right. --scroll-lock-gutter is measured and
-   set by search.js, and is 0 when there was no scrollbar to lose. */
-body.search-scroll-lock {
-  overflow: hidden;
-  padding-inline-end: var(--scroll-lock-gutter, 0px);
-}
-
-body.search-scroll-lock .octo-header-bkg {
-  /* html's border-box does not inherit, so width: 100% would grow by the
-     padding instead of absorbing it. */
-  box-sizing: border-box;
-  padding-inline-end: var(--scroll-lock-gutter, 0px);
 }
 
 a,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2438,6 +2438,17 @@ a[data-youtube] {
   visibility: visible;
 }
 
+/* The overlay is fixed, so it stops at the reserved scrollbar gutter and leaves
+   that strip showing the undimmed page colour once the scrollbar goes. Painting
+   the same wash onto the canvas carries the dimming across it. */
+html:has(.site-search__wrapper.is-active) {
+  background-color: var(--color-base-primary);
+  background-image: linear-gradient(
+    var(--search-overlay),
+    var(--search-overlay)
+  );
+}
+
 .site-search__icon path {
   fill: var(--blue-grey-light);
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2439,7 +2439,7 @@ a[data-youtube] {
 }
 
 /* The overlay is fixed, so it stops at the reserved scrollbar gutter and leaves
-   that strip showing the undimmed page colour once the scrollbar goes. Painting
+   that strip showing the undimmed page color once the scrollbar goes. Painting
    the same wash onto the canvas carries the dimming across it. */
 html:has(.site-search__wrapper.is-active) {
   background-color: var(--color-base-primary);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -52,6 +52,23 @@ body.no-scroll {
   overflow: hidden;
 }
 
+/* Search locks the page while its dropdown is open. Hiding the overflow takes
+   the scrollbar away and widens the viewport, so hold the width it was using
+   open — otherwise the page and the viewport-sized fixed header both grow into
+   it and their contents jump to the right. --scroll-lock-gutter is measured and
+   set by search.js, and is 0 when there was no scrollbar to lose. */
+body.search-scroll-lock {
+  overflow: hidden;
+  padding-inline-end: var(--scroll-lock-gutter, 0px);
+}
+
+body.search-scroll-lock .octo-header-bkg {
+  /* html's border-box does not inherit, so width: 100% would grow by the
+     padding instead of absorbing it. */
+  box-sizing: border-box;
+  padding-inline-end: var(--scroll-lock-gutter, 0px);
+}
+
 a,
 summary,
 summary > * {


### PR DESCRIPTION
Focusing the search hides the body overflow to lock scrolling. That takes the scrollbar with it and widens the viewport, so both fixed headers grew and their contents jumped 15px to the right.

`scrollbar-gutter: stable` on `html` holds that width open, so the viewport stays a constant width whenever anything locks scrolling.

This was "worse" on the new navbar and resolutions that are "tight" on space.

## Before:

https://github.com/user-attachments/assets/46a2ee08-ae7e-4e80-ab82-d3ec6587323b


## After:

https://github.com/user-attachments/assets/c93c2e69-2c12-4e06-ad03-f6d8b5ffb794



🤖 Generated with [Claude Code](https://claude.com/claude-code)
