### PR TITLE
Tweak new top nav so it's closer to production viable

### DIFF
--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -16,7 +16,7 @@ const {
   showSearch = true,
   links = [
     { label: 'Docs', href: '/docs' },
-    { label: 'Learn', href: '#' }, // TODO: Make this a real link
+    // TODO: { label: 'Learn', href: '/docs/?' },
     { label: 'API', href: '/docs/octopus-rest-api' },
     { label: 'CLI', href: '/docs/octopus-rest-api/cli' },
   ],
@@ -65,8 +65,6 @@ const signInHref = `${SITE.url}/signin?ReturnUrl=${encodeURIComponent(Astro.url.
       data-tooltip-position="bottom"
       data-theme-toggle-button
     />
-    <!-- TODO: Make this a real link -->
-    <Button label="Changelog" href="#" />
     <Button label="Sign in" href={signInHref} data-signed-out-only />
     <Button
       label="Start for free"

--- a/src/components/TopNavSearch.astro
+++ b/src/components/TopNavSearch.astro
@@ -39,7 +39,7 @@ const siteUrl = Astro.site ? Astro.site.href : '';
         autocomplete="off"
         data-docs-search-trigger
       />
-      <kbd class="top-nav-search__shortcut" aria-hidden="true">^K</kbd>
+      <kbd class="top-nav-search__shortcut" aria-hidden="true">Ctrl+K</kbd>
     </fieldset>
   </form>
 </div>
@@ -68,6 +68,7 @@ const siteUrl = Astro.site ? Astro.site.href : '';
   .top-nav-search__field.site-search {
     box-sizing: border-box;
     height: auto;
+    overflow: hidden;
     border: var(--borderWidth1) solid var(--colorBorderPrimary);
     border-radius: var(--borderRadiusSmall);
     background: var(--colorBackgroundPrimaryDefault);

--- a/tests/topnav-signedin.spec.ts
+++ b/tests/topnav-signedin.spec.ts
@@ -47,7 +47,9 @@ test.describe('top nav signed-in state', () => {
     await expect(
       page.locator(trailing).getByText('Start for free')
     ).toBeHidden();
-    await expect(page.locator(trailing).getByText('Changelog')).toBeVisible();
+    await expect(
+      page.locator(`${trailing} [data-theme-toggle-button]`)
+    ).toBeVisible();
 
     await expect(page.locator(avatar)).toBeVisible();
     await expect(page.locator(`${avatar} [data-user-initials]`)).toHaveText(


### PR DESCRIPTION
# Summary

- Remove `Learn` temporarily as it has nowhere to point to yet
- Remove the `Changelog` button, we're not including this (at least for now)
- Remove "Ask a question or " from the search placeholder so it now only reads "Search the docs…", as it has no AI / LLM capabilities
- Show `Ctrl+K` as the hotkey hint for focusing the search bar on non-Apple platforms (replacing `^K` placeholder)

# Results

See it in action at: https://stoctodocspr3375.z22.web.core.windows.net/docs?newnav

## Before

<img width="1853" height="66" alt="image" src="https://github.com/user-attachments/assets/6954478a-af34-479e-b165-e3ec3ebdf9c9" />

## After

<img width="1853" height="66" alt="image" src="https://github.com/user-attachments/assets/98b7c925-03ed-4553-9d0c-994aefccb669" />
