### PR TITLE
Consolidate structured data into JSON-LD

### DIFF
--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -3,7 +3,7 @@ import { accelerator } from '@lib/accelerator';
 import { PostFiltering } from 'astro-accelerator-utils';
 import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
-import { getImageInfo } from '@util/custom-markdown.mjs';
+import { buildCrumbs, type Crumb } from '@util/breadcrumbs';
 
 // Theme components
 import Head from '@components/HtmlHead.astro';
@@ -30,18 +30,16 @@ import DocsSearch from '../components/DocsSearch.astro';
 type Props = {
   frontmatter: OriginalFrontmatter;
   headings: { depth: number; slug: string; text: string }[];
-  breadcrumbs?: { url: string; title: string; ariaCurrent?: string }[] | null;
+  breadcrumbs?: Crumb[] | null;
 };
 const { frontmatter, headings, breadcrumbs } = Astro.props satisfies Props;
+
+const crumbs = buildCrumbs(Astro.url, breadcrumbs);
 
 const lang = frontmatter.lang ?? SITE.default.lang;
 const textDirection = frontmatter.dir ?? SITE.default.dir;
 
 // Logic
-const metaImage = frontmatter.bannerImage
-  ? getImageInfo(frontmatter.bannerImage.src, '', SITE.images.contentSize)
-  : null;
-
 const title = await accelerator.markdown.getInlineHtmlFrom(
   frontmatter.title ?? SITE.title
 );
@@ -60,12 +58,17 @@ const isSearchPage =
 
 const showSearch = !isSearchPage;
 
-// The footer prints this; the article keeps it in its schema.org markup.
+// The footer prints this; JSON-LD carries it as dateModified.
 const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
 ---
 
 <html dir={textDirection} lang={lang} class="initial" data-theme="light">
-  <Head frontmatter={frontmatter} headings={headings} lang={lang} />
+  <Head
+    frontmatter={frontmatter}
+    headings={headings}
+    lang={lang}
+    crumbs={crumbs}
+  />
   <body>
     <SkipLinks frontmatter={frontmatter} headings={headings} lang={lang} />
     <Header
@@ -80,9 +83,9 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
           frontmatter={frontmatter}
           headings={headings}
           lang={lang}
-          breadcrumbs={breadcrumbs}
+          crumbs={crumbs}
         />
-        <article itemscope itemtype="https://schema.org/Article">
+        <article>
           <ArticleHeader lang={lang} subtitle={subtitle} title={title} />
           <div class="page-actions">
             <CopyAsMarkdown lang={lang} />
@@ -93,20 +96,11 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
               lang={lang}
             />
           </div>
-          <div class="page-content anim-show-parent" itemprop="articleBody">
+          <div class="page-content anim-show-parent">
             <slot />
             <Authors frontmatter={frontmatter} lang={lang} />
             <Taxonomy frontmatter={frontmatter} lang={lang} />
             <MarkdownLinks lang={lang} />
-            {metaImage && <meta itemprop="image" content={metaImage.src} />}
-            {
-              lastUpdated && (
-                <meta
-                  itemprop="dateModified"
-                  content={new Date(lastUpdated).toISOString()}
-                />
-              )
-            }
           </div>
         </article>
       </main>

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -79,12 +79,7 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
     />
     <div class="content-group">
       <main id="site-main">
-        <Breadcrumbs
-          frontmatter={frontmatter}
-          headings={headings}
-          lang={lang}
-          crumbs={crumbs}
-        />
+        <Breadcrumbs lang={lang} crumbs={crumbs} />
         <article>
           <ArticleHeader lang={lang} subtitle={subtitle} title={title} />
           <div class="page-actions">

--- a/src/themes/octopus/components/Authors.astro
+++ b/src/themes/octopus/components/Authors.astro
@@ -47,11 +47,7 @@ stats.stop();
         <span class="author-list">
           {_(Translations.post.written_by) + ' '}
           {authorList.mainAuthor && (
-            <span
-              itemprop="author"
-              itemscope
-              itemtype="https://schema.org/Person"
-            >
+            <span>
               <a
                 href={
                   // TODO: `formatAddress(...) + '1/'` produces `<slug>1/`,
@@ -61,11 +57,8 @@ stats.stop();
                     authorList.mainAuthor.url
                   ) + '1/'
                 }
-                itemprop="url"
               >
-                <span itemprop="name">
-                  {authorList.mainAuthor.frontmatter.title}
-                </span>
+                <span>{authorList.mainAuthor.frontmatter.title}</span>
               </a>
             </span>
           )}
@@ -73,18 +66,13 @@ stats.stop();
             {authorList.contributors.map((writer, index) => (
               <>
                 {index > 0 && ', '}
-                <span
-                  itemprop="contributor"
-                  itemscope
-                  itemtype="https://schema.org/Person"
-                >
+                <span>
                   <a
                     href={
                       accelerator.urlFormatter.formatAddress(writer.url) + '1/'
                     }
-                    itemprop="url"
                   >
-                    <span itemprop="name">{writer.frontmatter.title}</span>
+                    <span>{writer.frontmatter.title}</span>
                   </a>
                 </span>
               </>
@@ -93,10 +81,7 @@ stats.stop();
           <>
             <>
               <br />
-              <time
-                datetime={frontmatter.pubDate.toString()}
-                itemprop="datePublished"
-              >
+              <time datetime={frontmatter.pubDate.toString()}>
                 {accelerator.dateFormatter.formatDate(
                   frontmatter.pubDate,
                   lang
@@ -106,10 +91,7 @@ stats.stop();
             {frontmatter.modDate && (
               <>
                 <br />
-                <time
-                  datetime={frontmatter.modDate.toString()}
-                  itemprop="dateModified"
-                >
+                <time datetime={frontmatter.modDate.toString()}>
                   {_(Translations.post.last_modified) +
                     ' ' +
                     accelerator.dateFormatter.formatDate(

--- a/src/themes/octopus/components/Breadcrumbs.astro
+++ b/src/themes/octopus/components/Breadcrumbs.astro
@@ -1,13 +1,8 @@
 ---
 import { accelerator } from '@lib/accelerator';
-import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
-import { SITE } from '@config';
+import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { Translations, Lang } from '@util/Languages';
-
-// Extend Frontmatter with crumbTitle
-type Frontmatter = OriginalFrontmatter & {
-  crumbTitle?: string;
-};
+import type { Crumb } from '@util/breadcrumbs';
 
 const stats = new accelerator.statistics(
   'octopus/components/Breadcrumbs.astro'
@@ -19,74 +14,27 @@ type Props = {
   lang: string;
   frontmatter: Frontmatter;
   headings: { depth: number; slug: string; text: string }[];
-  breadcrumbs?: { url: string; title: string; ariaCurrent?: string }[] | null;
+  crumbs?: ReadonlyArray<Crumb> | null;
 };
-const { lang, breadcrumbs } = Astro.props satisfies Props;
+const { lang, crumbs } = Astro.props satisfies Props;
 
 // Language
 const _ = Lang(lang);
-
-// Logic
-const currentUrl = new URL(Astro.request.url);
-const navPages = accelerator.navigation.breadcrumbs(
-  currentUrl,
-  SITE.subfolder,
-  breadcrumbs?.length ?? 0
-);
-
-const allPages = accelerator.posts.all();
-
-// Apply crumbTitle from frontmatter if available
-for (let i = 0; i < navPages.length; i++) {
-  const matchingPage = allPages.find((p) => {
-    const pageUrl = accelerator.urlFormatter.addSlashToAddress(p.url ?? '/');
-    return pageUrl === navPages[i].url;
-  });
-
-  if (matchingPage) {
-    const fm = matchingPage.frontmatter as Frontmatter;
-    if (fm.crumbTitle) {
-      // Use crumbTitle if it's set in frontmatter
-      navPages[i].title = fm.crumbTitle;
-    } else {
-      // Fall back to original behavior
-      navPages[i].title = navPages[i].section || navPages[i].title;
-    }
-  } else {
-    // No matching page found, use original behavior
-    navPages[i].title = navPages[i].section || navPages[i].title;
-  }
-}
-
-// The derived nav pages and any explicit crumbs render identically, so they
-// share one list. That keeps the schema.org position sequence, which is
-// 1-based, tied to a single index rather than two counters that have to agree.
-type Crumb = {
-  url: string;
-  title: string;
-  ariaCurrent?: string;
-  rel?: string;
-};
-
-const crumbs: Crumb[] = [...navPages, ...(breadcrumbs ?? [])];
 
 stats.stop();
 ---
 
 <nav aria-label={_(Translations.aria.breadcrumbs)}>
-  <ol vocab="http://schema.org/" typeof="BreadcrumbList">
+  <ol>
     {
-      crumbs.map((crumb, index) => (
-        <li property="itemListElement" typeof="ListItem">
-          <meta property="position" content={(index + 1).toString()} />
+      (crumbs ?? []).map((crumb) => (
+        <li>
           <a
-            property="item"
-            typeof="WebPage"
             href={accelerator.urlFormatter.formatAddress(crumb.url)}
             aria-current={crumb.ariaCurrent ? crumb.ariaCurrent : null}
             rel={crumb.rel}
           >
-            <span property="name">{crumb.title}</span>
+            {crumb.title}
           </a>
         </li>
       ))

--- a/src/themes/octopus/components/Breadcrumbs.astro
+++ b/src/themes/octopus/components/Breadcrumbs.astro
@@ -1,6 +1,5 @@
 ---
 import { accelerator } from '@lib/accelerator';
-import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { Translations, Lang } from '@util/Languages';
 import type { Crumb } from '@util/breadcrumbs';
 
@@ -12,8 +11,6 @@ stats.start();
 // Properties
 type Props = {
   lang: string;
-  frontmatter: Frontmatter;
-  headings: { depth: number; slug: string; text: string }[];
   crumbs?: ReadonlyArray<Crumb> | null;
 };
 const { lang, crumbs } = Astro.props satisfies Props;

--- a/src/themes/octopus/components/HtmlHead.astro
+++ b/src/themes/octopus/components/HtmlHead.astro
@@ -4,6 +4,7 @@ import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE, OPEN_GRAPH, HEADER_SCRIPTS } from '@config';
 import { getEligibleSlugs } from '@util/mdxContent';
 import JsonLd from '@components/JsonLd.astro';
+import type { Crumb } from '@util/breadcrumbs';
 import ThemeScript from '@components/ThemeScript.astro';
 
 // Design tokens as CSS custom properties. globals and textTheme apply at :root;
@@ -31,8 +32,9 @@ type Props = {
   lang: string;
   frontmatter: Frontmatter;
   headings: { depth: number; slug: string; text: string }[];
+  crumbs?: ReadonlyArray<Crumb> | null;
 };
-const { frontmatter } = Astro.props;
+const { frontmatter, crumbs } = Astro.props;
 
 // Logic
 const imageSrc = frontmatter.bannerImage?.src ?? OPEN_GRAPH.image.src;
@@ -152,6 +154,7 @@ stats.stop();
     socialTitle={socialTitle}
     imageURL={canonicalImageSrc.toString()}
     authors={authorList}
+    crumbs={crumbs}
   />
   <Fragment set:html={HEADER_SCRIPTS} />
 </head>

--- a/src/themes/octopus/components/JsonLd.astro
+++ b/src/themes/octopus/components/JsonLd.astro
@@ -1,9 +1,11 @@
 ---
+import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import type { AuthorList } from 'astro-accelerator-utils/types/AuthorList';
 import { STRUCTURED_DATA } from '@config';
 import {
   buildArticle,
+  buildBreadcrumbList,
   buildOrganization,
   buildPersonNodes,
   buildWebSite,
@@ -14,6 +16,7 @@ import {
   toGraphPayload,
   type GraphNode,
 } from '@util/structured-data';
+import type { Crumb } from '@util/breadcrumbs';
 
 type Props = {
   frontmatter: Frontmatter;
@@ -21,9 +24,10 @@ type Props = {
   socialTitle: string;
   imageURL?: string;
   authors?: AuthorList | null;
+  crumbs?: ReadonlyArray<Crumb> | null;
 };
 
-const { frontmatter, canonicalURL, socialTitle, imageURL, authors } =
+const { frontmatter, canonicalURL, socialTitle, imageURL, authors, crumbs } =
   Astro.props;
 
 type Payload = ReturnType<typeof toGraphPayload>;
@@ -56,7 +60,7 @@ function buildPayload(): Payload | null {
   const pathname = normalizePathname(
     pathnameFromCanonical(canonicalURL, Astro.url.pathname)
   );
-  const articleType = pickArticleType(pathname, frontmatter);
+  const articleType = pickArticleType(frontmatter);
   const headline = cleanHeadline(socialTitle);
 
   // Author branch is unreachable today (no author pages); kept wired.
@@ -87,6 +91,18 @@ function buildPayload(): Payload | null {
   }
 
   const nodes: GraphNode[] = [article, buildWebSite(), buildOrganization()];
+
+  const breadcrumbList = crumbs?.length
+    ? buildBreadcrumbList(
+        crumbs.map((c) => ({
+          url: accelerator.urlFormatter.formatAddress(c.url),
+          title: c.title,
+        })),
+        canonicalURL
+      )
+    : null;
+  if (breadcrumbList) nodes.push(breadcrumbList);
+
   return toGraphPayload(nodes);
 }
 

--- a/src/themes/octopus/components/Taxonomy.astro
+++ b/src/themes/octopus/components/Taxonomy.astro
@@ -33,7 +33,7 @@ stats.stop();
       {tags.length > 0 && (
         <div class="post-tag">
           <h2>{_(Translations.articles.tag_title)}: </h2>
-          <ul itemprop="keywords">
+          <ul>
             {tags.map((tag) => (
               <li>
                 <a href={links.getTagLink(tag)}>{tag}</a>
@@ -48,12 +48,7 @@ stats.stop();
           <ul>
             {categories.map((category) => (
               <li>
-                <a
-                  href={links.getCategoryLink(category)}
-                  itemprop="articleSection"
-                >
-                  {category}
-                </a>
+                <a href={links.getCategoryLink(category)}>{category}</a>
               </li>
             ))}
           </ul>

--- a/src/themes/octopus/layouts/Default.astro
+++ b/src/themes/octopus/layouts/Default.astro
@@ -53,12 +53,7 @@ stats.stop();
   <body>
     <SkipLinks frontmatter={frontmatter} headings={headings} lang={lang} />
     <Header frontmatter={frontmatter} headings={headings} lang={lang} />
-    <Breadcrumbs
-      frontmatter={frontmatter}
-      headings={headings}
-      lang={lang}
-      crumbs={crumbs}
-    />
+    <Breadcrumbs lang={lang} crumbs={crumbs} />
     <div class="content-group">
       <main id="site-main">
         <article>

--- a/src/themes/octopus/layouts/Default.astro
+++ b/src/themes/octopus/layouts/Default.astro
@@ -1,7 +1,7 @@
 ---
 import { accelerator } from '@lib/accelerator';
 import type { Frontmatter } from 'astro-accelerator-utils/types/Frontmatter';
-import { getImageInfo } from '@util/custom-markdown.mjs';
+import { buildCrumbs, type Crumb } from '@util/breadcrumbs';
 import { SITE } from '@config';
 import Head from '@components/HtmlHead.astro';
 import Header from '@components/Header.astro';
@@ -20,18 +20,16 @@ stats.start();
 type Props = {
   frontmatter: Frontmatter;
   headings: { depth: number; slug: string; text: string }[];
-  breadcrumbs?: { url: string; title: string; ariaCurrent?: string }[] | null;
+  breadcrumbs?: Crumb[] | null;
 };
 const { frontmatter, headings, breadcrumbs } = Astro.props satisfies Props;
+
+const crumbs = buildCrumbs(Astro.url, breadcrumbs);
 
 const lang = frontmatter.lang ?? SITE.default.lang;
 const textDirection = frontmatter.dir ?? SITE.default.dir;
 
 // Logic
-const metaImage = frontmatter.bannerImage
-  ? getImageInfo(frontmatter.bannerImage.src, '', SITE.images.contentSize)
-  : null;
-
 const title = await accelerator.markdown.getInlineHtmlFrom(
   frontmatter.title ?? SITE.title
 );
@@ -46,7 +44,12 @@ stats.stop();
 ---
 
 <html dir={textDirection} lang={lang} class="initial">
-  <Head frontmatter={frontmatter} headings={headings} lang={lang} />
+  <Head
+    frontmatter={frontmatter}
+    headings={headings}
+    lang={lang}
+    crumbs={crumbs}
+  />
   <body>
     <SkipLinks frontmatter={frontmatter} headings={headings} lang={lang} />
     <Header frontmatter={frontmatter} headings={headings} lang={lang} />
@@ -54,13 +57,13 @@ stats.stop();
       frontmatter={frontmatter}
       headings={headings}
       lang={lang}
-      breadcrumbs={breadcrumbs}
+      crumbs={crumbs}
     />
     <div class="content-group">
       <main id="site-main">
-        <article itemscope itemtype="https://schema.org/Article">
+        <article>
           <header>
-            <h1 itemprop="name headline"><Fragment set:html={title} /></h1>
+            <h1><Fragment set:html={title} /></h1>
             {
               subtitle && (
                 <p>
@@ -69,7 +72,7 @@ stats.stop();
               )
             }
           </header>
-          <div class="page-content anim-show-parent" itemprop="articleBody">
+          <div class="page-content anim-show-parent">
             <TableOfContents
               frontmatter={frontmatter}
               headings={headings}
@@ -83,7 +86,6 @@ stats.stop();
               headings={headings}
               lang={lang}
             />
-            {metaImage && <meta itemprop="image" content={metaImage.src} />}
           </div>
         </article>
       </main>

--- a/src/themes/octopus/utilities/breadcrumbs.ts
+++ b/src/themes/octopus/utilities/breadcrumbs.ts
@@ -1,0 +1,45 @@
+import { accelerator } from '@lib/accelerator';
+import { SITE } from '@config';
+
+export type Crumb = {
+  url: string;
+  title: string;
+  ariaCurrent?: string | false;
+  rel?: string;
+};
+
+let crumbTitles: Map<string, string> | null = null;
+
+function crumbTitleMap(): Map<string, string> {
+  if (crumbTitles !== null) return crumbTitles;
+
+  const map = new Map<string, string>();
+  for (const page of accelerator.posts.all()) {
+    const title = page.frontmatter?.crumbTitle;
+    if (typeof title !== 'string' || title.length === 0) continue;
+    map.set(accelerator.urlFormatter.addSlashToAddress(page.url ?? '/'), title);
+  }
+
+  // Builds only. In dev the page set changes under you, so rebuild each call.
+  if (import.meta.env.PROD) crumbTitles = map;
+  return map;
+}
+
+export function buildCrumbs(
+  currentUrl: URL,
+  extraCrumbs?: ReadonlyArray<Crumb> | null
+): Crumb[] {
+  const navPages = accelerator.navigation.breadcrumbs(
+    currentUrl,
+    SITE.subfolder,
+    extraCrumbs?.length ?? 0
+  );
+
+  const titles = crumbTitleMap();
+
+  for (const page of navPages) {
+    page.title = titles.get(page.url) || page.section || page.title;
+  }
+
+  return [...navPages, ...(extraCrumbs ?? [])];
+}

--- a/src/themes/octopus/utilities/structured-data.ts
+++ b/src/themes/octopus/utilities/structured-data.ts
@@ -55,23 +55,34 @@ type ArticleNode = {
   contributor?: PersonNode | PersonNode[];
 };
 
-export type GraphNode = OrganizationNode | WebSiteNode | ArticleNode;
+type ListItemNode = {
+  '@type': 'ListItem';
+  position: number;
+  name: string;
+  item?: string;
+};
+type BreadcrumbListNode = {
+  '@type': 'BreadcrumbList';
+  '@id': string;
+  itemListElement: ListItemNode[];
+};
+
+export type GraphNode =
+  | OrganizationNode
+  | WebSiteNode
+  | ArticleNode
+  | BreadcrumbListNode;
 
 // Frontmatter values can drift from declared types at runtime (YAML parses
 // invalid dates as strings). Helpers take unknown and validate.
 
 const SITE_ROOT = SITE.url + SITE.subfolder;
-const SUBFOLDER = SITE.subfolder.replace(/\/$/, '');
 
 const ORG_ID = `${SITE_ROOT}#organization`;
 const WEBSITE_ID = `${SITE_ROOT}#website`;
 const ORG_LOGO_URL = SITE.url + STRUCTURED_DATA.organizationLogo.src;
 const ORG_LOGO_WIDTH = STRUCTURED_DATA.organizationLogo.width;
 const ORG_LOGO_HEIGHT = STRUCTURED_DATA.organizationLogo.height;
-
-const TECH_ARTICLE_PREFIXES = ['/installation', '/getting-started'].map(
-  (p) => SUBFOLDER + p
-);
 
 // frontmatter.layout is absent at this stage, so no layout check.
 // Add one if a Search-layout page appears without navSitemap: false.
@@ -138,12 +149,6 @@ function pickLang(val: unknown): string {
   }
 }
 
-function normalizePathname(pathname: string): string {
-  return pathname.length > 1 && pathname.endsWith('/')
-    ? pathname.slice(0, -1)
-    : pathname;
-}
-
 // Same exclusion axes as the sitemap filter, minus layout (absent here).
 export function isStructuredDataEligible(
   frontmatter: StructuredDataFrontmatter | null | undefined
@@ -157,18 +162,13 @@ export function isStructuredDataEligible(
   return true;
 }
 
-// URL-prefix default; frontmatter.articleType overrides.
+// TechArticle default; frontmatter.articleType overrides.
 export function pickArticleType(
-  pathname: string,
   frontmatter: StructuredDataFrontmatter
 ): ArticleType {
   const override = frontmatter.articleType;
-  if (override === 'Article' || override === 'TechArticle') return override;
-  const path = normalizePathname(pathname);
-  for (const prefix of TECH_ARTICLE_PREFIXES) {
-    if (path === prefix || path.startsWith(prefix + '/')) return 'TechArticle';
-  }
-  return 'Article';
+  if (override === 'Article') return override;
+  return 'TechArticle';
 }
 
 // Cached per-page nodes. Convention: do not mutate. No runtime enforcement.
@@ -290,6 +290,39 @@ export function buildArticle({
   }
 
   return node;
+}
+
+export function buildBreadcrumbList(
+  crumbs: ReadonlyArray<{ url: string; title: string }>,
+  canonicalURL: string
+): BreadcrumbListNode | null {
+  const crumbsWithTitle = crumbs.filter(
+    (c) => typeof c.title === 'string' && c.title
+  );
+  if (crumbsWithTitle.length < 2) return null;
+
+  const itemListElement = crumbsWithTitle.map((crumb, index) => {
+    const isLast = index === crumbsWithTitle.length - 1;
+    const item = isLast ? undefined : toAbsoluteUrl(crumb.url);
+    return {
+      '@type': 'ListItem' as const,
+      position: index + 1,
+      name: crumb.title,
+      ...(item && { item }),
+    };
+  });
+
+  return {
+    '@type': 'BreadcrumbList',
+    '@id': `${canonicalURL}#breadcrumb`,
+    itemListElement,
+  };
+}
+
+function toAbsoluteUrl(url: string): string | undefined {
+  try {
+    return new URL(url, SITE.url).toString();
+  } catch {}
 }
 
 // Single @graph payload; all @ids resolve in-document. Article first.


### PR DESCRIPTION
# Summary

JSON-LD is Google's recommended format for structured data. Source: https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data

> In general, Google recommends using JSON-LD for structured data if your site's setup allows it, as it's the easiest solution for website owners to implement and maintain at scale (in other words, less prone to user errors).

Prior to this PR, we had a mix of all three types: microdata, RFDa, and JSON-LD. Microdata and RFDa were to some degree broken / contradicting the JSON-LD in places. This PR consolidates it all on JSON-LD, and makes an effort to improve it without introducing any regressions.

- Everything now emits `TechArticle` instead of `Article` as the article type (previously only `/getting-started` and `/installation` had this type) as I think it's more accurate given the nature of our docs. (This can be opted out of if there are pages that warrant it)
- JSON-LD is now the source of truth for breadcrumbs rather than RFDa. They use absolute URLs (seems to be the correct approach from what I can tell, Google's own examples also follow this). The breadcrumb trail is shared between the rendered breadcrumbs and the metadata so they can't drift.
- I verified across all rendered pages there's no difference to the breadcrumbs, and to the best of my ability to tell all JSON-LD data is valid per schema.org.

There are a few pages no longer emitting breadcrumb data but three have `noindex` so they can't show up in search results anyway and thus are irrelevant, one is octopus.com/docs/guides which is a redirect to `/docs`, and the last is `/docs` itself which only has one crumb, itself, which doesn't mean anything.
