### PR TITLE
Keep crawler submissions out of the feedback responses

### DIFF
--- a/src/scripts/modules/feedback.js
+++ b/src/scripts/modules/feedback.js
@@ -8,6 +8,22 @@ import {
 } from './feedback-form.js';
 
 /**
+ * Crawlers walk the docs on every environment and work each control they find,
+ * and their submissions land among the readers' in the same responses. Two
+ * things separate them from someone reading the page: a click a script
+ * dispatched carries `isTrusted` false, and a browser being driven says so on
+ * `navigator.webdriver`, which the scanners running headless Chrome set as
+ * surely as our own Playwright run does. Neither is proof and a determined
+ * crawler defeats both, so this thins the noise rather than sealing anything.
+ *
+ * @param {Event} event
+ * @returns {boolean}
+ */
+function automated(event) {
+  return navigator.webdriver === true || !event.isTrusted;
+}
+
+/**
  * Google Forms sends no CORS headers, so the POST has to go out as no-cors and
  * the response comes back opaque. There is no way to read whether the form
  * accepted it - a rejected submission looks identical to an accepted one, so
@@ -31,17 +47,43 @@ async function submit(page, rating, comment) {
 }
 
 /**
+ * The fragment is worth keeping - it says which section the reader had open -
+ * but it is also the one part of the address that arrives verbatim from
+ * whatever link was followed, and scanners crawl the docs appending prototype
+ * pollution probes to it. Those probes ended up in the responses. Rather than
+ * guess at which characters are junk, the fragment is kept only when it names
+ * something on the page, which the legacy anchors carrying brackets, question
+ * marks and emoji still do.
+ *
+ * @returns {string}
+ */
+function anchor() {
+  const { hash } = window.location;
+  if (hash.length < 2) return '';
+
+  let id;
+  try {
+    id = decodeURIComponent(hash.slice(1));
+  } catch {
+    // A half-written escape sequence, so nothing a heading would answer to.
+    return '';
+  }
+
+  return document.getElementById(id) ? hash : '';
+}
+
+/**
  * The title alone is ambiguous - "Overview" and "Prerequisites" repeat across
  * the docs - and the URL alone is unreadable in a spreadsheet, so the field
- * carries both. The hash says which section was open. The query string is
- * dropped, as campaign parameters say nothing about the page.
+ * carries both. The query string is dropped, as campaign parameters say
+ * nothing about the page.
  *
  * @param {string} title
  * @returns {string}
  */
 function pageLabel(title) {
-  const { origin, pathname, hash } = window.location;
-  const url = `${origin}${pathname}${hash}`;
+  const { origin, pathname } = window.location;
+  const url = `${origin}${pathname}${anchor()}`;
 
   return title ? `${title} - ${url}` : url;
 }
@@ -65,7 +107,7 @@ class Feedback {
     this.votes.forEach((button) => {
       button.addEventListener('click', () => this.vote(button));
     });
-    this.send.addEventListener('click', () => this.submit());
+    this.send.addEventListener('click', (event) => this.submit(event));
   }
 
   /** @param {HTMLElement} chosen */
@@ -77,8 +119,17 @@ class Feedback {
     this.comment.hidden = false;
   }
 
-  async submit() {
+  /** @param {Event} event */
+  async submit(event) {
     if (!this.rating) return;
+
+    // Answered the same way a reader's click is, so a crawler finds nothing to
+    // work around and a run of the test suite still exercises the whole widget.
+    if (automated(event)) {
+      console.info('[feedback] automated click, nothing sent');
+      this.thank();
+      return;
+    }
 
     // Guards against a second submission while the first is in flight.
     this.send.setAttribute('disabled', '');
@@ -96,6 +147,10 @@ class Feedback {
       return;
     }
 
+    this.thank();
+  }
+
+  thank() {
     this.root.querySelectorAll('.feedback__vote, .feedback__comment').forEach(
       /** @param {Element} el */ (el) => {
         /** @type {HTMLElement} */ (el).hidden = true;

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
   FIELD_COMMENT,
   FIELD_PAGE,
@@ -8,12 +8,41 @@ import {
 } from '../src/scripts/modules/feedback-form.js';
 
 const PAGE = '/docs/kubernetes/steps/kustomize';
+const ANCHOR = '#recommended-step-usages';
+const SCANNER_HASH =
+  '#__proto__%5Bsssied%5D=sssieda&x.__proto__.sssied=sssiede';
+
+/**
+ * Playwright drives a real browser, so `navigator.webdriver` is true and the
+ * widget takes every test click for a crawler's. The tests below are about
+ * what a reader gets, so they put a reader's browser back.
+ */
+async function asReader(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', {
+      get: () => undefined,
+      configurable: true,
+    });
+  });
+}
+
+/** Captures the body of the submission, or leaves it null if none goes out. */
+async function catchSubmission(page: Page) {
+  const sent = { body: null as string | null };
+  await page.route('**/docs.google.com/**', (route) => {
+    sent.body = route.request().postData();
+    return route.fulfill({ status: 200, body: '' });
+  });
+
+  return sent;
+}
 
 test.describe('feedback widget', () => {
   test.beforeEach(async ({ page }) => {
-    // Blocked for every test, so no run can post to the live form. The success
-    // case below overrides this: Playwright matches the newest route first.
+    // Blocked for every test, so no run can post to the live form. The cases
+    // below override this: Playwright matches the newest route first.
     await page.route('**/docs.google.com/**', (route) => route.abort());
+    await asReader(page);
     await page.goto(PAGE);
   });
 
@@ -50,9 +79,7 @@ test.describe('feedback widget', () => {
   test('thanks the reader once the submission has gone out', async ({
     page,
   }) => {
-    await page.route('**/docs.google.com/**', (route) =>
-      route.fulfill({ status: 200, body: '' })
-    );
+    await catchSubmission(page);
 
     await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
     await page.locator('[data-feedback-send]').click();
@@ -64,25 +91,80 @@ test.describe('feedback widget', () => {
 
   test('sends the page title and url, the rating and the comment', async ({
     page,
+    baseURL,
   }) => {
-    /** @type {string | null} */
-    let body = null;
-    await page.route('**/docs.google.com/**', (route) => {
-      body = route.request().postData();
-      return route.fulfill({ status: 200, body: '' });
-    });
+    const sent = await catchSubmission(page);
 
     await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
     await page.locator('.feedback__textarea').fill('the kustomize page');
     await page.locator('[data-feedback-send]').click();
     await expect(page.locator('.feedback__thanks')).toBeVisible();
 
-    const sent = new URLSearchParams(body ?? '');
-    expect(sent.get(FIELD_PAGE)).toBe(
-      `Deploy with Kustomize - http://localhost:3000${PAGE}`
+    const body = new URLSearchParams(sent.body ?? '');
+    expect(body.get(FIELD_PAGE)).toBe(
+      `Deploy with Kustomize - ${baseURL}${PAGE}`
     );
-    expect(sent.get(FIELD_RATING)).toBe(RATING_YES);
-    expect(sent.get(FIELD_COMMENT)).toBe('the kustomize page');
+    expect(body.get(FIELD_RATING)).toBe(RATING_YES);
+    expect(body.get(FIELD_COMMENT)).toBe('the kustomize page');
+  });
+
+  test('keeps a fragment that names a section', async ({ page, baseURL }) => {
+    const sent = await catchSubmission(page);
+    await page.goto(`${PAGE}${ANCHOR}`);
+
+    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    await page.locator('[data-feedback-send]').click();
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+
+    expect(new URLSearchParams(sent.body ?? '').get(FIELD_PAGE)).toBe(
+      `Deploy with Kustomize - ${baseURL}${PAGE}${ANCHOR}`
+    );
+  });
+
+  test('drops a fragment that names nothing on the page', async ({
+    page,
+    baseURL,
+  }) => {
+    const sent = await catchSubmission(page);
+    await page.goto(`${PAGE}${SCANNER_HASH}`);
+
+    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    await page.locator('[data-feedback-send]').click();
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+
+    expect(new URLSearchParams(sent.body ?? '').get(FIELD_PAGE)).toBe(
+      `Deploy with Kustomize - ${baseURL}${PAGE}`
+    );
+  });
+
+  test('posts nothing when a script does the clicking', async ({ page }) => {
+    const sent = await catchSubmission(page);
+
+    await page.evaluate(() => {
+      document.querySelector<HTMLElement>('[data-feedback-vote]')?.click();
+      document.querySelector<HTMLElement>('[data-feedback-send]')?.click();
+    });
+
+    // Thanked all the same, so a crawler has nothing to work around.
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    expect(sent.body).toBeNull();
+  });
+
+  test('posts nothing from a browser under automation', async ({ page }) => {
+    const sent = await catchSubmission(page);
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', {
+        get: () => true,
+        configurable: true,
+      });
+    });
+    await page.goto(PAGE);
+
+    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    await page.locator('[data-feedback-send]').click();
+
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    expect(sent.body).toBeNull();
   });
 
   test('keeps the form up when the submission never leaves the browser', async ({


### PR DESCRIPTION
The feedback responses are carrying rows nobody submitted: pages from dev and preprod, and page URLs ending in prototype pollution probes (`#__proto__[sssied]=sssieda&...`). Something crawls the docs and works the widget.

Two changes:

- A scripted click, or a click in a browser reporting `navigator.webdriver`, gets the same thanks a reader gets and sends nothing.
- The URL fragment is only kept when it names an element on the page, so appended junk is dropped and real anchors survive.

Best effort, so a determined crawler still gets through. `npx playwright test tests/feedback.spec.ts` covers both, 10 passing.

Additional "hardening" coming in another pr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)