### PR TITLE
Fix macOS check when assigning cmd/ctrl+K keybind

### DIFF
--- a/src/scripts/docs-search.ts
+++ b/src/scripts/docs-search.ts
@@ -316,10 +316,10 @@ function setup(dialog: HTMLDialogElement) {
   if (name !== SITE_SEARCH) return;
 
   // Cmd+K on Apple platforms, Ctrl+K everywhere else.
-  const platform =
-    (navigator as Navigator & { userAgentData?: { platform: string } })
-      .userAgentData?.platform ?? navigator.platform;
-  const isApple = /Mac|iPhone|iPad/.test(platform || navigator.userAgent);
+  const navigator = (window.navigator as Navigator & { userAgentData?: { platform: string } });
+  const isApple = navigator.userAgentData
+    ? navigator.userAgentData.platform === 'macOS'
+    : (navigator.platform || navigator.userAgent).includes('Mac');
 
   document.addEventListener('keydown', (event) => {
     if (event.key.toLowerCase() !== 'k') return;


### PR DESCRIPTION
Prior to #3369 there was a single macOS check which was used both for visually displaying a `⌘K` to indicate that shortcut would focus the search bar, and assigning a `keydown` listener for that key combination.

https://github.com/OctopusDeploy/docs/blame/a530d440d6627449c113e4c670097ebe548c2f33/src/components/TopNavSearch.astro#L104-L106

#3369 added a second, different check, which doesn't work in Chrome. In that browser `⌘K` still displays, but you have to press Ctrl+K due to the check failing. This PR changes that second check to match the one that's used to display the key combination so it works in Chrome again.