### PR TITLE
Optimize breadcrumbs build

### DIFF
--- a/src/lib/page-index.ts
+++ b/src/lib/page-index.ts
@@ -1,0 +1,25 @@
+// Breadcrumbs needs to map a crumb URL back to the page it came from. Doing
+// that with `posts.all().find(...)` is a linear scan of ~2,700 pages per crumb
+// per page, and every probe builds a `new URL` inside `addSlashToAddress` — it
+// measured at ~2.8s of the build. The page set is fixed for the duration of a
+// build, so index it once.
+import accelerator from '@lib/accelerator';
+
+type Page = ReturnType<typeof accelerator.posts.all>[number];
+
+let index: Map<string, Page> | null = null;
+
+export function pageByCrumbUrl(url: string): Page | undefined {
+  if (index === null) {
+    const built = new Map<string, Page>();
+    for (const p of accelerator.posts.all()) {
+      const key = accelerator.urlFormatter.addSlashToAddress(p.url ?? '/');
+      // `.find` returned the first match, so first write wins.
+      if (!built.has(key)) built.set(key, p);
+    }
+    // In dev the page set changes under you, so keep rebuilding.
+    if (import.meta.env.PROD) index = built;
+    return built.get(url);
+  }
+  return index.get(url);
+}

--- a/src/themes/octopus/components/Breadcrumbs.astro
+++ b/src/themes/octopus/components/Breadcrumbs.astro
@@ -1,5 +1,6 @@
 ---
 import { accelerator } from '@lib/accelerator';
+import { pageByCrumbUrl } from '@lib/page-index';
 import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
 import { Translations, Lang } from '@util/Languages';
@@ -34,14 +35,9 @@ const navPages = accelerator.navigation.breadcrumbs(
   breadcrumbs?.length ?? 0
 );
 
-const allPages = accelerator.posts.all();
-
 // Apply crumbTitle from frontmatter if available
 for (let i = 0; i < navPages.length; i++) {
-  const matchingPage = allPages.find((p) => {
-    const pageUrl = accelerator.urlFormatter.addSlashToAddress(p.url ?? '/');
-    return pageUrl === navPages[i].url;
-  });
+  const matchingPage = pageByCrumbUrl(navPages[i].url);
 
   if (matchingPage) {
     const fm = matchingPage.frontmatter as Frontmatter;


### PR DESCRIPTION
In [Cut docs build time by ~70% (3.7x faster)](https://github.com/OctopusDeploy/docs/pull/3258) a significant improvement was made by caching the navigation menu structure. Previously, every page build would read _all the other pages_ to build the nav menu, and then repeat for the next page -- caching lets us build the nav structure one time rather than on every build

It turns out the Breadcrumb functionality suffered from the same problem. Building a breadcrumb required reading all the other pages to find the parent(s), so each page did the work over and over again.

This PR applies a similar caching technique for breadcrumbs. It shaves **13 seconds** off the build time on my mac.

Note: Claude wrote all the code here. The description is mine.

### Reducing Risk:

Claude verified that all generated output files are byte-identical before and after, so we can be confident this change hasn't broken anything.