### PR TITLE
Document removal of deployment targets on EE deprovision

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/index.mdx
@@ -40,7 +40,7 @@ You select the target type when you add it to Octopus. Based on the type, you'll
 
 ## Environment scoping
 
-Deployment targets must be associated with at least one environment. While a deployment target is associated with a long-lived environment or [parent environment](/docs/infrastructure/ephemeral-environments#scoping-variables-deployment-targets-and-accounts), Octopus will prevent that environment from being deleted.
+Deployment targets must be associated with at least one environment. While a deployment target is associated with a [long-lived environment](/docs/infrastructure/environments) or [parent environment](/docs/infrastructure/ephemeral-environments#scoping-variables-deployment-targets-and-accounts), Octopus will prevent that environment from being deleted.
 
 In the case where a deployment target is associated with an [ephemeral environment](/docs/infrastructure/ephemeral-environments), the association will be removed when the ephemeral environment deprovisions. If a target has no remaining environments, it will also be automatically deleted.
 

--- a/src/pages/docs/infrastructure/deployment-targets/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/index.mdx
@@ -12,6 +12,7 @@ import DeploymentTargets from "src/shared-content/infrastructure/deployment-targ
 import TargetRoles from "src/shared-content/infrastructure/target-roles.include.md";
 
 Locations that software may be deployed to and run can include:
+
 - Containers running in clusters
 - Cloud-managed services, platforms, or serverless functions
 - Virtual machines or infrastructure as a service
@@ -19,9 +20,10 @@ Locations that software may be deployed to and run can include:
 - Point-of-sale devices in retail stores
 - Medical devices in hospitals
 
-All these places are different kinds of deployment targets. 
+All these places are different kinds of deployment targets.
 
-A deployment target is a location that will host your software. We've used the term _deployment target_ as this could refer to many different destinations, such as:
+A deployment target is a location that will host your software. We've used the term *deployment target* as this could refer to many different destinations, such as:
+
 - Kubernetes clusters
 - Cloud apps or services
 - Cloud storage
@@ -43,5 +45,6 @@ Deployment targets must be associated with at least one environment. While a dep
 In the case where a deployment target is associated with an [ephemeral environment](/docs/infrastructure/ephemeral-environments), the association will be removed when the ephemeral environment deprovisions. If a target has no remaining environments, it will also be automatically deleted.
 
 ## Learn more
+
 - [How Octopus counts deployment targets](/docs/infrastructure/deployment-targets/how-octopus-counts-deployment-targets)
 - [Adding deployment targets](/docs/getting-started/first-deployment/add-deployment-targets)

--- a/src/pages/docs/infrastructure/deployment-targets/index.mdx
+++ b/src/pages/docs/infrastructure/deployment-targets/index.mdx
@@ -36,6 +36,12 @@ Deployments to Kubernetes clusters are performed by a lightweight agent that run
 
 You select the target type when you add it to Octopus. Based on the type, you'll be prompted to set up the appropriate connection using a simple form.
 
+## Environment scoping
+
+Deployment targets must be associated with at least one environment. While a deployment target is associated with a long-lived environment or [parent environment](/docs/infrastructure/ephemeral-environments#scoping-variables-deployment-targets-and-accounts), Octopus will prevent that environment from being deleted.
+
+In the case where a deployment target is associated with an [ephemeral environment](/docs/infrastructure/ephemeral-environments), the association will be removed when the ephemeral environment deprovisions. If a target has no remaining environments, it will also be automatically deleted.
+
 ## Learn more
 - [How Octopus counts deployment targets](/docs/infrastructure/deployment-targets/how-octopus-counts-deployment-targets)
 - [Adding deployment targets](/docs/getting-started/first-deployment/add-deployment-targets)

--- a/src/pages/docs/infrastructure/ephemeral-environments/index.md
+++ b/src/pages/docs/infrastructure/ephemeral-environments/index.md
@@ -37,6 +37,10 @@ Parent environments can be selected alongside existing long-lived environments i
 - Project variables
 - User roles assigned to teams
 
+:::div{.info}
+Support for scoping deployment targets directly to ephemeral environments is rolling out to Octopus Cloud and will be available in Octopus Server `2026.3`.
+:::
+
 ## Availability
 
 Ephemeral environments are available to all cloud and self-hosted customers from version `2025.4`.

--- a/src/pages/docs/projects/ephemeral-environments/index.md
+++ b/src/pages/docs/projects/ephemeral-environments/index.md
@@ -172,6 +172,10 @@ When an ephemeral environment is no longer needed it can be deprovisioned and an
 - For projects using runbooks stored in Octopus the published snapshot will be used to run the runbook.
 - For projects using runbooks stored in version control, the Git reference used to provision the environment will be used to run the runbook.
 
+:::div{.info}
+When an ephemeral environment is deprovisioned, it will automatically be removed from any associated deployment targets. If there are no environments remaining on a target, the target will also be deleted.
+:::
+
 Ephemeral environments can be deprovisioned via the:
 
 - Octopus Web Portal


### PR DESCRIPTION
## What's this? ⛵ 

We are adding support for scoping deployment targets to ephemeral environments, matching the existing functionality available for other environment types. As part of this, we have included automatic clean-up of deployment targets scoped to a deprovisioning ephemeral environment, so that no targets exist without an associated ephemeral environment.

This PR adds docs to make customers aware that: 
- Deployment targets scoped to a deprovisioning ephemeral environment will lose their scoping to that ephemeral environment.
- If a target is no longer scoped to any environment, it will be automatically deleted.

## What's it look like?

### 🔗 [Deployment targets page](https://stoctodocspr3374.z22.web.core.windows.net/docs/infrastructure/deployment-targets)
<img width="1001" height="345" alt="image" src="https://github.com/user-attachments/assets/e9b72b04-f54b-4d47-aacc-5cac46663596" />

### 🔗 [Ephemeral environments page](https://stoctodocspr3374.z22.web.core.windows.net/docs/projects/ephemeral-environments#deprovisioning-an-environment)
<img width="938" height="371" alt="image" src="https://github.com/user-attachments/assets/b082fa26-a73a-45ff-b98b-aa3d762b5c17" />

Part of BMBB-814