### PR TITLE
Ensure top right state is correct on initial render

### DIFF
--- a/src/components/ProfileMenu.astro
+++ b/src/components/ProfileMenu.astro
@@ -93,10 +93,6 @@ const items: MenuItem[] = [
     display: flex;
   }
 
-  .profile-menu[hidden] {
-    display: none;
-  }
-
   .profile-menu__trigger {
     display: flex;
     border-radius: var(--borderRadiusCircle);

--- a/src/components/TopNav.astro
+++ b/src/components/TopNav.astro
@@ -102,12 +102,12 @@ const sectionItems: MenuItem[] = links.map(({ label, href }) => ({
       <div class="top-nav__drawer-theme">
         <span class="top-nav__drawer-theme-label">Theme</span>
         <Button
-          icon="theme-switcher__moon_icon"
+          icon="top-nav__theme-icon"
           aria-label="Toggle theme"
           data-theme-toggle-button
         />
       </div>
-      <div class="top-nav__drawer-profile" data-signed-in-only hidden>
+      <div class="top-nav__drawer-profile" data-signed-in-only>
         <ProfileMenu inline />
       </div>
     </div>
@@ -115,7 +115,7 @@ const sectionItems: MenuItem[] = links.map(({ label, href }) => ({
 
   <div class="top-nav__trailing">
     <Button
-      icon="theme-switcher__moon_icon"
+      icon="top-nav__theme-icon"
       aria-label="Toggle theme"
       data-tooltip="Toggle theme"
       data-tooltip-position="bottom"
@@ -128,7 +128,7 @@ const sectionItems: MenuItem[] = links.map(({ label, href }) => ({
       importance="loud"
       data-signed-out-only
     />
-    <ProfileMenu data-signed-in-only hidden />
+    <ProfileMenu data-signed-in-only />
     <Button
       class="top-nav__drawer-toggle"
       icon="top-nav__bars-icon"
@@ -380,10 +380,6 @@ const sectionItems: MenuItem[] = links.map(({ label, href }) => ({
     .top-nav__drawer-actions {
       display: flex;
       gap: var(--space12);
-    }
-
-    .top-nav__drawer-actions[hidden] {
-      display: none;
     }
 
     .top-nav__drawer-actions :global(.btn) {

--- a/src/layouts/Api.astro
+++ b/src/layouts/Api.astro
@@ -63,7 +63,13 @@ const showSearch = !isSearchPage;
 const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
 ---
 
-<html dir={textDirection} lang={lang} class="initial" data-theme="light">
+<html
+  dir={textDirection}
+  lang={lang}
+  class="initial"
+  data-theme="light"
+  data-signed-in="false"
+>
   <Head
     frontmatter={frontmatter}
     headings={headings}

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -61,7 +61,13 @@ const showSearch = !isSearchPage;
 const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
 ---
 
-<html dir={textDirection} lang={lang} class="initial" data-theme="light">
+<html
+  dir={textDirection}
+  lang={lang}
+  class="initial"
+  data-theme="light"
+  data-signed-in="false"
+>
   <Head
     frontmatter={frontmatter}
     headings={headings}

--- a/src/lib/signedInUser.ts
+++ b/src/lib/signedInUser.ts
@@ -1,5 +1,6 @@
 export const USER_COOKIE = 'OctopusSignedInUser';
 export const USER_CHANGED_EVENT = 'octopus:user-changed';
+export const SIGNED_IN_ATTRIBUTE = 'data-signed-in';
 
 export type SignedInUser = {
   email?: string;

--- a/src/scripts/signed-in-user.ts
+++ b/src/scripts/signed-in-user.ts
@@ -2,6 +2,7 @@ import {
   getSignedInUser,
   addSignedInUserChangedListener,
   safeImageUrl,
+  SIGNED_IN_ATTRIBUTE,
   type SignedInUser,
 } from '../lib/signedInUser';
 import {
@@ -11,8 +12,6 @@ import {
 } from '../lib/avatar';
 import { setAvatarImage } from './avatar';
 
-const SIGNED_OUT_ONLY_SELECTOR = '[data-signed-out-only]';
-const SIGNED_IN_ONLY_SELECTOR = '[data-signed-in-only]';
 const USER_AVATAR_SELECTOR = '[data-user-avatar]';
 const USER_INITIALS_SELECTOR = '[data-user-initials]';
 const USER_DETAILS_SELECTOR = '[data-user-details]';
@@ -28,17 +27,13 @@ function avatarSize(avatar: HTMLElement) {
   return isAvatarSize(size) ? size : 'medium';
 }
 
-function toggle(selector: string, hidden: boolean) {
-  document.querySelectorAll<HTMLElement>(selector).forEach((el) => {
-    el.hidden = hidden;
-  });
-}
-
 function apply() {
   const user = getSignedInUser();
 
-  toggle(SIGNED_OUT_ONLY_SELECTOR, user !== null);
-  toggle(SIGNED_IN_ONLY_SELECTOR, user === null);
+  document.documentElement.setAttribute(
+    SIGNED_IN_ATTRIBUTE,
+    user === null ? 'false' : 'true'
+  );
 
   if (user) {
     const name = displayName(user);

--- a/src/scripts/theme-switcher.ts
+++ b/src/scripts/theme-switcher.ts
@@ -14,12 +14,6 @@ import {
 const TRANSITION_MS = 300;
 
 const BUTTON_SELECTOR = '[data-theme-toggle-button]';
-const BUTTON_ICON_SELECTOR = '.btn__icon';
-
-const BUTTON_ICON_CLASSES: Record<Theme, string> = {
-  light: 'theme-switcher__moon_icon',
-  dark: 'theme-switcher__sun_icon',
-};
 
 const root = document.documentElement;
 const darkQuery = window.matchMedia(COLOR_SCHEME_QUERY);
@@ -60,16 +54,6 @@ function currentTheme(): Theme {
   return root.getAttribute(THEME_ATTRIBUTE) === 'dark' ? 'dark' : 'light';
 }
 
-function syncControls(theme: Theme) {
-  buttons().forEach((button) => {
-    const icon = button.querySelector(BUTTON_ICON_SELECTOR);
-    icon?.classList.remove(
-      BUTTON_ICON_CLASSES[theme === 'dark' ? 'light' : 'dark']
-    );
-    icon?.classList.add(BUTTON_ICON_CLASSES[theme]);
-  });
-}
-
 let transitionTimer: ReturnType<typeof setTimeout> | undefined;
 
 function markTransition() {
@@ -86,7 +70,6 @@ function apply(preference: ThemePreference) {
   if (theme !== currentTheme()) markTransition();
   root.setAttribute(THEME_ATTRIBUTE, theme);
   root.setAttribute(THEME_PREFERENCE_ATTRIBUTE, preference);
-  syncControls(theme);
   root.dispatchEvent(
     new CustomEvent(THEME_CHANGE_EVENT, { detail: { theme, preference } })
   );
@@ -103,10 +86,6 @@ export function getTheme(): Theme {
 }
 
 function bind() {
-  // The inline head script already set the attribute; mirror it onto every
-  // control rather than re-deriving it, so all switchers agree from paint one.
-  syncControls(currentTheme());
-
   buttons().forEach((button) => {
     if (button.dataset.themeBound) return;
     button.dataset.themeBound = 'true';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -715,14 +715,21 @@ nav.skip-links a:focus {
   width: auto;
 }
 
-.theme-switcher__moon_icon {
+.top-nav__theme-icon {
   background-color: var(--colorIconPrimary);
+}
+
+html[data-theme='light'] .top-nav__theme-icon {
   mask: url('../assets/icons/moon.svg') center / contain no-repeat;
 }
 
-.theme-switcher__sun_icon {
-  background-color: var(--colorIconPrimary);
+html[data-theme='dark'] .top-nav__theme-icon {
   mask: url('../assets/icons/sun.svg') center / contain no-repeat;
+}
+
+html[data-signed-in='true'] [data-signed-out-only],
+html[data-signed-in='false'] [data-signed-in-only] {
+  display: none;
 }
 
 .docs-home {

--- a/src/themes/octopus/components/HtmlHead.astro
+++ b/src/themes/octopus/components/HtmlHead.astro
@@ -6,6 +6,7 @@ import { getEligibleSlugs } from '@util/mdxContent';
 import JsonLd from '@components/JsonLd.astro';
 import type { Crumb } from '@util/breadcrumbs';
 import ThemeScript from '@components/ThemeScript.astro';
+import SignedInScript from '@components/SignedInScript.astro';
 
 // Design tokens as CSS custom properties. globals and textTheme apply at :root;
 // lightTheme and darkTheme are selected by the data-theme attribute on <html> -
@@ -75,6 +76,7 @@ stats.stop();
 <head>
   <meta charset="utf-8" />
   <ThemeScript />
+  <SignedInScript />
   <title>{title}</title>
   <meta name="robots" content={'max-image-preview:large, ' + robots} />
   <meta name="keywords" content={frontmatter.keywords} />

--- a/src/themes/octopus/components/SignedInScript.astro
+++ b/src/themes/octopus/components/SignedInScript.astro
@@ -1,0 +1,29 @@
+---
+import { SIGNED_IN_ATTRIBUTE, USER_COOKIE } from 'src/lib/signedInUser';
+---
+
+<script define:vars={{ SIGNED_IN_ATTRIBUTE, USER_COOKIE }}>
+  (() => {
+    let signedIn = false;
+
+    try {
+      const match = document.cookie.match(
+        new RegExp(`(^|;\\s*)${USER_COOKIE}=([^;]+)`)
+      );
+
+      if (match) {
+        const user = JSON.parse(decodeURIComponent(match[2]));
+        const hasEmail =
+          typeof user?.email === 'string' && user.email.length > 0;
+        const hasName =
+          typeof user?.fullName === 'string' && user.fullName.length > 0;
+        signedIn = hasEmail || hasName;
+      }
+    } catch {}
+
+    document.documentElement.setAttribute(
+      SIGNED_IN_ATTRIBUTE,
+      signedIn ? 'true' : 'false'
+    );
+  })();
+</script>

--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { readFileSync } from 'node:fs';
 
 const home = '/docs/';
 const otherPage = '/docs/getting-started/';
@@ -19,9 +20,19 @@ function expectPreference(page: Page, value: string) {
   );
 }
 
-function expectToggleOffers(page: Page, theme: string) {
-  return expect(page.locator(toggleIcon)).toHaveClass(
-    new RegExp(`theme-switcher__${theme === 'dark' ? 'moon' : 'sun'}_icon`)
+function iconMask(name: 'moon' | 'sun') {
+  const svg = readFileSync(
+    new URL(`../src/assets/icons/${name}.svg`, import.meta.url),
+    'utf8'
+  );
+  const outline = svg.match(/ d="([^"]+)"/)![1].slice(0, 24);
+  return outline.replace(/ /g, '%20').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function expectToggleOffers(page: Page, theme: string, icon = toggleIcon) {
+  return expect(page.locator(icon)).toHaveCSS(
+    'mask-image',
+    new RegExp(iconMask(theme === 'dark' ? 'moon' : 'sun'))
   );
 }
 
@@ -86,9 +97,19 @@ test.describe('theme', () => {
       await expectTheme(page, 'dark');
       await expectToggleOffers(page, 'light');
       // The drawer's toggle is the one used when the page narrows.
-      await expect(page.locator(drawerToggleIcon)).toHaveClass(
-        /theme-switcher__sun_icon/
-      );
+      await expectToggleOffers(page, 'light', drawerToggleIcon);
+    });
+  });
+
+  test.describe('before the deferred scripts load', () => {
+    test.use({ colorScheme: 'dark' });
+
+    test('the toggle already shows the resolved theme', async ({ page }) => {
+      await page.route('**/_astro/*.js', (route) => route.abort());
+      await page.goto(home);
+
+      await expectTheme(page, 'dark');
+      await expectToggleOffers(page, 'light');
     });
   });
 

--- a/tests/topnav-signedin.spec.ts
+++ b/tests/topnav-signedin.spec.ts
@@ -33,6 +33,24 @@ test.describe('top nav signed-in state', () => {
     await expect(page.locator(avatar)).toBeHidden();
   });
 
+  test('shows the signed-in state before the deferred scripts load', async ({
+    page,
+    baseURL,
+  }) => {
+    await signIn(page, baseURL, {
+      fullName: 'John Doe',
+      email: 'jd@example.com',
+    });
+    await page.route('**/_astro/*.js', (route) => route.abort());
+    await page.goto(docsPage);
+
+    await expect(page.locator(avatar)).toBeVisible();
+    await expect(page.locator(trailing).getByText('Sign in')).toBeHidden();
+    await expect(
+      page.locator(trailing).getByText('Start for free')
+    ).toBeHidden();
+  });
+
   test('swaps those buttons for an initials avatar when signed in', async ({
     page,
     baseURL,
@@ -55,10 +73,7 @@ test.describe('top nav signed-in state', () => {
     await expect(page.locator(`${avatar} [data-user-initials]`)).toHaveText(
       'JD'
     );
-    await expect(page.locator(avatar)).toHaveAttribute(
-      'title',
-      'John Doe'
-    );
+    await expect(page.locator(avatar)).toHaveAttribute('title', 'John Doe');
   });
 
   test('takes the first two characters of a single-word name', async ({


### PR DESCRIPTION
# Summary

The initial state of the elements in the top-right of the new nav bar (theme switcher, sign-in buttons or avatar) was always initially rendered in the light theme + signed-out state. As soon as the theme and the signed-in state was known, it would change to the correct state.

This manifested as a visible flicker that could be annoying/distracting.

This ensures the appropriate scripts to determine the theme and signed-in state run ASAP synchronously, before the browser even gets to the point of rendering these elements, such that they're always rendered in the correct state immediately and never change.


# Results

Test it out at https://stoctodocspr3388.z22.web.core.windows.net/docs; navigate between a few pages in dark mode and observe that the top right should never show the moon icon to change to the dark theme, it should always show the sun icon indicating it's currently in dark mode.

Same deal with the signed-in state. Note that this isn't _quite_ perfect as the initials/avatar image do not load synchronously, so they can flicker into existence, but the scope of this PR is just that the _Sign in_ and _Start for free_ buttons **should never appear when signed in**. It can be tested with:

```js
document.cookie = 'OctopusSignedInUser=' + encodeURIComponent(JSON.stringify({fullName: 'John Doe', email: 'jd@example.com'})) + ';path=/';
window.dispatchEvent(new CustomEvent('octopus:user-changed'));
```

Undo:
```js
document.cookie = 'OctopusSignedInUser=;path=/;max-age=0';
window.dispatchEvent(new CustomEvent('octopus:user-changed'));
```