### PR TITLE
Require a comment before the feedback form will send

### DIFF
--- a/src/components/Feedback.astro
+++ b/src/components/Feedback.astro
@@ -62,6 +62,7 @@ stats.stop();
       label={_(Translations.octopus_feedback.send)}
       size="small"
       importance="loud"
+      disabled
       data-feedback-send
     />
   </div>

--- a/src/data/language.json
+++ b/src/data/language.json
@@ -31,7 +31,7 @@
             "en": "No"
         },
         "comment_label": {
-            "en": "Why did you give this rating? (optional)"
+            "en": "Why did you give this rating? (required)"
         },
         "send": {
             "en": "Send"

--- a/src/scripts/modules/feedback.js
+++ b/src/scripts/modules/feedback.js
@@ -23,9 +23,9 @@ async function submit(page, rating, comment) {
   const body = new URLSearchParams();
   body.set(FIELD_PAGE, page);
   body.set(FIELD_RATING, rating);
-  // The comment is marked required on the form, so a blank box still has to
-  // send something for the submission to be accepted at all.
-  body.set(FIELD_COMMENT, comment.trim() || ' ');
+  // Required on the form, and required by the widget as well, so there is
+  // always something here.
+  body.set(FIELD_COMMENT, comment.trim());
 
   await fetch(FORM_URL, { method: 'POST', mode: 'no-cors', body });
 }
@@ -65,7 +65,21 @@ class Feedback {
     this.votes.forEach((button) => {
       button.addEventListener('click', () => this.vote(button));
     });
+    this.textarea.addEventListener('input', () => this.allowSend());
     this.send.addEventListener('click', () => this.submit());
+  }
+
+  /**
+   * The security scanner that crawls the docs works every control it finds and
+   * types into none of them, so each of its submissions arrives with an empty
+   * box. Send is out of reach until there is something worth sending.
+   */
+  allowSend() {
+    if (this.textarea.value.trim()) {
+      this.send.removeAttribute('disabled');
+    } else {
+      this.send.setAttribute('disabled', '');
+    }
   }
 
   /** @param {HTMLElement} chosen */
@@ -78,7 +92,9 @@ class Feedback {
   }
 
   async submit() {
-    if (!this.rating) return;
+    // The disabled button covers both of these already. They are here for the
+    // caller that reaches the handler another way.
+    if (!this.rating || !this.textarea.value.trim()) return;
 
     // Guards against a second submission while the first is in flight.
     this.send.setAttribute('disabled', '');

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -47,6 +47,38 @@ test.describe('feedback widget', () => {
     ).toHaveAttribute('aria-pressed', 'true');
   });
 
+  test('keeps send out of reach until the box has something in it', async ({
+    page,
+  }) => {
+    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    await expect(page.locator('[data-feedback-send]')).toBeDisabled();
+
+    // Whitespace is nothing to send, so it does not count as an answer.
+    await page.locator('.feedback__textarea').fill('   ');
+    await expect(page.locator('[data-feedback-send]')).toBeDisabled();
+
+    await page.locator('.feedback__textarea').fill('the diagram is wrong');
+    await expect(page.locator('[data-feedback-send]')).toBeEnabled();
+
+    await page.locator('.feedback__textarea').fill('');
+    await expect(page.locator('[data-feedback-send]')).toBeDisabled();
+  });
+
+  test('sends nothing on a vote with an empty box', async ({ page }) => {
+    let sent = false;
+    await page.route('**/docs.google.com/**', (route) => {
+      sent = true;
+      return route.fulfill({ status: 200, body: '' });
+    });
+
+    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    // Past the disabled attribute, which a click alone cannot get through.
+    await page.locator('[data-feedback-send]').dispatchEvent('click');
+
+    await expect(page.locator('.feedback__thanks')).toBeHidden();
+    expect(sent).toBe(false);
+  });
+
   test('thanks the reader once the submission has gone out', async ({
     page,
   }) => {
@@ -55,6 +87,7 @@ test.describe('feedback widget', () => {
     );
 
     await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    await page.locator('.feedback__textarea').fill('clear enough');
     await page.locator('[data-feedback-send]').click();
 
     await expect(page.locator('.feedback__thanks')).toBeVisible();
@@ -89,6 +122,9 @@ test.describe('feedback widget', () => {
     page,
   }) => {
     await page.locator(`[data-feedback-vote="${RATING_NO}"]`).click();
+    await page
+      .locator('.feedback__textarea')
+      .fill('the steps are out of order');
     await page.locator('[data-feedback-send]').click();
 
     // Send is disabled for the attempt and only comes back on the failure, so


### PR DESCRIPTION
Send stays disabled until the comment box has text in it.

**Why:** our own security scanner crawls the docs, clicks every control it finds, and types into none of them. Since the widget shipped in #3324 it has been submitting the form on every page it scans — 209 junk rows in the sample I checked, all with an empty comment, all rated 1 because it clicks both thumbs and the last one wins.

Every one of those 209 rows had an empty comment, so this drops all of them. A URL filter was the other option and it only covered 81%, because the scanner also makes a clean control visit alongside each probe.

**Cost:** vote-only feedback stops being recorded. A thumb with no text no longer submits.

`npx playwright test tests/feedback.spec.ts` — 8 passing.

---

## How we think the junk is getting in

This is inferred from the response rows and our own markup. Nobody has seen the scanner's traffic, so it's a reading of the side effects rather than a confirmed account. SecOps can settle it in one message.

### What it appears to be

A client-side vulnerability scanner — prototype pollution and DOM source-to-sink — driving a headless browser. It runs in two modes, and both submit the form:

1. **Wordlist sweep.** ~189 parameter names, chunked into batches of about 25, appended to the URL fragment as `#name=sssiedh<name>xsx&…`. It loads the page, lets our JS run, then looks for its markers in the DOM, JS state and storage. Finding `sssiedhthemexsx` in a variable means the `theme` fragment parameter flowed into it.
2. **Prototype pollution probe.** Eight fixed payloads (`__proto__[sssied]`, `constructor.prototype.sssied`, `x.__proto__.sssied`…), each paired with a **clean control visit** of the same page seconds earlier, so it can diff against a baseline. Those control visits are why a URL filter can't catch everything — they carry no payload at all.

The wordlist is built from a site-wide crawl and includes our own identifiers: `THEME_STORAGE_KEY`, `COLOR_SCHEME_QUERY`, `THEME_PREFERENCE_ATTRIBUTE`, `useNewNav`, `newNavRequested`, `theme-switcher-mobile`, `themeSwitchers`, `whenActivated`, `happyPath`, `SIGNED_IN_ATTRIBUTE`. All of those are inline-script variable names or DOM ids in `dist/docs/index.html`. It also fires anchor ids harvested from other pages, e.g. `creating-an-agent-api-key` turning up on `/docs/insights`.

### How it ends up submitting

Loading a page only reaches sinks that fire on load, so it then works every control to reach the rest. On our widget that plays out as: click thumbs-up (`rating = 5`), click thumbs-down (`rating = 1`, overwriting), the comment block un-hides and exposes Send, click Send. Our handler builds the label from `window.location` — which is carrying its own payload — and posts it.

### Why a browser rather than posts straight to the form endpoint

The alternative theory is that it reads `FORM_URL` and the `entry.*` ids out of the bundle and posts directly. The rows argue against it:

| Observation | Direct post would need to | A browser gets it for free |
|---|---|---|
| Rating is always 1 | Guess `1`, every time | Clicks both thumbs, last one wins |
| Send is `hidden` until a vote | Not care — it skips the DOM | Must click a thumb first, then re-scan |
| Comment always empty | Send exactly `' '` to satisfy the required field | That was our `\|\| ' '` fallback |
| Label is `Title - URL#its-own-payload` | Parse each page for the title, rebuild our template, then copy its probe into a form field for no benefit | `pageLabel()` reads `window.location` |
| ~7 seconds per submission, uniformly | Run at hundreds per second | A page load plus interaction |
| Clean control rows with real anchors | Have no reason to | Baseline visits during the probe |

The label is the strongest of those. A prototype pollution payload only does anything when a browser navigates to it; copying it into a form field achieves nothing for the scanner.

### Timeline

#3324 merged 03:25 UTC on 12 Aug. First junk row 04:53 — 88 minutes later. It has since covered `a.dev`, `b.dev`, `c.dev`, `preprod`, prod and at least one ephemeral PR environment. Eight to nine rows per page scanned, so a full pass over the 2,781 docs pages is roughly 22,000 rows per environment.

### What would disprove this

A row our code could not have produced: a malformed label, a rating other than 1 or 5, or a comment containing a payload rather than being blank. None so far across every sample.

### What this PR does and doesn't do

It stops the rows being recorded. It doesn't stop the scanner clicking, and it isn't a defence against anyone determined — the endpoint and field ids are public in the bundle, as they were before #3324. The durable fix is a SecOps scan exclusion for the widget, which is being asked for separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
