### PR TITLE
Experiment: stronger bot gating on the feedback widget

### DIFF
--- a/src/components/Feedback.astro
+++ b/src/components/Feedback.astro
@@ -58,10 +58,16 @@ stats.stop();
     </label>
     <textarea class="feedback__textarea" id="feedback-comment" rows="3"
     ></textarea>
+    {
+      /* Disabled here and released by the script on a vote it accepted, as the
+        browser dispatches no click at all on a disabled button. Released as
+        this container is revealed, so the state is never on screen. */
+    }
     <Button
       label={_(Translations.octopus_feedback.send)}
       size="small"
       importance="loud"
+      disabled
       data-feedback-send
     />
   </div>

--- a/src/scripts/modules/feedback-form.js
+++ b/src/scripts/modules/feedback-form.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+// Constants shared by the widget's script, its markup and its tests. Nothing
+// here reads the DOM, so the component can import it during the build.
+
 // The Google Form behind the feedback widget. Its three fields, read off the
 // live form:
 //   entry.336432709  "Which page did you view?"  short text, optional
@@ -14,3 +17,33 @@ export const FIELD_RATING = 'entry.128617088';
 export const FIELD_COMMENT = 'entry.434783109';
 export const RATING_YES = '5';
 export const RATING_NO = '1';
+
+// A scanner drove the widget by loading every page with a payload in the
+// fragment and clicking each button it found, which sent a stream of
+// thumbs-down responses carrying that payload in the page field. The rest of
+// this file is what separates that from a person reading a page.
+
+// Events a person produces on the way to the widget. Pointer and touch presses
+// are left out: they arrive as part of the click rather than ahead of it, so
+// they say nothing about what came first.
+export const HUMAN_EVENTS = [
+  'pointermove',
+  'wheel',
+  'scroll',
+  'keydown',
+  'touchmove',
+];
+
+// Three, so one synthesised mouse move in front of a click falls short.
+export const HUMAN_EVENTS_NEEDED = 3;
+
+// The scanner loaded a page, clicked through it and submitted inside three
+// seconds. Reading enough of an article to hold an opinion takes longer.
+export const MIN_READ_MS = 3000;
+
+// Long enough to reach for the textarea and then the button.
+export const MIN_VOTE_TO_SEND_MS = 800;
+
+// Well past the longest heading slug in the docs, and short enough that the
+// field cannot be used to carry a payload.
+export const MAX_HASH_LENGTH = 100;

--- a/src/scripts/modules/feedback.js
+++ b/src/scripts/modules/feedback.js
@@ -5,7 +5,58 @@ import {
   FIELD_PAGE,
   FIELD_RATING,
   FORM_URL,
+  HUMAN_EVENTS,
+  HUMAN_EVENTS_NEEDED,
+  MAX_HASH_LENGTH,
+  MIN_READ_MS,
+  MIN_VOTE_TO_SEND_MS,
 } from './feedback-form.js';
+
+// The gates below read what the browser reports about the input itself, so none
+// of them depend on recognising a particular tool. See feedback-form.js for
+// what they are answering.
+
+// Capture, so scrolling inside a nested container still counts. Passive, as
+// these only ever read.
+const LISTENER_OPTIONS = { capture: true, passive: true };
+
+// Selenium, Puppeteer and Playwright all set this. A browser a person is
+// sitting at reports false, and a caller that clears it still has the rest of
+// the gates to get past.
+const automated = navigator.webdriver === true;
+
+let humanEvents = 0;
+
+/** @param {Event} event */
+function countHumanEvent(event) {
+  // Synthesised events are the reason this counter exists.
+  if (!event.isTrusted) return;
+
+  humanEvents += 1;
+
+  if (humanEvents >= HUMAN_EVENTS_NEEDED) {
+    HUMAN_EVENTS.forEach((name) =>
+      window.removeEventListener(name, countHumanEvent, LISTENER_OPTIONS)
+    );
+  }
+}
+
+if (!automated) {
+  HUMAN_EVENTS.forEach((name) =>
+    window.addEventListener(name, countHumanEvent, LISTENER_OPTIONS)
+  );
+}
+
+/**
+ * `isTrusted` is false for anything dispatched from script, `element.click()`
+ * included.
+ *
+ * @param {Event} event
+ * @returns {boolean}
+ */
+function fromAPerson(event) {
+  return !automated && event.isTrusted && humanEvents >= HUMAN_EVENTS_NEEDED;
+}
 
 /**
  * Google Forms sends no CORS headers, so the POST has to go out as no-cors and
@@ -31,6 +82,23 @@ async function submit(page, rating, comment) {
 }
 
 /**
+ * A fragment is kept only where it names a heading that is on the page, so the
+ * field carries a real section of a real page and nothing else. The fragment is
+ * the one part of the URL this field preserves, which is where a scanner
+ * probing the page from the address bar puts its payload.
+ *
+ * @returns {string}
+ */
+function sectionHash() {
+  const id = window.location.hash.slice(1);
+
+  // Slug characters only, which rules out the `=` and `&` a query string needs.
+  if (!id || id.length > MAX_HASH_LENGTH || !/^[\w-]+$/.test(id)) return '';
+
+  return document.getElementById(id) ? `#${id}` : '';
+}
+
+/**
  * The title alone is ambiguous - "Overview" and "Prerequisites" repeat across
  * the docs - and the URL alone is unreadable in a spreadsheet, so the field
  * carries both. The hash says which section was open. The query string is
@@ -40,8 +108,8 @@ async function submit(page, rating, comment) {
  * @returns {string}
  */
 function pageLabel(title) {
-  const { origin, pathname, hash } = window.location;
-  const url = `${origin}${pathname}${hash}`;
+  const { origin, pathname } = window.location;
+  const url = `${origin}${pathname}${sectionHash()}`;
 
   return title ? `${title} - ${url}` : url;
 }
@@ -57,28 +125,52 @@ class Feedback {
     this.thanks = qs('[data-feedback-thanks]', root);
     /** @type {string | null} */
     this.rating = null;
+    /** Milliseconds since the page loaded, as `performance.now()` reports. */
+    this.votedAt = 0;
 
     this.addListeners();
   }
 
   addListeners() {
     this.votes.forEach((button) => {
-      button.addEventListener('click', () => this.vote(button));
+      button.addEventListener('click', (event) => this.vote(event, button));
     });
-    this.send.addEventListener('click', () => this.submit());
+    this.send.addEventListener('click', (event) => this.submit(event));
   }
 
-  /** @param {HTMLElement} chosen */
-  vote(chosen) {
+  /**
+   * A rejected click does nothing and says nothing, so a caller reading the DOM
+   * afterwards learns only that the widget is where it was.
+   *
+   * @param {Event} event
+   * @param {HTMLElement} chosen
+   */
+  vote(event, chosen) {
+    if (!fromAPerson(event)) return;
+
     this.rating = chosen.dataset.feedbackVote ?? null;
+    this.votedAt = performance.now();
     this.votes.forEach((button) => {
       button.setAttribute('aria-pressed', String(button === chosen));
     });
     this.comment.hidden = false;
+    // The markup ships this disabled, so a widget that never took a vote leaves
+    // a button the browser fires no click on at all.
+    this.send.removeAttribute('disabled');
   }
 
-  async submit() {
+  /**
+   * The two waits sit here rather than on the vote, so an early click still
+   * opens the comment box and the reader has somewhere to go. Writing anything
+   * at all takes longer than either wait.
+   *
+   * @param {Event} event
+   */
+  async submit(event) {
     if (!this.rating) return;
+    if (!fromAPerson(event)) return;
+    if (performance.now() < MIN_READ_MS) return;
+    if (performance.now() - this.votedAt < MIN_VOTE_TO_SEND_MS) return;
 
     // Guards against a second submission while the first is in flight.
     this.send.setAttribute('disabled', '');

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -1,18 +1,52 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
   FIELD_COMMENT,
   FIELD_PAGE,
   FIELD_RATING,
+  HUMAN_EVENTS_NEEDED,
+  MIN_READ_MS,
+  MIN_VOTE_TO_SEND_MS,
   RATING_NO,
   RATING_YES,
 } from '../src/scripts/modules/feedback-form.js';
 
 const PAGE = '/docs/kubernetes/steps/kustomize';
 
+const VOTE_YES = `[data-feedback-vote="${RATING_YES}"]`;
+const VOTE_NO = `[data-feedback-vote="${RATING_NO}"]`;
+const SEND = '[data-feedback-send]';
+
+/**
+ * The widget waits for the browser to report the events a person produces on
+ * the way to it, and for long enough that the page could have been read. Enough
+ * steps to clear the count in a single move.
+ */
+async function readThePage(page: Page) {
+  await page.mouse.move(400, 400, { steps: HUMAN_EVENTS_NEEDED * 2 });
+  await page.waitForTimeout(MIN_READ_MS);
+}
+
+/** The pause a person takes over the comment box before sending. */
+async function writeAComment(page: Page, text?: string) {
+  if (text) await page.locator('.feedback__textarea').fill(text);
+  await page.waitForTimeout(MIN_VOTE_TO_SEND_MS);
+}
+
 test.describe('feedback widget', () => {
   test.beforeEach(async ({ page }) => {
+    // Playwright reports itself through `navigator.webdriver`, which the widget
+    // treats as reason enough to stay inert. The suite is here to cover what
+    // the widget does for a person, so it presents itself as one; the tests
+    // below that cover the automated path do their own thing.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', {
+        get: () => false,
+        configurable: true,
+      });
+    });
+
     // Blocked for every test, so no run can post to the live form. The success
-    // case below overrides this: Playwright matches the newest route first.
+    // cases below override this: Playwright matches the newest route first.
     await page.route('**/docs.google.com/**', (route) => route.abort());
     await page.goto(PAGE);
   });
@@ -24,27 +58,30 @@ test.describe('feedback widget', () => {
   });
 
   test('discloses the comment box on a rating', async ({ page }) => {
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
+    await readThePage(page);
+    await page.locator(VOTE_YES).click();
 
     await expect(page.locator('.feedback__comment')).toBeVisible();
-    await expect(
-      page.locator(`[data-feedback-vote="${RATING_YES}"]`)
-    ).toHaveAttribute('aria-pressed', 'true');
-    await expect(
-      page.locator(`[data-feedback-vote="${RATING_NO}"]`)
-    ).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator(VOTE_YES)).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    await expect(page.locator(VOTE_NO)).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
   });
 
   test('moves the rating to the other button', async ({ page }) => {
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
-    await page.locator(`[data-feedback-vote="${RATING_NO}"]`).click();
+    await readThePage(page);
+    await page.locator(VOTE_YES).click();
+    await page.locator(VOTE_NO).click();
 
-    await expect(
-      page.locator(`[data-feedback-vote="${RATING_YES}"]`)
-    ).toHaveAttribute('aria-pressed', 'false');
-    await expect(
-      page.locator(`[data-feedback-vote="${RATING_NO}"]`)
-    ).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator(VOTE_YES)).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+    await expect(page.locator(VOTE_NO)).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('thanks the reader once the submission has gone out', async ({
@@ -54,8 +91,10 @@ test.describe('feedback widget', () => {
       route.fulfill({ status: 200, body: '' })
     );
 
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
-    await page.locator('[data-feedback-send]').click();
+    await readThePage(page);
+    await page.locator(VOTE_YES).click();
+    await writeAComment(page);
+    await page.locator(SEND).click();
 
     await expect(page.locator('.feedback__thanks')).toBeVisible();
     await expect(page.locator('.feedback__vote')).toBeHidden();
@@ -65,21 +104,21 @@ test.describe('feedback widget', () => {
   test('sends the page title and url, the rating and the comment', async ({
     page,
   }) => {
-    /** @type {string | null} */
-    let body = null;
+    let body: string | null = null;
     await page.route('**/docs.google.com/**', (route) => {
       body = route.request().postData();
       return route.fulfill({ status: 200, body: '' });
     });
 
-    await page.locator(`[data-feedback-vote="${RATING_YES}"]`).click();
-    await page.locator('.feedback__textarea').fill('the kustomize page');
-    await page.locator('[data-feedback-send]').click();
+    await readThePage(page);
+    await page.locator(VOTE_YES).click();
+    await writeAComment(page, 'the kustomize page');
+    await page.locator(SEND).click();
     await expect(page.locator('.feedback__thanks')).toBeVisible();
 
     const sent = new URLSearchParams(body ?? '');
     expect(sent.get(FIELD_PAGE)).toBe(
-      `Deploy with Kustomize - http://localhost:3000${PAGE}`
+      `Deploy with Kustomize - ${new URL(page.url()).origin}${PAGE}`
     );
     expect(sent.get(FIELD_RATING)).toBe(RATING_YES);
     expect(sent.get(FIELD_COMMENT)).toBe('the kustomize page');
@@ -88,14 +127,184 @@ test.describe('feedback widget', () => {
   test('keeps the form up when the submission never leaves the browser', async ({
     page,
   }) => {
-    await page.locator(`[data-feedback-vote="${RATING_NO}"]`).click();
-    await page.locator('[data-feedback-send]').click();
+    await readThePage(page);
+    await page.locator(VOTE_NO).click();
+    await writeAComment(page);
+    await page.locator(SEND).click();
 
     // Send is disabled for the attempt and only comes back on the failure, so
     // this settles after the handler has run. The two checks below would each
     // pass against a handler that had not reached its catch yet.
-    await expect(page.locator('[data-feedback-send]')).toBeEnabled();
+    await expect(page.locator(SEND)).toBeEnabled();
     await expect(page.locator('.feedback__thanks')).toBeHidden();
     await expect(page.locator('.feedback__vote')).toBeVisible();
+  });
+});
+
+test.describe('feedback widget, driven by a scanner', () => {
+  /** Every request the widget made, so an empty array is the whole assertion. */
+  async function watchForSubmissions(page: Page) {
+    const sent: string[] = [];
+    await page.route('**/docs.google.com/**', (route) => {
+      sent.push(route.request().url());
+      return route.fulfill({ status: 200, body: '' });
+    });
+    return sent;
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', {
+        get: () => false,
+        configurable: true,
+      });
+    });
+
+    // Blocked for every test, so no run can post to the live form.
+    await page.route('**/docs.google.com/**', (route) => route.abort());
+  });
+
+  test('ships the send button disabled', async ({ page }) => {
+    await page.goto(PAGE);
+
+    await expect(page.locator(SEND)).toBeDisabled();
+  });
+
+  test('sends nothing for a run that clicks every button from script', async ({
+    page,
+  }) => {
+    const sent = await watchForSubmissions(page);
+    await page.goto(PAGE);
+    await readThePage(page);
+
+    // The observed sequence: down the widget in document order, so the vote
+    // lands on No and the comment box is open by the time Send is reached.
+    await page.evaluate(
+      (selectors) => {
+        selectors.forEach((selector) =>
+          document.querySelector<HTMLElement>(selector)?.click()
+        );
+      },
+      [VOTE_YES, VOTE_NO, SEND]
+    );
+
+    await expect(page.locator('.feedback__comment')).toBeHidden();
+    await expect(page.locator('.feedback__thanks')).toBeHidden();
+    expect(sent).toHaveLength(0);
+  });
+
+  test('sends nothing for a run that clicks straight through', async ({
+    page,
+  }) => {
+    const sent = await watchForSubmissions(page);
+    await page.goto(PAGE);
+    await readThePage(page);
+
+    // Real clicks this time, so only the pace of them is left to go on.
+    await page.locator(VOTE_YES).click();
+    await page.locator(SEND).click();
+
+    await expect(page.locator('.feedback__thanks')).toBeHidden();
+    expect(sent).toHaveLength(0);
+  });
+
+  test('sends nothing while the page is younger than a read of it', async ({
+    page,
+  }) => {
+    const sent = await watchForSubmissions(page);
+    // The page's own clock, so its age is whatever this test says it is
+    // however long the run takes in real time.
+    await page.addInitScript(() => {
+      let age = 0;
+      performance.now = () => age;
+      Object.assign(window, { advance: (ms: number) => (age += ms) });
+    });
+    await page.goto(PAGE);
+    await page.mouse.move(400, 400, { steps: HUMAN_EVENTS_NEEDED * 2 });
+
+    const advance = (ms: number) =>
+      page.evaluate(
+        (by) =>
+          (window as unknown as { advance(ms: number): void }).advance(by),
+        ms
+      );
+
+    // Past the wait between voting and sending, short of the read.
+    await advance(MIN_READ_MS - MIN_VOTE_TO_SEND_MS * 2);
+    await page.locator(VOTE_YES).click();
+    await advance(MIN_VOTE_TO_SEND_MS + 100);
+    await page.locator(SEND).click();
+
+    await expect(page.locator('.feedback__thanks')).toBeHidden();
+    expect(sent).toHaveLength(0);
+  });
+
+  test('sends nothing when the browser reports itself as automated', async ({
+    page,
+  }) => {
+    const sent = await watchForSubmissions(page);
+    // Undoes the beforeEach, leaving Playwright's own value in place.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'webdriver', {
+        get: () => true,
+        configurable: true,
+      });
+    });
+    await page.goto(PAGE);
+    await readThePage(page);
+
+    await page.locator(VOTE_YES).click();
+
+    await expect(page.locator('.feedback__comment')).toBeHidden();
+    expect(sent).toHaveLength(0);
+  });
+
+  test('drops a fragment that names no heading on the page', async ({
+    page,
+  }) => {
+    let body: string | null = null;
+    await page.route('**/docs.google.com/**', (route) => {
+      body = route.request().postData();
+      return route.fulfill({ status: 200, body: '' });
+    });
+
+    // The shape the scanner used, cut down to two of its parameters.
+    await page.goto(`${PAGE}#q=sssiedhqxsx&token=sssiedhtokenxsx`);
+    await readThePage(page);
+    await page.locator(VOTE_YES).click();
+    await writeAComment(page);
+    await page.locator(SEND).click();
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+
+    const sent = new URLSearchParams(body ?? '');
+    expect(sent.get(FIELD_PAGE)).toBe(
+      `Deploy with Kustomize - ${new URL(page.url()).origin}${PAGE}`
+    );
+  });
+
+  test('keeps a fragment that names a heading on the page', async ({
+    page,
+  }) => {
+    let body: string | null = null;
+    await page.route('**/docs.google.com/**', (route) => {
+      body = route.request().postData();
+      return route.fulfill({ status: 200, body: '' });
+    });
+
+    await page.goto(PAGE);
+    const heading = await page.locator('h2[id]').first().getAttribute('id');
+    expect(heading).toBeTruthy();
+
+    await page.goto(`${PAGE}#${heading}`);
+    await readThePage(page);
+    await page.locator(VOTE_YES).click();
+    await writeAComment(page);
+    await page.locator(SEND).click();
+    await expect(page.locator('.feedback__thanks')).toBeVisible();
+
+    const sent = new URLSearchParams(body ?? '');
+    expect(sent.get(FIELD_PAGE)).toBe(
+      `Deploy with Kustomize - ${new URL(page.url()).origin}${PAGE}#${heading}`
+    );
   });
 });


### PR DESCRIPTION
An automated scanner loads docs pages with a payload in the URL fragment and clicks every button it finds, which submits a thumbs-down response carrying that payload in the page field. It has been doing this from every environment, dev and staging included, since #3324 merged.

Votes and sends now need a trusted event, a browser that does not report itself as automated, a few input events ahead of the click, and enough time on the page. The send button ships disabled so it cannot be clicked into. The fragment is kept only where it names a heading that is on the page.

Draft and experimental. The thresholds are a first guess and want real traffic to confirm, and a scanner driving Chrome over CDP at reading pace would still get through.

For review: an empty comment still submits, which is what lets a run that never types reach the form at all. Requiring text would close that, and would also stop readers sending a bare thumbs-up.

13 Playwright tests pass against the dev server. `npm run build` fails on a missing `html-to-text` dependency, which also fails on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
