### PR TITLE
Document environment state limits

### DIFF
--- a/src/pages/docs/infrastructure/environments/environment-state.md
+++ b/src/pages/docs/infrastructure/environments/environment-state.md
@@ -12,7 +12,7 @@ Environment state lets a deployment or [runbook](/docs/runbooks) run save key/va
 
 Environment state is useful in scenarios where a value produced during one run needs to be reused later. A common example is provisioning and deprovisioning [ephemeral environments](/docs/infrastructure/ephemeral-environments). A provisioning runbook might create a Kubernetes namespace or an application URL that later deployments and the deprovisioning runbook depend on. Recording each value as environment state means Octopus stores it once, so every later run reads it directly instead of re-deriving the value.
 
-Each state entry is scoped to project, environment, and optionally a tenant, so state isn't shared with other projects, environments, or tenants. Setting an entry with a key that already exists for the same project, environment, and tenant overwrites the previous value.
+Each state entry is scoped to project, environment, and optionally a tenant, so state isn't shared with other projects, environments, or tenants. Setting an entry with a key that already exists for the same project, environment, and tenant overwrites the previous value. Keys are case insensitive.
 
 ## Setting environment state
 
@@ -137,7 +137,7 @@ Use [Octopus variable logging](/docs/support/how-to-turn-on-variable-logging-and
 
 ## Deleting environment state
 
-If a project, environment, and tenant combination has hit the limit above, delete entries you no longer need to make room for new ones. Deleting is API-only.
+If a project, environment, and tenant combination has hit the limit above, delete entries you no longer need to make room for new ones. This function is only available via the HTTP API.
 
 For environment state scoped to a project and environment:
 

--- a/src/pages/docs/infrastructure/environments/environment-state.md
+++ b/src/pages/docs/infrastructure/environments/environment-state.md
@@ -124,6 +124,35 @@ The response is an array of name and URL pairs:
 ]
 ```
 
+## Limits on environment state
+
+Up to 10 environment state entries can be created for each combination of project, environment and optional tenant.
+
+- Maximum key length is 100 characters
+- Maximum value length is 1000 characters
+
+If any of these limits are exceeded during a deployment or runbook run, the task will fail with an error message explaining how the limit was hit.
+
+Use [Octopus variable logging](/docs/support/how-to-turn-on-variable-logging-and-export-the-task-log) to check if you are nearing your maximum number of environment state entries.
+
+## Deleting environment state
+
+If a project, environment, and tenant combination has hit the limit above, delete entries you no longer need to make room for new ones. Deleting is API-only.
+
+For environment state scoped to a project and environment:
+
+```text
+DELETE /api/spaces/{spaceId}/projects/{projectId}/environments/{environmentId}/untenanted/states/{key}
+```
+
+For environment state scoped to a project, environment and tenant:
+
+```text
+DELETE /api/spaces/{spaceId}/projects/{projectId}/environments/{environmentId}/tenants/{tenantId}/states/{key}
+```
+
+Use [Octopus variable logging](/docs/support/how-to-turn-on-variable-logging-and-export-the-task-log) to get a list of environment state keys for a project, environment, and optional tenant scope.
+
 ## Availability
 
 Environment state is rolling out to Octopus Cloud, and will be available to self-hosted customers from version `2026.3`.


### PR DESCRIPTION
## What's this? ⛵ 

The PR updates our environment state documentation to include information on: 
- Limits to environment state length and number of entries.
- How to delete environment state entries.

See a preview [here](https://stoctodocspr3378.z22.web.core.windows.net/docs/infrastructure/environments/environment-state#limits-on-environment-state). 

- [x] TODO - Before merging, check that these docs align with the final version of https://github.com/OctopusDeploy/OctopusDeploy/pull/46429
- [x] TODO - Before merging, check that docs align with the outcome of our conversations on printing keys on task failures. 

## What's it look like?

<img width="637" height="617" alt="image" src="https://github.com/user-attachments/assets/692efc69-72a5-4c30-9100-9d079e1d8351" />

Completes BMBB-815