### PR TITLE
Switch markdown pipeline from unified to Sätteri

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,11 @@
-import remarkDirective from 'remark-directive';
-import remarkHeading from 'remark-heading-id';
 import { defineConfig } from 'astro/config';
-import { unified } from '@astrojs/markdown-remark';
+import { satteri } from '@astrojs/markdown-satteri';
 import mdx from '@astrojs/mdx';
 import { attributeMarkdown, wrapTables } from '/src/themes/octopus/utilities/custom-markdown.mjs';
 import llmMdEmitter from './src/integrations/llm-md-emitter.ts';
 import pruneDist from './src/integrations/prune-dist.ts';
-import rehypeWbr from './src/plugins/rehype-wbr.js';
+import satteriHeadingId from './src/plugins/satteri-heading-id.js';
+import satteriWbr from './src/plugins/satteri-wbr.js';
 import shikiCodeBlock from './src/plugins/shiki-code-block.js';
 
 // https://astro.build/config
@@ -37,19 +36,26 @@ export default defineConfig({
             langAlias: {
                 ocl: 'hcl'
             },
-            // A transformer, because rehype plugins registered through
-            // `processor` below never reach .mdx pages
+            // A transformer, so the shell is built as each block is
+            // highlighted rather than by re-parsing the markup afterwards
             transformers: [shikiCodeBlock()]
         },
-        processor: unified({
-            remarkPlugins: [
-                remarkDirective,
-                remarkHeading,
+        // Sätteri, the Rust processor, replaces the unified pipeline. Unlike
+        // unified's remark/rehype plugins, these also run over .mdx pages.
+        processor: satteri({
+            features: {
+                // `:::div{.hint}` containers and `:img{src=...}` directives
+                directive: true,
+                // `## Title {#custom-id}` explicit heading ids
+                headingAttributes: true
+            },
+            mdastPlugins: [
+                satteriHeadingId,
                 attributeMarkdown,
                 wrapTables
             ],
-            rehypePlugins: [
-                rehypeWbr
+            hastPlugins: [
+                satteriWbr
             ],
         }),
     },

--- a/dictionary-octopus.txt
+++ b/dictionary-octopus.txt
@@ -13,6 +13,7 @@ antipattern
 antipatterns
 apikey
 apikeys
+apos
 appcmd
 apphost
 APPNAME
@@ -492,6 +493,8 @@ sakila
 SAMEORIGIN
 sandboxed
 sandboxing
+satteri
+Sätteri
 Schannel
 SCIM
 scopeduserroles

--- a/package.json
+++ b/package.json
@@ -26,19 +26,17 @@
         "watch": "onchange 'src/**/*.{js,mjs,ts,astro,css}' -- prettier --write --plugin=prettier-plugin-astro {{changed}}"
     },
     "dependencies": {
-        "@astrojs/markdown-remark": "7.2.2",
+        "@astrojs/markdown-satteri": "^0.3.5",
         "@astrojs/mdx": "^7.0.5",
         "@octopusdeploy/design-system-tokens": "^2026.3.8240",
         "astro": "^7.2.2",
         "astro-accelerator-utils": "^0.3.84",
         "glob": "^13.0.6",
         "gray-matter": "^4.0.3",
-        "hast-util-from-selector": "^3.0.1",
         "html-to-text": "^10.0.0",
         "keyword-extractor": "^0.0.28",
         "optional": "^0.1.4",
-        "remark-directive": "^4.0.0",
-        "remark-heading-id": "^1.0.1",
+        "satteri": "^0.9.5",
         "sharp": "^0.34.5"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,9 @@ importers:
 
   .:
     dependencies:
-      '@astrojs/markdown-remark':
-        specifier: 7.2.2
-        version: 7.2.2
+      '@astrojs/markdown-satteri':
+        specifier: ^0.3.5
+        version: 0.3.5
       '@astrojs/mdx':
         specifier: ^7.0.5
         version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.2(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.10.1)(yaml@2.8.4))
@@ -39,9 +39,6 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
-      hast-util-from-selector:
-        specifier: ^3.0.1
-        version: 3.0.1
       html-to-text:
         specifier: ^10.0.0
         version: 10.0.0
@@ -51,12 +48,9 @@ importers:
       optional:
         specifier: ^0.1.4
         version: 0.1.4
-      remark-directive:
-        specifier: ^4.0.0
-        version: 4.0.0
-      remark-heading-id:
-        specifier: ^1.0.1
-        version: 1.0.1
+      satteri:
+        specifier: ^0.9.5
+        version: 0.9.5
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -1062,9 +1056,6 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
@@ -1363,9 +1354,6 @@ packages:
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
-
-  css-selector-parser@3.3.0:
-    resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -1754,9 +1742,6 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
-  hast-util-from-selector@3.0.1:
-    resolution: {integrity: sha512-CA2dwcsAS6a7DNZq8HT5fNP4FzUq2PUpQpKnAtOCmfTk429jR0RtasLSMlFA1FNKd8lgfeCIAFl3/vD95be8Lg==}
-
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
@@ -2084,9 +2069,6 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
@@ -2129,9 +2111,6 @@ packages:
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
-
-  mdast-util-directive@3.1.0:
-    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -2197,9 +2176,6 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
-
-  micromark-extension-directive@4.0.0:
-    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -2581,15 +2557,8 @@ packages:
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
 
-  remark-directive@4.0.0:
-    resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
-
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
-
-  remark-heading-id@1.0.1:
-    resolution: {integrity: sha512-GmJjuCeEkYvwFlvn/Skjc/1Qafj71412gbQnrwUmP/tKskmAf1cMRlZRNoovV+aIvsSRkTb2rCmGv2b9RdoJbQ==}
-    engines: {node: '>=8'}
 
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
@@ -2940,9 +2909,6 @@ packages:
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
-  unist-util-is@3.0.0:
-    resolution: {integrity: sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==}
-
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -2964,14 +2930,8 @@ packages:
   unist-util-visit-children@3.0.0:
     resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
 
-  unist-util-visit-parents@2.1.2:
-    resolution: {integrity: sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==}
-
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
-
-  unist-util-visit@1.4.1:
-    resolution: {integrity: sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==}
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
@@ -4017,10 +3977,6 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/hast@3.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
-
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
@@ -4436,8 +4392,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
-
-  css-selector-parser@3.3.0: {}
 
   css-tree@2.2.1:
     dependencies:
@@ -4932,20 +4886,13 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
-  hast-util-from-selector@3.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      css-selector-parser: 3.3.0
-      devlop: 1.1.0
-      hastscript: 9.0.1
-
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
 
   hast-util-parse-selector@4.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-raw@9.1.0:
     dependencies:
@@ -5041,7 +4988,7 @@ snapshots:
 
   hastscript@9.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
@@ -5320,8 +5267,6 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
-  lodash@4.18.1: {}
-
   loglevel@1.9.2: {}
 
   longest-streak@3.1.0: {}
@@ -5355,20 +5300,6 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
-
-  mdast-util-directive@3.1.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      ccount: 2.0.1
-      devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-      parse-entities: 4.0.2
-      stringify-entities: 4.0.4
-      unist-util-visit-parents: 6.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -5559,16 +5490,6 @@ snapshots:
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
-
-  micromark-extension-directive@4.0.0:
-    dependencies:
-      devlop: 1.1.0
-      micromark-factory-space: 2.0.1
-      micromark-factory-whitespace: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-      parse-entities: 4.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     dependencies:
@@ -6124,15 +6045,6 @@ snapshots:
       hast-util-to-html: 9.0.5
       unified: 11.0.5
 
-  remark-directive@4.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0
-      micromark-extension-directive: 4.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6143,11 +6055,6 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
-
-  remark-heading-id@1.0.1:
-    dependencies:
-      lodash: 4.18.1
-      unist-util-visit: 1.4.1
 
   remark-mdx@3.1.1:
     dependencies:
@@ -6638,8 +6545,6 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
-  unist-util-is@3.0.0: {}
-
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -6670,18 +6575,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  unist-util-visit-parents@2.1.2:
-    dependencies:
-      unist-util-is: 3.0.0
-
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
-
-  unist-util-visit@1.4.1:
-    dependencies:
-      unist-util-visit-parents: 2.1.2
 
   unist-util-visit@5.1.0:
     dependencies:

--- a/src/pages/docs/support/log-files.md
+++ b/src/pages/docs/support/log-files.md
@@ -114,7 +114,9 @@ ${date:universalTime=true:format=yyyy-MM-dd HH\:mm\:ss.ffff}Z
 
 :::div{.hint}
 **Note:** Colons in date format strings must be escaped with a backslash (`\:`) because colons are used as parameter delimiters in NLog layout syntax.
-::: For example, to include the logger name:
+:::
+
+For example, to include the logger name:
 
 ```xml
 <variable name="normalLayout" value="${longdate} ${uppercase:${level}:padding=5} [${logger:shortName=true}] ${message}${onexception:${newline}${exception:format=ToString}}"/>

--- a/src/plugins/satteri-heading-id.js
+++ b/src/plugins/satteri-heading-id.js
@@ -1,0 +1,70 @@
+import { defineMdastPlugin } from 'satteri';
+
+// Explicit heading ids are written `## Title {#custom-id}`, which Sätteri reads
+// natively under `features.headingAttributes` — but only on the Markdown side,
+// and MDX pages have to write the brace escaped (`## Title \{#custom-id}`)
+// because a bare `{` opens an expression there. That leaves three shapes to
+// reconcile against what the unified pipeline used to emit:
+//
+//   .md  `{#id}`   the parser takes the id and the text comes out clean
+//   .md  `\{#id}`  the parser takes the id but leaves the backslash behind
+//   .mdx `\{#id}`  the escape is consumed before the attribute parser runs, so
+//                  no id is taken and `{#id}` is left sitting in the heading
+//
+// Untouched, the last one slugs the braces into the id itself — `AWS {#runbooks-aws}`
+// became `id="aws-runbooks-aws"` — so the id is lifted out of the text here.
+const TRAILING_ID = /\s*\\?\{#([^}\s]+)\}$/;
+
+const NAMED = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+
+// A few legacy ids carry the anchor as a character reference — `{#…can&#39;t…}`.
+// The attribute parser reads the id straight off the source, before references
+// are resolved, so without this the `&` is escaped again on the way out and the
+// anchor renders as a literal `&amp;#39;`.
+function decodeReferences(id) {
+  return id.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/gi, (match, body) => {
+    if (body[0] === '#') {
+      const code =
+        body[1] === 'x' || body[1] === 'X'
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10);
+      return Number.isNaN(code) ? match : String.fromCodePoint(code);
+    }
+    return NAMED[body.toLowerCase()] ?? match;
+  });
+}
+
+export default defineMdastPlugin({
+  name: 'heading-id',
+  heading(node, ctx) {
+    const last = node.children.at(-1);
+    if (last?.type !== 'text') return;
+
+    const parsedId = node.data?.hProperties?.id;
+    if (typeof parsedId === 'string') {
+      const decoded = decodeReferences(parsedId);
+      if (decoded !== parsedId) {
+        ctx.setProperty(node, 'data', {
+          ...node.data,
+          hProperties: { ...node.data.hProperties, id: decoded },
+        });
+      }
+
+      // Only the stray escape is left to clean up. A heading that genuinely
+      // ends in a backslash keeps it, since the parser took no id from it.
+      if (last.value.endsWith('\\')) {
+        ctx.setProperty(last, 'value', last.value.slice(0, -1).trimEnd());
+      }
+      return;
+    }
+
+    const match = last.value.match(TRAILING_ID);
+    if (!match) return;
+
+    ctx.setProperty(last, 'value', last.value.slice(0, match.index).trimEnd());
+    ctx.setProperty(node, 'data', {
+      ...node.data,
+      hProperties: { ...node.data?.hProperties, id: match[1] },
+    });
+  },
+});

--- a/src/plugins/satteri-wbr.js
+++ b/src/plugins/satteri-wbr.js
@@ -1,9 +1,9 @@
-import { visit } from 'unist-util-visit';
+import { defineHastPlugin } from 'satteri';
 
 // Browsers will break a line on a hyphen character, but not on a slash or period.
 // This can cause long strings of text to overflow their container, especially in code blocks.
 
-// This rehype plugin adds <wbr> elements to code blocks to allow for better line breaking in long strings of text.
+// This hast plugin adds <wbr> elements to code blocks to allow for better line breaking in long strings of text.
 const SEPARATORS = /(?=[.\[:\/\\])/;
 
 function withBreaks(value) {
@@ -21,15 +21,18 @@ function withBreaks(value) {
   });
 }
 
-export default function rehypeWbr() {
-  return (tree) => {
-    visit(tree, 'element', (node, index, parent) => {
-      if (node.tagName !== 'code') return;
-      if (parent?.tagName === 'pre') return; // fenced blocks, leave alone
+export default defineHastPlugin({
+  name: 'wbr',
+  element: {
+    filter: ['code'],
+    visit(node, ctx) {
+      if (ctx.parent(node)?.tagName === 'pre') return; // fenced blocks, leave alone
 
-      node.children = node.children.flatMap((child) =>
+      const children = node.children.flatMap((child) =>
         child.type === 'text' ? (withBreaks(child.value) ?? [child]) : [child]
       );
-    });
-  };
-}
+
+      ctx.setProperty(node, 'children', children);
+    },
+  },
+});

--- a/src/themes/octopus/utilities/custom-markdown.mjs
+++ b/src/themes/octopus/utilities/custom-markdown.mjs
@@ -1,12 +1,13 @@
 import { SITE } from '/src/config';
 import { size } from '/src/data/image-size.mjs';
-import { h } from 'hastscript';
-import { visit } from 'unist-util-visit';
-import { fromSelector } from 'hast-util-from-selector';
+import { defineMdastPlugin } from 'satteri';
 import path from 'path';
 import fs from 'fs';
 
-/* Based on https://github.com/remarkjs/remark-directive
+/* Directive syntax is parsed by Sätteri itself, under `features.directive`.
+* The parser produces bare directive nodes with no HTML meaning of their own —
+* rendering them is what attributeMarkdown below is for.
+*
 * Examples:
 
 ## Inline
@@ -89,61 +90,56 @@ export function getImageInfo(src, className, sizes) {
   return info;
 }
 
-/** @type {import('unified').Plugin<[], import('mdast').Root>} */
-export function attributeMarkdown() {
-  return (tree) => {
-    visit(tree, (node) => {
-      if (
-        ['textDirective', 'leafDirective', 'containerDirective'].includes(
-          node.type
-        )
-      ) {
-        const data = node.data || (node.data = {});
-        const hast = h(node.name, node.attributes);
+// A directive's `name` is the tag to render and its `attributes` are already
+// parsed into plain properties (`{.hint}` arrives as `class: 'hint'`), so
+// hanging hName/hProperties off the node is all the conversion needs. Sätteri
+// drops null and undefined properties on the way out, which is what keeps an
+// image with no srcset from emitting an empty attribute.
+function directiveToHtml(node, ctx) {
+  const properties = { ...node.attributes };
 
-        if (hast.properties.src) {
-          // Process the image
-          const info = getImageInfo(
-            hast.properties.src,
-            hast.properties.class,
-            SITE.images.contentSize
-          );
+  if (properties.src) {
+    // Process the image
+    const info = getImageInfo(
+      properties.src,
+      properties.class,
+      SITE.images.contentSize
+    );
 
-          hast.properties.src = info.src;
-          hast.properties.srcset = info.srcset;
-          hast.properties.sizes = info.sizes;
-          hast.properties.class = info.class;
+    properties.src = info.src;
+    properties.srcset = info.srcset;
+    properties.sizes = info.sizes;
+    properties.class = info.class;
 
-          if (info.metadata) {
-            hast.properties.width = info.metadata.width;
-            hast.properties.height = info.metadata.height;
-          }
-        }
+    if (info.metadata) {
+      properties.width = info.metadata.width;
+      properties.height = info.metadata.height;
+    }
+  }
 
-        data.hName = hast.tagName;
-        data.hProperties = hast.properties;
-      }
-    });
-  };
+  ctx.setProperty(node, 'data', {
+    hName: node.name,
+    hProperties: properties,
+  });
 }
 
-/** @type {import('unified').Plugin<[], import('mdast').Root>} */
-export function wrapTables() {
-  return (tree) => {
-    visit(tree, (node, i, parent) => {
-      if (node.type == 'table') {
-        // Create the wrapping element
-        const wrap = fromSelector('div');
-        const data = wrap.data || (wrap.data = {});
-        const props = data.hProperties || (data.hProperties = {});
-        props.className = 'table-wrap';
+export const attributeMarkdown = defineMdastPlugin({
+  name: 'attribute-markdown',
+  textDirective: directiveToHtml,
+  leafDirective: directiveToHtml,
+  containerDirective: directiveToHtml,
+});
 
-        // Add the table to the wrapper
-        wrap.children = [node];
-
-        // Replace the table with the wrapper
-        parent.children[i] = wrap;
-      }
+export const wrapTables = defineMdastPlugin({
+  name: 'wrap-tables',
+  table(node, ctx) {
+    // wrapNode makes the table the wrapper's first child. The wrapper only
+    // exists to carry hName/hProperties, so the node type it is built from
+    // never reaches the output.
+    ctx.wrapNode(node, {
+      type: 'paragraph',
+      data: { hName: 'div', hProperties: { class: 'table-wrap' } },
+      children: [],
     });
-  };
-}
+  },
+});


### PR DESCRIPTION
I wanted to see if it wasn't too difficult to switch from astro's previous `unified` pipeline over to the new `Sätteri` one.
Satteri uses a new Markdown parser written in Rust. It is stricter about some malformed content but will also let invalid HTML pass where unified might have fixed it (e.g. unclosed tags)

More detail at https://danny.is/notes/upgrading-astro-7-switching-satteri/

### Reducing Risk

Claude went through multiple rounds of verification; It built the site and diffed the HTML content of each generated page both before and after. It fixed multiple issues with its first conversion attempt, and then catalogued the remaining small number of differences below for manual verification.

_Note to reviewer: Claude wrote the detail below, except where I have annotated otherwise_

------

Swaps the markdown pipeline from unified (remark/rehype) to Sätteri, the Rust processor Astro 7 ships.

`remark-directive` and `remark-heading-id` are gone — Sätteri parses both natively via `features.directive` and `features.headingAttributes`. The three custom plugins are ported to mdast/hast visitors:

| was | now |
| --- | --- |
| `attributeMarkdown` (remark) | mdast plugin — directive → `hName`/`hProperties` |
| `wrapTables` (remark) | mdast plugin — uses `ctx.wrapNode()` |
| `rehype-wbr.js` | `satteri-wbr.js` — hast plugin, tag-filtered in Rust |

`shiki-code-block.js` is unchanged. Unlike rehype plugins, Sätteri's hast plugins also run over `.mdx`.

Verified by diffing all 2673 built pages against a unified build, parsed with parse5 so entity/whitespace noise doesn't hide anything. 2412 are identical.

Full builds are ~10s faster (about 19%). Alternating runs, `dist` wiped each time, unified pipeline built from a worktree at `abb3dd428` with its own install:

| run | unified | satteri |
| --- | --- | --- |
| 1 | 56.9s | 47.1s |
| 2 | 50.6s | 40.6s |
| 3 | 57.1s | 47.3s |
| 4 | 50.6s | 39.9s |

## Content changes — worth eyeballing on staging

**Fixed — MDX heading anchors were broken.** `.mdx` has to escape the brace (`### AWS \{#runbooks-aws}`) because `{` starts an expression. The escape gets eaten before the attribute parser runs, so the id wasn't picked up and the braces were slugged into it — `id="aws-runbooks-aws"` instead of `id="runbooks-aws"`. 213 headings across 45 files. `satteri-heading-id.js` handles it.

_Orion: I verified the referenced AWS link on the staging site - it appears on the "Samples Instance" page. It's good. We also don't really need to care about URL stability in the hash-fragment portion, so even if this part is wrong it's not a big deal_

**Fixed — double-escaped anchors.** Heading ids containing entities (`{#...Username&amp;Password...}`) rendered as literal `&amp;`. 3 headings.

_Orion: Verified this is OK_

**Fixed — dropped sentence in `support/log-files.md`.** Source had prose on a closing fence (`::: For example, to include the logger name:`). Sätteri discarded it. Fixed the markdown; the hint box now closes properly instead of swallowing the code block below it.

_Orion: Verified this is OK_

**Changed — one anchor.** `#IsolatedOctopusDeployservers-Tentaclecan’tbeinstalled(offlinedeployments)` → `...can't...` (straight apostrophe). The old pipeline decoded `&#39;` then curled it inside the identifier. Deep links to that heading will break.

_Orion: Verified this is OK_

**Changed — `c#` fences now highlight as C#** instead of falling back to plain `c`. One page (`subscriptions/webhook-slack`). `
_Orion: Verified this is OK_

**Changed — ```bash; ` on `projects/variables/prompted-variables` now falls back to plaintext — stray semicolon in the fence, fix the source if you care.

_Orion: Verified this is OK, plaintext looks fine_

**Cosmetic, no action needed:** trailing blank line gone from the end of code blocks (210 pages); table alignment emits `style="text-align:…"` rather than the deprecated `align=` (19 pages, nothing in the CSS targets it); minor smart-punctuation differences — entities like `&#39;`/`&quot;` no longer curl, `alt` text now does, `--` is an en dash rather than em dash (~28 pages).

## Not fixed

`pnpm test` can't start its own server — `astro preview` is a daemon in v7, so Playwright sees the launcher exit and bails. Pre-existing from the Astro 7 upgrade, not this change. Ran the suite against a manually started server: 159/160. The one failure (ArrowDown on a `<select>`) fails on main too.
