### PR TITLE
Honeypot, reading pause and a once-a-day limit on feedback

### DIFF
--- a/src/components/Feedback.astro
+++ b/src/components/Feedback.astro
@@ -52,6 +52,22 @@ stats.stop();
     </div>
   </div>
 
+  {
+    /* Nothing a reader sees, reaches by keyboard or hears read out, so anything
+      in it was put there by something filling in every input it found. Held
+      outside the comment block, which starts hidden, as a crawler working the
+      page in one pass would never see it there. */
+  }
+  <input
+    class="feedback__trap"
+    type="text"
+    name="feedback-website"
+    tabindex="-1"
+    autocomplete="off"
+    aria-hidden="true"
+    data-feedback-trap
+  />
+
   <div class="feedback__comment" data-feedback-comment hidden>
     <label class="feedback__label" for="feedback-comment">
       {_(Translations.octopus_feedback.comment_label)}
@@ -77,6 +93,7 @@ stats.stop();
 
 <style>
   .feedback {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -99,6 +116,20 @@ stats.stop();
   /* Two classes, so this beats the `display: flex` above. */
   .feedback [hidden] {
     display: none;
+  }
+
+  /* Taken out of the layout the way the live regions elsewhere are, and left
+     rendered on purpose: a crawler that skips `display: none` still finds it. */
+  .feedback__trap {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .feedback__actions {

--- a/src/scripts/modules/feedback-form.js
+++ b/src/scripts/modules/feedback-form.js
@@ -14,3 +14,10 @@ export const FIELD_RATING = 'entry.128617088';
 export const FIELD_COMMENT = 'entry.434783109';
 export const RATING_YES = '5';
 export const RATING_NO = '1';
+
+// The Send button arrives with the comment box on the vote, so a reader has to
+// find it and press it. Mouse travel and reaction put a few hundred
+// milliseconds under that at the very least, where a script does both clicks in
+// one turn of the event loop. Set low, as feedback lost to a fast reader costs
+// more than a row of noise. Lives here so the tests can wait it out.
+export const READING_TIME = 400;

--- a/src/scripts/modules/feedback.js
+++ b/src/scripts/modules/feedback.js
@@ -5,6 +5,7 @@ import {
   FIELD_PAGE,
   FIELD_RATING,
   FORM_URL,
+  READING_TIME,
 } from './feedback-form.js';
 
 /**
@@ -21,6 +22,39 @@ import {
  */
 function automated(event) {
   return navigator.webdriver === true || !event.isTrusted;
+}
+
+// A page is answered once a day per browser. Long enough to stop a flood or a
+// double send, short enough that a page revised next week can be answered
+// again.
+const ANSWERED_FOR = 24 * 60 * 60 * 1000;
+const ANSWERED_KEY = 'feedback:answered:';
+
+/**
+ * Private browsing and storage turned off both throw on any of this. A reader
+ * we cannot keep a note about is better served by being asked twice than by
+ * losing the widget, so a failure reads as unanswered.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+function answered(path) {
+  try {
+    const at = Number(localStorage.getItem(ANSWERED_KEY + path));
+
+    return at > 0 && Date.now() - at < ANSWERED_FOR;
+  } catch {
+    return false;
+  }
+}
+
+/** @param {string} path */
+function recordAnswer(path) {
+  try {
+    localStorage.setItem(ANSWERED_KEY + path, String(Date.now()));
+  } catch {
+    // Nothing depends on the note having been kept.
+  }
 }
 
 /**
@@ -97,8 +131,15 @@ class Feedback {
     this.textarea = qs('textarea', root);
     this.send = qs('[data-feedback-send]', root);
     this.thanks = qs('[data-feedback-thanks]', root);
+    this.trap = qs('[data-feedback-trap]', root);
     /** @type {string | null} */
     this.rating = null;
+    this.votedAt = 0;
+
+    if (answered(window.location.pathname)) {
+      this.thank();
+      return;
+    }
 
     this.addListeners();
   }
@@ -113,10 +154,27 @@ class Feedback {
   /** @param {HTMLElement} chosen */
   vote(chosen) {
     this.rating = chosen.dataset.feedbackVote ?? null;
+    this.votedAt = performance.now();
     this.votes.forEach((button) => {
       button.setAttribute('aria-pressed', String(button === chosen));
     });
     this.comment.hidden = false;
+  }
+
+  /**
+   * Each of these is something a reader does not do. None of them is proof and
+   * a crawler written against this widget defeats all three, so they thin the
+   * noise rather than sealing anything.
+   *
+   * @param {Event} event
+   * @returns {string} what gave the sender away, empty for a reader
+   */
+  crawlerTell(event) {
+    if (automated(event)) return 'automated click';
+    if (this.trap.value) return 'honeypot filled';
+    if (performance.now() - this.votedAt < READING_TIME) return 'sent too fast';
+
+    return '';
   }
 
   /** @param {Event} event */
@@ -125,8 +183,9 @@ class Feedback {
 
     // Answered the same way a reader's click is, so a crawler finds nothing to
     // work around and a run of the test suite still exercises the whole widget.
-    if (automated(event)) {
-      console.info('[feedback] automated click, nothing sent');
+    const tell = this.crawlerTell(event);
+    if (tell) {
+      console.info(`[feedback] ${tell}, nothing sent`);
       this.thank();
       return;
     }
@@ -147,6 +206,7 @@ class Feedback {
       return;
     }
 
+    recordAnswer(window.location.pathname);
     this.thank();
   }
 

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -5,6 +5,7 @@ import {
   FIELD_RATING,
   RATING_NO,
   RATING_YES,
+  READING_TIME,
 } from '../src/scripts/modules/feedback-form.js';
 
 const PAGE = '/docs/kubernetes/steps/kustomize';
@@ -35,6 +36,17 @@ async function catchSubmission(page: Page) {
   });
 
   return sent;
+}
+
+/** Anything sent faster than a reader could manage is dropped unsent. */
+async function readingPause(page: Page) {
+  await page.waitForTimeout(READING_TIME + 100);
+}
+
+async function voteThenSend(page: Page, rating = RATING_YES) {
+  await page.locator(`[data-feedback-vote="${rating}"]`).click();
+  await readingPause(page);
+  await page.locator('[data-feedback-send]').click();
 }
 
 test.describe('feedback widget', () => {
@@ -81,8 +93,7 @@ test.describe('feedback widget', () => {
   }) => {
     await catchSubmission(page);
 
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
-    await page.locator('[data-feedback-send]').click();
+    await voteThenSend(page);
 
     await expect(page.locator('.feedback__thanks')).toBeVisible();
     await expect(page.locator('.feedback__vote')).toBeHidden();
@@ -97,6 +108,7 @@ test.describe('feedback widget', () => {
 
     await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
     await page.locator('.feedback__textarea').fill('the kustomize page');
+    await readingPause(page);
     await page.locator('[data-feedback-send]').click();
     await expect(page.locator('.feedback__thanks')).toBeVisible();
 
@@ -112,8 +124,7 @@ test.describe('feedback widget', () => {
     const sent = await catchSubmission(page);
     await page.goto(`${PAGE}${ANCHOR}`);
 
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
-    await page.locator('[data-feedback-send]').click();
+    await voteThenSend(page);
     await expect(page.locator('.feedback__thanks')).toBeVisible();
 
     expect(new URLSearchParams(sent.body ?? '').get(FIELD_PAGE)).toBe(
@@ -128,8 +139,7 @@ test.describe('feedback widget', () => {
     const sent = await catchSubmission(page);
     await page.goto(`${PAGE}${SCANNER_HASH}`);
 
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
-    await page.locator('[data-feedback-send]').click();
+    await voteThenSend(page);
     await expect(page.locator('.feedback__thanks')).toBeVisible();
 
     expect(new URLSearchParams(sent.body ?? '').get(FIELD_PAGE)).toBe(
@@ -140,10 +150,16 @@ test.describe('feedback widget', () => {
   test('posts nothing when a script does the clicking', async ({ page }) => {
     const sent = await catchSubmission(page);
 
-    await page.evaluate(() => {
-      document.querySelector<HTMLElement>('[data-feedback-vote]')?.click();
-      document.querySelector<HTMLElement>('[data-feedback-send]')?.click();
-    });
+    const click = (selector: string) =>
+      page.evaluate(
+        (target) => document.querySelector<HTMLElement>(target)?.click(),
+        selector
+      );
+
+    // Paced out, so the untrusted click is the only thing under test here.
+    await click('[data-feedback-vote]');
+    await readingPause(page);
+    await click('[data-feedback-send]');
 
     // Thanked all the same, so a crawler has nothing to work around.
     await expect(page.locator('.feedback__thanks')).toBeVisible();
@@ -160,6 +176,42 @@ test.describe('feedback widget', () => {
     });
     await page.goto(PAGE);
 
+    await voteThenSend(page);
+
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    expect(sent.body).toBeNull();
+  });
+
+  test('posts nothing when the honeypot has been filled', async ({ page }) => {
+    const sent = await catchSubmission(page);
+    await page.evaluate(() => {
+      const trap = document.querySelector<HTMLInputElement>(
+        '[data-feedback-trap]'
+      );
+      if (trap) trap.value = 'https://example.com/buy-things';
+    });
+
+    await voteThenSend(page);
+
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    expect(sent.body).toBeNull();
+  });
+
+  test('posts nothing when send follows the vote instantly', async ({
+    page,
+  }) => {
+    const sent = await catchSubmission(page);
+    // Frozen, so no time can pass between the two clicks however long
+    // Playwright actually takes over them.
+    await page.addInitScript(() => {
+      const frozen = performance.now();
+      Object.defineProperty(performance, 'now', {
+        value: () => frozen,
+        configurable: true,
+      });
+    });
+    await page.goto(PAGE);
+
     await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
     await page.locator('[data-feedback-send]').click();
 
@@ -167,11 +219,38 @@ test.describe('feedback widget', () => {
     expect(sent.body).toBeNull();
   });
 
+  test('asks a page only once, and remembers on the next visit', async ({
+    page,
+  }) => {
+    const sent = await catchSubmission(page);
+
+    await voteThenSend(page);
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    expect(sent.body).not.toBeNull();
+
+    sent.body = null;
+    await page.goto(PAGE);
+
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    await expect(page.locator('.feedback__vote')).toBeHidden();
+    expect(sent.body).toBeNull();
+  });
+
+  test('asks again on a page that has not been answered', async ({ page }) => {
+    await catchSubmission(page);
+
+    await voteThenSend(page);
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+    await page.goto('/docs/kubernetes/steps/yaml');
+
+    await expect(page.locator('.feedback__vote')).toBeVisible();
+    await expect(page.locator('.feedback__thanks')).toBeHidden();
+  });
+
   test('keeps the form up when the submission never leaves the browser', async ({
     page,
   }) => {
-    await page.locator(`[data-feedback-vote="${RATING_NO}"]`).click();
-    await page.locator('[data-feedback-send]').click();
+    await voteThenSend(page, RATING_NO);
 
     // Send is disabled for the attempt and only comes back on the failure, so
     // this settles after the handler has run. The two checks below would each


### PR DESCRIPTION
Stacked on #3391. Three cheap guards, all of them client side:

- A honeypot input a reader never sees, reaches by keyboard or hears read out. Anything in it means something filled in every input it found.
- A minimum gap between the vote click and Send. The Send button only appears on the vote, so a reader has to travel to it.
- One answer per page, per browser, per day, kept in `localStorage`.

The comment field is left alone. Readers paste URLs into it legitimately, so a rule against `http` would cost real feedback, and a length cap alone buys nothing.

**Open question before this is worth merging.** Every guard here, and in #3391, requires the sender to be running the page. If the scanner reads the entry IDs out of the public bundle and posts to the Google Form endpoint directly, none of this touches it. The counter-evidence is that the junk rows carry well-formed `Title - URL` values with the correct per-page title, which only our JS builds. That points at a browser, though it does not prove one.

Either way, the only defence that survives a direct post is response validation on the form itself.

`npx playwright test tests/feedback.spec.ts` covers all three, 14 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)