### PR TITLE
Introduce an "area" concept, so we aren't locked into a single layout under the "API" section of the docs site.

### DIFF
--- a/frontmatter.json
+++ b/frontmatter.json
@@ -71,6 +71,16 @@
           "title": "navOrder",
           "name": "navOrder",
           "type": "number"
+        },
+        {
+          "title": "area",
+          "name": "area",
+          "type": "choice",
+          "choices": [
+            "docs",
+            "api"
+          ],
+          "required": false
         }
       ]
     }

--- a/src/components/ApiNavigation.astro
+++ b/src/components/ApiNavigation.astro
@@ -8,14 +8,15 @@ stats.start();
 
 type Props = {
   lang: string;
-  headings: { depth: number; slug: string; text: string }[];
+  // Left off by a layout that lists this page's headings somewhere else, which
+  // leaves the nav as the flat list of pages with nothing under the current one.
+  headings?: { depth: number; slug: string; text: string }[];
   // One entry per endpoint, in heading order, left on the frontmatter by
   // plugins/satteri-api-examples.js from the `:endpoint` directive under each
   // heading. Sections without one — and pages that never reach that plugin —
   // simply have none.
   apiMethods?:
-    | { text: string; method: string | null; deprecated?: boolean }[]
-    | null;
+    { text: string; method: string | null; deprecated?: boolean }[] | null;
 };
 const { lang, headings, apiMethods } = Astro.props satisfies Props;
 

--- a/src/components/AreaNavigation.astro
+++ b/src/components/AreaNavigation.astro
@@ -8,7 +8,10 @@ import ApiNavigation from './ApiNavigation.astro';
 
 // The area's nav, picked by area rather than by layout, so a page can be laid
 // out one way and navigated another. Every layout renders this and none of them
-// names a nav component; a new area adds a branch here and nothing else.
+// names a nav component.
+//
+// Adding an area means adding a line at the bottom of this file, and the rest
+// of the checklist is in lib/areas.ts - this is step 3 of four.
 type Props = {
   area: Area;
   lang: string;
@@ -23,9 +26,13 @@ const { area, lang, headings, apiMethods } = Astro.props satisfies Props;
 ---
 
 {
-  area === 'api' ? (
+  /* One line per area, each handed only the props its own nav takes. An area
+  with no line here renders no nav at all, which is louder than quietly showing
+  it the wrong one. */
+}
+{area === 'docs' && <Navigation lang={lang} />}
+{
+  area === 'api' && (
     <ApiNavigation lang={lang} headings={headings} apiMethods={apiMethods} />
-  ) : (
-    <Navigation lang={lang} />
   )
 }

--- a/src/components/AreaNavigation.astro
+++ b/src/components/AreaNavigation.astro
@@ -1,0 +1,31 @@
+---
+import type { Area } from '@lib/areas';
+
+// The nav for the docs area
+import Navigation from '@components/Navigation.astro';
+// The nav for the API reference
+import ApiNavigation from './ApiNavigation.astro';
+
+// The area's nav, picked by area rather than by layout, so a page can be laid
+// out one way and navigated another. Every layout renders this and none of them
+// names a nav component; a new area adds a branch here and nothing else.
+type Props = {
+  area: Area;
+  lang: string;
+  // The API nav lists the current page's endpoints under it, and reads both of
+  // these to do it. A layout that shows this page's headings elsewhere — the
+  // table of contents in the side column — leaves them off, and the nav is
+  // then the flat page list on its own.
+  headings?: { depth: number; slug: string; text: string }[];
+  apiMethods?: { text: string; method: string | null }[] | null;
+};
+const { area, lang, headings, apiMethods } = Astro.props satisfies Props;
+---
+
+{
+  area === 'api' ? (
+    <ApiNavigation lang={lang} headings={headings} apiMethods={apiMethods} />
+  ) : (
+    <Navigation lang={lang} />
+  )
+}

--- a/src/layouts/Api.astro
+++ b/src/layouts/Api.astro
@@ -3,7 +3,7 @@ import { accelerator } from '@lib/accelerator';
 import { PostFiltering } from 'astro-accelerator-utils';
 import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
-import { buildApiCrumbs } from '@lib/apiNavigation';
+import { buildAreaCrumbs, resolveArea, type Area } from '@lib/areas';
 import type { Crumb } from '@util/breadcrumbs';
 
 // Theme components
@@ -14,7 +14,7 @@ import Authors from '@components/Authors.astro';
 import Taxonomy from '@components/Taxonomy.astro';
 
 // Custom components
-import ApiNavigation from '../components/ApiNavigation.astro';
+import AreaNavigation from '../components/AreaNavigation.astro';
 import ArticleHeader from '../components/ArticleHeader.astro';
 import Feedback from '../components/Feedback.astro';
 import TopNav from '../components/TopNav.astro';
@@ -23,9 +23,12 @@ import Footer from 'src/components/Footer.astro';
 import DocsSearch from '../components/DocsSearch.astro';
 
 type Props = {
-  // `apiMethods` is not written by hand: plugins/satteri-api-examples.js leaves
-  // it on the frontmatter for the left nav, an entry per endpoint.
   frontmatter: OriginalFrontmatter & {
+    // The nav this page appears in. Optional, and normally left alone: these
+    // pages live under /docs/api, which is the API area already.
+    area?: Area;
+    // `apiMethods` is not written by hand: plugins/satteri-api-examples.js
+    // leaves it on the frontmatter for the left nav, an entry per endpoint.
     apiMethods?: { text: string; method: string | null }[];
   };
   headings: { depth: number; slug: string; text: string }[];
@@ -33,9 +36,10 @@ type Props = {
 };
 const { frontmatter, headings, breadcrumbs } = Astro.props satisfies Props;
 
-// buildApiCrumbs, not buildCrumbs: the section has no page of its own at
-// /docs/api for the generic walk to find, so it splices the crumb in.
-const crumbs = buildApiCrumbs(Astro.url, breadcrumbs);
+const area = resolveArea(frontmatter.area, Astro.url.pathname);
+// The API section has no page of its own at /docs/api for the generic crumb
+// walk to find, so buildAreaCrumbs splices the crumb in for it.
+const crumbs = buildAreaCrumbs(Astro.url, area, breadcrumbs);
 
 const lang = frontmatter.lang ?? SITE.default.lang;
 const textDirection = frontmatter.dir ?? SITE.default.dir;
@@ -100,7 +104,12 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
         </article>
         <Feedback frontmatter={frontmatter} lang={lang} />
       </main>
-      <ApiNavigation
+      {
+        /* The nav belongs to the area, not to this layout. This column is the
+          only nav on the page, so the headings go with it. */
+      }
+      <AreaNavigation
+        area={area}
         headings={headings}
         lang={lang}
         apiMethods={frontmatter.apiMethods}

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -3,17 +3,18 @@ import { accelerator } from '@lib/accelerator';
 import { PostFiltering } from 'astro-accelerator-utils';
 import type { Frontmatter as OriginalFrontmatter } from 'astro-accelerator-utils/types/Frontmatter';
 import { SITE } from '@config';
-import { buildCrumbs, type Crumb } from '@util/breadcrumbs';
+import type { Crumb } from '@util/breadcrumbs';
+import { buildAreaCrumbs, resolveArea, type Area } from '@lib/areas';
 
 // Theme components
 import Head from '@components/HtmlHead.astro';
 import SkipLinks from '@components/SkipLinks.astro';
 import Breadcrumbs from '@components/Breadcrumbs.astro';
-import Navigation from '@components/Navigation.astro';
 import Authors from '@components/Authors.astro';
 import Taxonomy from '@components/Taxonomy.astro';
 
 // Custom components
+import AreaNavigation from '../components/AreaNavigation.astro';
 import ArticleHeader from '../components/ArticleHeader.astro';
 import ArticleNav from '../components/ArticleNav.astro';
 import Feedback from '../components/Feedback.astro';
@@ -27,13 +28,17 @@ import Footer from 'src/components/Footer.astro';
 import DocsSearch from '../components/DocsSearch.astro';
 
 type Props = {
-  frontmatter: OriginalFrontmatter;
+  // `area` is the nav this page appears in, and it is optional: the section the
+  // page lives in supplies it (see lib/areas.ts). It is here for the page that
+  // wants this layout's middle column while belonging to another area's nav.
+  frontmatter: OriginalFrontmatter & { area?: Area };
   headings: { depth: number; slug: string; text: string }[];
   breadcrumbs?: Crumb[] | null;
 };
 const { frontmatter, headings, breadcrumbs } = Astro.props satisfies Props;
 
-const crumbs = buildCrumbs(Astro.url, breadcrumbs);
+const area = resolveArea(frontmatter.area, Astro.url.pathname);
+const crumbs = buildAreaCrumbs(Astro.url, area, breadcrumbs);
 
 const lang = frontmatter.lang ?? SITE.default.lang;
 const textDirection = frontmatter.dir ?? SITE.default.dir;
@@ -99,7 +104,11 @@ const lastUpdated = frontmatter.modDate ?? frontmatter.pubDate ?? null;
           </div>
         </article>
       </main>
-      <Navigation lang={lang} />
+      {
+        /* The nav belongs to the area, not to this layout. The page's own
+          headings are not passed: the side column below lists them. */
+      }
+      <AreaNavigation area={area} lang={lang} />
       <div class="side-nav">
         <!-- <TableOfContents
           expanded={930}

--- a/src/lib/apiNavigation.ts
+++ b/src/lib/apiNavigation.ts
@@ -1,22 +1,18 @@
 import type { MarkdownInstance } from 'astro-accelerator-utils/types/Astro';
 import { accelerator } from './accelerator';
-import { SITE } from '@config';
-import { buildCrumbs, type Crumb } from '@util/breadcrumbs';
+import { pageArea } from './areas';
 
-// The API reference carries its own left nav, built here from the pages that
-// opt into src/layouts/Api.astro. Those same pages are pruned out of the main
-// site nav in navigationTree.ts, so the two trees never overlap.
+// The API reference carries its own left nav, built here from the pages in the
+// API area (see lib/areas.ts — the section they live in, not the layout they
+// render with). Those same pages are pruned out of the main site nav in
+// navigationTree.ts, so the two trees never overlap.
 //
 // Unlike the site nav, this one is flat: an entry per page, and under the page
 // the reader is on, an entry per endpoint. The endpoints come from the layout's
 // own headings rather than from here — Posts.all() reads the page set back from
 // a JSON cache, which leaves the frontmatter intact but drops getHeadings().
 
-const API_LAYOUT = '/Api.astro';
-
 const PAGES_ROOT = '/src/pages';
-
-const API_SECTION_TITLE = 'Api';
 
 function urlFromSourcePath(path: string): string {
   return path
@@ -57,8 +53,8 @@ export type ApiNavPage = {
   order: number;
 };
 
-export function isApiPage(post: MarkdownInstance): boolean {
-  return (post?.frontmatter?.layout ?? '').includes(API_LAYOUT);
+export function isApiPage(post: MarkdownInstance, urlHint?: string): boolean {
+  return pageArea(post, urlHint) === 'api';
 }
 
 // Same deal as menuTemplate(): the list is identical for every page in the
@@ -74,54 +70,19 @@ export function apiMenu(): ApiNavPage[] {
 
   const menu = accelerator.posts
     .all()
-    .filter(isApiPage)
-    .map((post) => ({
+    // The recovered url is what decides the area for a page Astro gave none, so
+    // it is worked out before the filter rather than inside the map.
+    .map((post) => ({ post, url: post.url ?? urls.get(post.file) ?? '/' }))
+    .filter(({ post, url }) => isApiPage(post, url))
+    .map(({ post, url }) => ({
       title: post.frontmatter.navTitle ?? post.frontmatter.title,
-      url: accelerator.urlFormatter.addSlashToAddress(
-        post.url ?? urls.get(post.file) ?? '/'
-      ),
+      url: accelerator.urlFormatter.addSlashToAddress(url),
       order: post.frontmatter.navOrder ?? Number.MAX_SAFE_INTEGER,
     }))
-    // The pages are generated one per API area and carry no navOrder, so the
+    // The pages are generated one per API resource and carry no navOrder, so the
     // fallback is the alphabetical order the index page already lists them in.
     .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
 
   if (import.meta.env.PROD) pages = menu;
   return menu;
-}
-
-/**
- * Every API page URL, trailing slash trimmed, for the site nav to prune
- * against.
- */
-export function apiPageUrls(): Set<string> {
-  return new Set(apiMenu().map((page) => page.url.replace(/\/$/, '')));
-}
-
-// The API reference has no page of its own at /docs/api yet - `_index.md` is
-// underscore-prefixed so Astro does not route it - so the generic breadcrumb
-// walk, which builds a crumb per path segment that resolves to a page, skips
-// straight from Docs to the endpoint page. Splice the section in by hand so an
-// API page reads "Docs / Api / Feeds".
-//
-// The crumb carries no url on purpose: there is nothing to link to until the
-// landing page lands.
-export function buildApiCrumbs(
-  currentUrl: URL,
-  extraCrumbs?: ReadonlyArray<Crumb> | null
-): Crumb[] {
-  const crumbs = buildCrumbs(currentUrl, extraCrumbs);
-  const sectionPath = SITE.subfolder + '/api';
-
-  if (!currentUrl.pathname.startsWith(sectionPath)) return crumbs;
-  if (crumbs.some((crumb) => crumb.title === API_SECTION_TITLE)) return crumbs;
-
-  // After the /docs crumb, which is the only one the walk finds above us.
-  const insertAt = crumbs.findIndex(
-    (crumb) => crumb.url.replace(/\/$/, '') === SITE.subfolder
-  );
-
-  const section: Crumb = { url: '', title: API_SECTION_TITLE };
-  crumbs.splice(insertAt + 1, 0, section);
-  return crumbs;
 }

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -1,0 +1,156 @@
+import type { MarkdownInstance } from 'astro-accelerator-utils/types/Astro';
+import { SITE } from '@config';
+import { buildCrumbs, type Crumb } from '@util/breadcrumbs';
+import { accelerator } from './accelerator';
+
+// An "area" is a slice of the site with its own navigation tree: the docs, the
+// API reference, and — as they arrive — Learn and the CLI reference. It is
+// deliberately not the layout. The layout decides what the middle column looks
+// like; the area decides which nav sits beside it and how the breadcrumbs read,
+// so a page can be in the API area and still be laid out like a docs page.
+//
+// A page's area comes from where it lives, which is what the section already
+// encodes: every page under /docs/api is in the API area without being told so,
+// including the ~100 generated ones. A page that needs to say otherwise puts
+// `area:` in its frontmatter and that wins.
+//
+// Adding an area takes three things: an entry below, a case in
+// components/AreaNavigation.astro, and the nav component it points at.
+
+export type Area = 'docs' | 'api';
+
+type AreaDefinition = {
+  // The path the area occupies, under SITE.subfolder. The docs area is
+  // everything left over, so it claims no path of its own.
+  path: string | null;
+  // A crumb to splice in for the section, for an area with no landing page for
+  // the generic breadcrumb walk to find. null when the walk finds one.
+  sectionCrumb: string | null;
+};
+
+export const AREAS = {
+  docs: { path: null, sectionCrumb: null },
+  // /docs/api has no page of its own yet: `_index.md` is underscore-prefixed so
+  // Astro does not route it, which is why the crumb has to be spliced in.
+  api: { path: '/api', sectionCrumb: 'Api' },
+} as const satisfies Record<Area, AreaDefinition>;
+
+const DEFAULT_AREA: Area = 'docs';
+
+// Longest path first, so an area nested inside another one still wins.
+const PATH_AREAS = (Object.entries(AREAS) as [Area, AreaDefinition][])
+  .filter(([, definition]) => definition.path !== null)
+  .sort((a, b) => (b[1].path as string).length - (a[1].path as string).length);
+
+const trimSlash = (path: string) => path.replace(/\/$/, '');
+
+function isArea(value: unknown): value is Area {
+  return typeof value === 'string' && value in AREAS;
+}
+
+/**
+ * The area a path falls in, before any frontmatter has its say.
+ *
+ * The prefix has to end on a path boundary, or /docs/api-and-integration would
+ * read as part of the API reference.
+ */
+export function areaFromPath(path: string): Area {
+  const pathname = trimSlash(path);
+
+  for (const [area, definition] of PATH_AREAS) {
+    const prefix = SITE.subfolder + definition.path;
+    if (pathname === prefix || pathname.startsWith(prefix + '/')) return area;
+  }
+
+  return DEFAULT_AREA;
+}
+
+/**
+ * The area for a page, given whatever its frontmatter declared and the path it
+ * is served from. An unrecognized `area:` falls back to the path rather than
+ * dropping the page out of every nav on the site.
+ */
+export function resolveArea(declared: unknown, path: string): Area {
+  if (declared != null) {
+    if (isArea(declared)) return declared;
+    console.warn(
+      `Unknown area "${String(declared)}" on ${path}. Falling back to the area its path implies. Known areas: ${Object.keys(AREAS).join(', ')}.`
+    );
+  }
+
+  return areaFromPath(path);
+}
+
+/**
+ * The area for a page read back from the post list.
+ *
+ * Astro only gives a page module a `url` when its file resolves inside
+ * src/pages, and the generated API pages are symlinked in during local
+ * development — so those modules arrive with no url at all. `urlHint` is for
+ * the caller that can rebuild it (see apiNavigation.urlsByFile).
+ */
+export function pageArea(post: MarkdownInstance, urlHint?: string): Area {
+  return resolveArea(post?.frontmatter?.area, post?.url ?? urlHint ?? '');
+}
+
+// Pages whose frontmatter puts them in a different area than their path would.
+// The site nav works from a tree of urls with no frontmatter attached, so the
+// exceptions are collected up front and it looks them up by url.
+//
+// Only pages Astro gave a url — every hand-written one — can be listed here,
+// which is the same set that can carry an `area:` of its own.
+let overrides: Map<string, Area> | null = null;
+
+function areaOverrides(): Map<string, Area> {
+  if (overrides !== null && import.meta.env.PROD) return overrides;
+
+  const map = new Map<string, Area>();
+  for (const post of accelerator.posts.all()) {
+    const declared = post.frontmatter?.area;
+    if (declared == null || post.url == null) continue;
+
+    const area = resolveArea(declared, post.url);
+    if (area !== areaFromPath(post.url)) map.set(trimSlash(post.url), area);
+  }
+
+  // Builds only. In dev the page set changes under you, so rebuild each call.
+  if (import.meta.env.PROD) overrides = map;
+  return map;
+}
+
+/**
+ * The area a url belongs to, frontmatter overrides included. For callers that
+ * have a url and nothing else; anything holding the page itself should use
+ * pageArea() and skip the lookup.
+ */
+export function areaForUrl(url: string): Area {
+  return areaOverrides().get(trimSlash(url)) ?? areaFromPath(url);
+}
+
+/**
+ * Breadcrumbs for a page, with the area's own section crumb spliced in where
+ * the section has no page for the generic walk to land on. For an area that
+ * needs no splice this is buildCrumbs().
+ */
+export function buildAreaCrumbs(
+  currentUrl: URL,
+  area: Area,
+  extraCrumbs?: ReadonlyArray<Crumb> | null
+): Crumb[] {
+  const crumbs = buildCrumbs(currentUrl, extraCrumbs);
+  const { path, sectionCrumb } = AREAS[area];
+
+  if (path === null || sectionCrumb === null) return crumbs;
+  if (!currentUrl.pathname.startsWith(SITE.subfolder + path)) return crumbs;
+  if (crumbs.some((crumb) => crumb.title === sectionCrumb)) return crumbs;
+
+  // After the /docs crumb, which is the only one the walk finds above us. The
+  // crumb carries no url on purpose: there is nothing to link to until the
+  // section has a landing page.
+  const insertAt = crumbs.findIndex(
+    (crumb) => trimSlash(crumb.url) === SITE.subfolder
+  );
+  crumbs.splice(insertAt + 1, 0, { url: '', title: sectionCrumb });
+
+  return crumbs;
+}

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -119,12 +119,27 @@ function areaOverrides(): Map<string, Area> {
 }
 
 /**
- * The area a url belongs to, frontmatter overrides included. For callers that
- * have a url and nothing else; anything holding the page itself should use
- * pageArea() and skip the lookup.
+ * A resolver for a caller that has urls and nothing else; anything holding the
+ * page itself should use pageArea() and skip the lookup.
+ *
+ * One resolver per pass over a set of urls. The overrides behind it are read
+ * once per resolver, which is the point: collecting them walks the whole page
+ * set, and in dev that set is re-read from disk every time, so a url-at-a-time
+ * lookup turns a tree walk into thousands of them.
+ *
+ * They are collected on first use rather than up front, because reading the
+ * page set is also what pulls the nav tree's lazy children into being, and
+ * doing that before the caller's first lookup reorders the siblings that tie
+ * on navOrder. A resolver that is only meant to be faster has no business
+ * moving nav rows around.
  */
-export function areaForUrl(url: string): Area {
-  return areaOverrides().get(trimSlash(url)) ?? areaFromPath(url);
+export function areaResolver(): (url: string) => Area {
+  let overridesForPass: Map<string, Area> | null = null;
+
+  return (url) => {
+    overridesForPass ??= areaOverrides();
+    return overridesForPass.get(trimSlash(url)) ?? areaFromPath(url);
+  };
 }
 
 /**

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -14,8 +14,13 @@ import { accelerator } from './accelerator';
 // including the ~100 generated ones. A page that needs to say otherwise puts
 // `area:` in its frontmatter and that wins.
 //
-// Adding an area takes three things: an entry below, a case in
-// components/AreaNavigation.astro, and the nav component it points at.
+// Adding an area takes four things, and this list is the only copy of it:
+//   1. an entry in AREAS below, and the area's name in the Area union
+//   2. the nav component it will render
+//   3. a line for it in components/AreaNavigation.astro
+//   4. its name in the `area` field's `choices` in frontmatter.json - miss this
+//      one and the build still passes while authors cannot pick the area in
+//      Front Matter CMS, with nothing on screen to say why
 
 export type Area = 'docs' | 'api';
 
@@ -45,7 +50,22 @@ const PATH_AREAS = (Object.entries(AREAS) as [Area, AreaDefinition][])
 const trimSlash = (path: string) => path.replace(/\/$/, '');
 
 function isArea(value: unknown): value is Area {
-  return typeof value === 'string' && value in AREAS;
+  // hasOwn, not `in`: `in` also finds Object.prototype's keys, so `area:
+  // constructor` would validate and then resolve to a function, taking the page
+  // out of every nav on the site - the outcome resolveArea() promises to avoid.
+  return typeof value === 'string' && Object.hasOwn(AREAS, value);
+}
+
+/**
+ * Whether a path sits inside an area's own path, on a path boundary.
+ *
+ * The boundary is the whole point: /docs/api-and-integration is not part of
+ * /docs/api. Everything that compares a path against an area goes through here
+ * so the rule cannot be applied in one place and skipped in another.
+ */
+function isUnderAreaPath(pathname: string, areaPath: string): boolean {
+  const prefix = SITE.subfolder + areaPath;
+  return pathname === prefix || pathname.startsWith(prefix + '/');
 }
 
 /**
@@ -58,8 +78,7 @@ export function areaFromPath(path: string): Area {
   const pathname = trimSlash(path);
 
   for (const [area, definition] of PATH_AREAS) {
-    const prefix = SITE.subfolder + definition.path;
-    if (pathname === prefix || pathname.startsWith(prefix + '/')) return area;
+    if (isUnderAreaPath(pathname, definition.path as string)) return area;
   }
 
   return DEFAULT_AREA;
@@ -81,6 +100,38 @@ export function resolveArea(declared: unknown, path: string): Area {
   return areaFromPath(path);
 }
 
+// astro-accelerator-utils rewrites a redirect page's nav url to point at
+// whatever it redirects to (mapNavPage in navigation.mjs), so the page has no
+// nav node of its own for an area to move. Honouring `area:` on one would put
+// it in the API nav via pageArea() while the site nav kept it, landing it in
+// both trees - so it is not honoured anywhere, and says so out loud.
+const REDIRECT_LAYOUT = 'src/layouts/Redirect.astro';
+
+function declaredArea(post: MarkdownInstance): unknown {
+  const declared = post?.frontmatter?.area;
+  if (declared == null) return null;
+
+  if (post?.frontmatter?.layout === REDIRECT_LAYOUT) {
+    console.warn(
+      `area: "${String(declared)}" on ${post.url ?? post.file} has no effect: the page redirects, so its nav entry belongs to ${String(post.frontmatter.redirect)}. Set the area on the page it redirects to.`
+    );
+    return null;
+  }
+
+  return declared;
+}
+
+/**
+ * The url the nav tree will carry for a page, which is not always the url the
+ * page is served from: mapNavPage() sends a paged page straight to its first
+ * page. Overrides are looked up by what the tree holds, so they are keyed the
+ * same way. Keep in step with astro-accelerator-utils navigation.mjs.
+ */
+function navUrl(post: MarkdownInstance): string {
+  const url = post.url ?? '';
+  return post.frontmatter?.paged ? trimSlash(url) + '/1' : url;
+}
+
 /**
  * The area for a page read back from the post list.
  *
@@ -90,7 +141,7 @@ export function resolveArea(declared: unknown, path: string): Area {
  * the caller that can rebuild it (see apiNavigation.urlsByFile).
  */
 export function pageArea(post: MarkdownInstance, urlHint?: string): Area {
-  return resolveArea(post?.frontmatter?.area, post?.url ?? urlHint ?? '');
+  return resolveArea(declaredArea(post), post?.url ?? urlHint ?? '');
 }
 
 // Pages whose frontmatter puts them in a different area than their path would.
@@ -106,11 +157,13 @@ function areaOverrides(): Map<string, Area> {
 
   const map = new Map<string, Area>();
   for (const post of accelerator.posts.all()) {
-    const declared = post.frontmatter?.area;
+    const declared = declaredArea(post);
     if (declared == null || post.url == null) continue;
 
+    // The area is decided by the url the page is served from; the key is the
+    // url the nav tree will look it up by. For most pages these are the same.
     const area = resolveArea(declared, post.url);
-    if (area !== areaFromPath(post.url)) map.set(trimSlash(post.url), area);
+    if (area !== areaFromPath(post.url)) map.set(trimSlash(navUrl(post)), area);
   }
 
   // Builds only. In dev the page set changes under you, so rebuild each call.
@@ -122,24 +175,16 @@ function areaOverrides(): Map<string, Area> {
  * A resolver for a caller that has urls and nothing else; anything holding the
  * page itself should use pageArea() and skip the lookup.
  *
- * One resolver per pass over a set of urls. The overrides behind it are read
- * once per resolver, which is the point: collecting them walks the whole page
- * set, and in dev that set is re-read from disk every time, so a url-at-a-time
- * lookup turns a tree walk into thousands of them.
- *
- * They are collected on first use rather than up front, because reading the
- * page set is also what pulls the nav tree's lazy children into being, and
- * doing that before the caller's first lookup reorders the siblings that tie
- * on navOrder. A resolver that is only meant to be faster has no business
- * moving nav rows around.
+ * One resolver per pass over a set of urls, and that is the whole point of it:
+ * collecting the overrides walks the entire page set, which in dev is re-read
+ * from disk every call, so looking them up a url at a time turns one tree walk
+ * into thousands of reads. It measured at 2.0s against 0.22s on a dev page
+ * render before this existed.
  */
 export function areaResolver(): (url: string) => Area {
-  let overridesForPass: Map<string, Area> | null = null;
+  const overridesForPass = areaOverrides();
 
-  return (url) => {
-    overridesForPass ??= areaOverrides();
-    return overridesForPass.get(trimSlash(url)) ?? areaFromPath(url);
-  };
+  return (url) => overridesForPass.get(trimSlash(url)) ?? areaFromPath(url);
 }
 
 /**
@@ -156,7 +201,11 @@ export function buildAreaCrumbs(
   const { path, sectionCrumb } = AREAS[area];
 
   if (path === null || sectionCrumb === null) return crumbs;
-  if (!currentUrl.pathname.startsWith(SITE.subfolder + path)) return crumbs;
+  // The crumbs follow the url, not the area: a page at /docs/guides/api-tour
+  // that declares `area: api` shows the API nav but still sits under Docs >
+  // Guides, so it gets no crumb from here. isUnderAreaPath, not a bare
+  // startsWith, or /docs/api-and-integration would collect an "Api" crumb.
+  if (!isUnderAreaPath(trimSlash(currentUrl.pathname), path)) return crumbs;
   if (crumbs.some((crumb) => crumb.title === sectionCrumb)) return crumbs;
 
   // After the /docs crumb, which is the only one the walk finds above us. The

--- a/src/lib/navigationTree.ts
+++ b/src/lib/navigationTree.ts
@@ -2,7 +2,7 @@ import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
 import { SITE } from '@config';
 import { menu } from '@data/navigation';
 import { accelerator } from './accelerator';
-import { apiPageUrls } from './apiNavigation';
+import { areaForUrl } from './areas';
 
 // Navigation.autoMenu() rebuilds the whole site nav tree from all ~2,700 pages
 // on every page render, and its getChildren() runs a full scan of that page
@@ -19,20 +19,20 @@ const TEMPLATE_URL = new URL('https://octopus.com/__nav-template__');
 
 let template: NavPage[] | null = null;
 
-// The API reference is navigated by its own tree (lib/apiNavigation.ts), so
-// its pages are dropped here rather than listed in both. Dropping a node drops
-// its children with it, which is what takes the whole section out in one go.
-function withoutApiPages(pages: NavPage[]): NavPage[] {
-  const apiUrls = apiPageUrls();
+// This is the docs area's tree. Every other area is navigated by its own — the
+// API reference by lib/apiNavigation.ts — so their pages are dropped here
+// rather than listed in both. Dropping a node drops its children with it, which
+// is what takes a whole section out in one go.
+function withoutOtherAreas(pages: NavPage[]): NavPage[] {
   const prune = (nodes: NavPage[]): NavPage[] =>
     nodes
-      .filter((node) => !apiUrls.has((node.url ?? '').replace(/\/$/, '')))
+      .filter((node) => areaForUrl(node.url ?? '') === 'docs')
       .map((node) => ({ ...node, children: prune(node.children ?? []) }));
   return prune(pages);
 }
 
 function buildMenu(): NavPage[] {
-  return withoutApiPages(
+  return withoutOtherAreas(
     accelerator.navigation.menu(TEMPLATE_URL, SITE.subfolder, menu)
   );
 }

--- a/src/lib/navigationTree.ts
+++ b/src/lib/navigationTree.ts
@@ -2,7 +2,7 @@ import type { NavPage } from 'astro-accelerator-utils/types/NavPage';
 import { SITE } from '@config';
 import { menu } from '@data/navigation';
 import { accelerator } from './accelerator';
-import { areaForUrl } from './areas';
+import { areaResolver } from './areas';
 
 // Navigation.autoMenu() rebuilds the whole site nav tree from all ~2,700 pages
 // on every page render, and its getChildren() runs a full scan of that page
@@ -24,9 +24,12 @@ let template: NavPage[] | null = null;
 // rather than listed in both. Dropping a node drops its children with it, which
 // is what takes a whole section out in one go.
 function withoutOtherAreas(pages: NavPage[]): NavPage[] {
+  // One resolver for the whole walk: areas.ts reads the page set to find the
+  // frontmatter overrides, and that is not a per-node cost.
+  const areaOf = areaResolver();
   const prune = (nodes: NavPage[]): NavPage[] =>
     nodes
-      .filter((node) => areaForUrl(node.url ?? '') === 'docs')
+      .filter((node) => areaOf(node.url ?? '') === 'docs')
       .map((node) => ({ ...node, children: prune(node.children ?? []) }));
   return prune(pages);
 }

--- a/src/pages/docs/api/accounts.md
+++ b/src/pages/docs/api/accounts.md
@@ -78,7 +78,8 @@ Lists accounts in the supplied Octopus Deploy Space in pages. The results will b
       "AccountType": "AmazonWebServicesAccount",
       "Description": "string",
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "LastModifiedBy": "string",
@@ -90,9 +91,10 @@ Lists accounts in the supplied Octopus Deploy Space in pages. The results will b
       },
       "Name": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -147,13 +149,15 @@ Also reachable at `/api/accounts`, `/api/spaces/{spaceIdentifier}/accounts`.
     "AccountType": "string"
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -193,7 +197,8 @@ Also reachable at `/api/accounts`, `/api/spaces/{spaceIdentifier}/accounts`.
   "AccountType": "AmazonWebServicesAccount",
   "Description": "string",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "LastModifiedBy": "string",
@@ -205,9 +210,10 @@ Also reachable at `/api/accounts`, `/api/spaces/{spaceIdentifier}/accounts`.
   },
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -261,7 +267,8 @@ Lists all of the accounts in the supplied Octopus Deploy Space. The results will
     "AccountType": "AmazonWebServicesAccount",
     "Description": "string",
     "EnvironmentIds": [
-      "string"
+      "Environments-1",
+      "..."
     ],
     "Id": "string",
     "LastModifiedBy": "string",
@@ -273,9 +280,10 @@ Lists all of the accounts in the supplied Octopus Deploy Space. The results will
     },
     "Name": "string",
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TenantIds": [
-      "string"
+      "Tenants-1",
+      "..."
     ],
     "TenantTags": [
       "string"
@@ -325,19 +333,21 @@ Also reachable at `/api/accounts/{accountId}`, `/api/spaces/{spaceIdentifier}/ac
 :::api-example{label="Request"}
 ```json
 {
-  "AccountId": "string",
+  "AccountId": "Accounts-1",
   "Description": "string",
   "Details": {
     "AccountType": "string"
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -377,7 +387,8 @@ Also reachable at `/api/accounts/{accountId}`, `/api/spaces/{spaceIdentifier}/ac
   "AccountType": "AmazonWebServicesAccount",
   "Description": "string",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "LastModifiedBy": "string",
@@ -389,9 +400,10 @@ Also reachable at `/api/accounts/{accountId}`, `/api/spaces/{spaceIdentifier}/ac
   },
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -444,7 +456,8 @@ Also reachable at `/api/accounts/{id}`, `/api/spaces/{spaceIdentifier}/accounts/
   "AccountType": "AmazonWebServicesAccount",
   "Description": "string",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "LastModifiedBy": "string",
@@ -456,9 +469,10 @@ Also reachable at `/api/accounts/{id}`, `/api/spaces/{spaceIdentifier}/accounts/
   },
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -618,7 +632,7 @@ Also reachable at `/api/accounts/{id}/usages`, `/api/spaces/{spaceIdentifier}/ac
       "LibraryVariableSets": [
         {}
       ],
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
   "DeploymentProcesses": [
@@ -650,13 +664,13 @@ Also reachable at `/api/accounts/{id}/usages`, `/api/spaces/{spaceIdentifier}/ac
       "Projects": [
         {}
       ],
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
   "ProjectVariableSets": [
     {
       "IsCurrentlyBeingUsedInProject": true,
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "ProjectSlug": "string",
       "Releases": [
@@ -691,7 +705,7 @@ Also reachable at `/api/accounts/{id}/usages`, `/api/spaces/{spaceIdentifier}/ac
   ],
   "RunbookSnapshots": [
     {
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "RunbookId": "string",
       "RunbookName": "string",

--- a/src/pages/docs/api/action-templates.md
+++ b/src/pages/docs/api/action-templates.md
@@ -143,7 +143,7 @@ Lists all of the Action Templates in the supplied Octopus Deploy Space. The resu
         "additionalProp2": {},
         "additionalProp3": {}
       },
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Version": 0
     }
   ],
@@ -234,7 +234,7 @@ Also reachable at `/api/actiontemplates`, `/api/spaces/{spaceIdentifier}/actiont
 ```json
 {
   "ActionType": "string",
-  "CommunityActionTemplateId": "string",
+  "CommunityActionTemplateId": "CommunityActionTemplates-1",
   "Description": "string",
   "GitDependencies": [
     {
@@ -317,7 +317,7 @@ Also reachable at `/api/actiontemplates`, `/api/spaces/{spaceIdentifier}/actiont
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StepPackageVersion": "string",
   "Version": 0
 }
@@ -472,7 +472,7 @@ Also reachable at `/api/actiontemplates`, `/api/spaces/{spaceIdentifier}/actiont
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -616,7 +616,7 @@ Lists the all of the action templates in the supplied Octopus Deploy Space. The 
         "Value": "string"
       }
     },
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Version": 0
   }
 ]
@@ -726,7 +726,7 @@ Lists all of the Action Templates in the supplied Octopus Deploy Space that fit 
     },
     "Name": "string",
     "Prerelease": true,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Type": "string",
     "Version": "string",
     "Website": "string"
@@ -896,7 +896,7 @@ Also reachable at `/api/actiontemplates/{id}`, `/api/spaces/{spaceIdentifier}/ac
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -982,7 +982,7 @@ Also reachable at `/api/actiontemplates/{id}`, `/api/spaces/{spaceIdentifier}/ac
       "StepPackageInputsReferenceId": "string"
     }
   ],
-  "Id": "string",
+  "Id": "ActionTemplates-1",
   "Inputs": {
     "Value": "string"
   },
@@ -1050,7 +1050,7 @@ Also reachable at `/api/actiontemplates/{id}`, `/api/spaces/{spaceIdentifier}/ac
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StepPackageVersion": "string"
 }
 ```
@@ -1204,7 +1204,7 @@ Also reachable at `/api/actiontemplates/{id}`, `/api/spaces/{spaceIdentifier}/ac
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -1304,7 +1304,7 @@ Also reachable at `/api/actiontemplates/{id}/actionsUpdate`, `/api/spaces/{space
       "Value": "string"
     }
   },
-  "Id": "string",
+  "Id": "ActionTemplates-1",
   "Overrides": {
     "additionalProp1": {
       "IsSensitive": true,
@@ -1334,7 +1334,7 @@ Also reachable at `/api/actiontemplates/{id}/actionsUpdate`, `/api/spaces/{space
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -1477,7 +1477,7 @@ Also reachable at `/api/actiontemplates/{id}/actionsUpdate/bulk`, `/api/spaces/{
       "Value": "string"
     }
   },
-  "Id": "string",
+  "Id": "ActionTemplates-1",
   "Overrides": {
     "additionalProp1": {
       "IsSensitive": true,
@@ -1507,7 +1507,7 @@ Also reachable at `/api/actiontemplates/{id}/actionsUpdate/bulk`, `/api/spaces/{
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -1562,7 +1562,7 @@ Also reachable at `/api/actiontemplates/{id}/actionsUpdate/bulk`, `/api/spaces/{
       ]
     }
   ],
-  "TaskId": "string",
+  "TaskId": "ServerTasks-1",
   "ValidationFailures": [
     "string"
   ]
@@ -1867,7 +1867,7 @@ Also reachable at `/api/actiontemplates/{id}/v1`, `/api/spaces/{spaceIdentifier}
         "Value": "string"
       }
     },
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Version": 0
   }
 }
@@ -2012,7 +2012,7 @@ Also reachable at `/api/actiontemplates/{id}/versions`, `/api/spaces/{spaceIdent
         "Value": "string"
       }
     },
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Version": 0
   }
 ]
@@ -2182,7 +2182,7 @@ Also reachable at `/api/actiontemplates/{id}/versions/{version}`, `/api/spaces/{
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```

--- a/src/pages/docs/api/api-keys.md
+++ b/src/pages/docs/api/api-keys.md
@@ -58,7 +58,8 @@ Lists all API keys for a user, returning the most recent results first.
   - **`Links`** :span[object]{.type-label}  
     Gets or sets a dictionary of links to other related resources. These links can be used to navigate the resources on the server.
   - **`Purpose`** :span[string]{.type-label}
-  - **`UserId`** :span[string]{.type-label}
+  - **`UserId`** :span[string]{.type-label}  
+    Minimum length 1.
 - **`ItemsPerPage`** :span[integer]{.type-label}
 - **`LastModifiedBy`** :span[string]{.type-label}  
   Gets or sets the username of the user who last modified this resource.
@@ -144,7 +145,7 @@ The API Key returned in the result must be saved by the caller, as it cannot be 
   "ActorType": "User",
   "Expires": "2020-01-01T00:00:00.000Z",
   "Purpose": "string",
-  "UserId": "string"
+  "UserId": "Users-1"
 }
 ```
 :::
@@ -155,7 +156,8 @@ The API Key returned in the result must be saved by the caller, as it cannot be 
 
 - **`ActorType`** :span[enum]{.type-label}  
   Allowed values: `User`, `AiAgent`.
-- **`ApiKey`** :span[string]{.type-label}
+- **`ApiKey`** :span[string]{.type-label}  
+  Minimum length 1.
 - **`Created`** :span[string]{.type-label}  
   Format `date-time`.
 - **`Expires`** :span[string]{.type-label}  
@@ -172,7 +174,8 @@ The API Key returned in the result must be saved by the caller, as it cannot be 
 - **`Links`** :span[object]{.type-label}  
   Gets or sets a dictionary of links to other related resources. These links can be used to navigate the resources on the server.
 - **`Purpose`** :span[string]{.type-label}
-- **`UserId`** :span[string]{.type-label}
+- **`UserId`** :span[string]{.type-label}  
+  Minimum length 1.
 
 :::api-example{label="Response"}
 ```json
@@ -319,7 +322,8 @@ Lists all API keys for a user, returning the most recent results first.
 - **`Links`** :span[object]{.type-label}  
   Gets or sets a dictionary of links to other related resources. These links can be used to navigate the resources on the server.
 - **`Purpose`** :span[string]{.type-label}
-- **`UserId`** :span[string]{.type-label}
+- **`UserId`** :span[string]{.type-label}  
+  Minimum length 1.
 
 :::api-example{label="Response"}
 ```json

--- a/src/pages/docs/api/artifacts.md
+++ b/src/pages/docs/api/artifacts.md
@@ -86,10 +86,10 @@ Also reachable at `/api/artifacts`, `/api/spaces/{spaceIdentifier}/artifacts`.
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "LogCorrelationId": "string",
+      "LogCorrelationId": "0c5a872485ac4b10857939a92d082e67",
       "ServerTaskId": "string",
       "Source": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -137,10 +137,10 @@ Creates a new artifact.
 ```json
 {
   "Filename": "Performance Test Results.csv",
-  "LogCorrelationId": "string",
-  "ServerTaskId": "string",
+  "LogCorrelationId": "0c5a872485ac4b10857939a92d082e67",
+  "ServerTaskId": "ServerTasks-1",
   "Source": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -182,10 +182,10 @@ Creates a new artifact.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "LogCorrelationId": "string",
+  "LogCorrelationId": "0c5a872485ac4b10857939a92d082e67",
   "ServerTaskId": "string",
   "Source": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -240,10 +240,10 @@ Also reachable at `/api/artifacts/{id}`, `/api/spaces/{spaceIdentifier}/artifact
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "LogCorrelationId": "string",
+  "LogCorrelationId": "0c5a872485ac4b10857939a92d082e67",
   "ServerTaskId": "string",
   "Source": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -298,10 +298,10 @@ Also reachable at `/api/artifacts/{id}`, `/api/spaces/{spaceIdentifier}/artifact
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "LogCorrelationId": "string",
+  "LogCorrelationId": "0c5a872485ac4b10857939a92d082e67",
   "ServerTaskId": "string",
   "Source": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/branches.md
+++ b/src/pages/docs/api/branches.md
@@ -120,8 +120,8 @@ Also reachable at `/api/projects/{projectId}/git/branches/v2`, `/api/spaces/{spa
 {
   "BaseGitRef": "string",
   "NewBranchName": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/build-information.md
+++ b/src/pages/docs/api/build-information.md
@@ -177,7 +177,7 @@ Also reachable at `/api/build-information`, `/api/spaces/{spaceIdentifier}/build
   "OverwriteMode": "FailIfExists",
   "PackageId": "string",
   "Replace": true,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": "string"
 }
 ```
@@ -286,7 +286,7 @@ Also reachable at `/api/build-information/bulk`, `/api/spaces/{spaceIdentifier}/
   "Ids": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/certificates.md
+++ b/src/pages/docs/api/certificates.md
@@ -118,7 +118,8 @@ Also reachable at `/api/certificates`, `/api/spaces/{spaceIdentifier}/certificat
       },
       "CertificateDataFormat": "Pkcs12",
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasPrivateKey": true,
       "Id": "string",
@@ -146,7 +147,7 @@ Also reachable at `/api/certificates`, `/api/spaces/{spaceIdentifier}/certificat
       "SelfSigned": true,
       "SerialNumber": "string",
       "SignatureAlgorithmName": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SubjectAlternativeNames": [
         "string"
       ],
@@ -154,7 +155,8 @@ Also reachable at `/api/certificates`, `/api/spaces/{spaceIdentifier}/certificat
       "SubjectDistinguishedName": "string",
       "SubjectOrganization": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -221,7 +223,8 @@ Adds a new certificate
     "NewValue": "string"
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Name": "string",
   "Notes": "string",
@@ -230,9 +233,10 @@ Adds a new certificate
     "Hint": "string",
     "NewValue": "string"
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -330,7 +334,8 @@ Adds a new certificate
   },
   "CertificateDataFormat": "Pkcs12",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasPrivateKey": true,
   "Id": "string",
@@ -358,7 +363,7 @@ Adds a new certificate
   "SelfSigned": true,
   "SerialNumber": "string",
   "SignatureAlgorithmName": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SubjectAlternativeNames": [
     "string"
   ],
@@ -366,7 +371,8 @@ Adds a new certificate
   "SubjectDistinguishedName": "string",
   "SubjectOrganization": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -485,7 +491,8 @@ Lists X.509 certificates managed by Octopus.
     },
     "CertificateDataFormat": "Pkcs12",
     "EnvironmentIds": [
-      "string"
+      "Environments-1",
+      "..."
     ],
     "HasPrivateKey": true,
     "Id": "string",
@@ -513,7 +520,7 @@ Lists X.509 certificates managed by Octopus.
     "SelfSigned": true,
     "SerialNumber": "string",
     "SignatureAlgorithmName": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "SubjectAlternativeNames": [
       "string"
     ],
@@ -521,7 +528,8 @@ Lists X.509 certificates managed by Octopus.
     "SubjectDistinguishedName": "string",
     "SubjectOrganization": "string",
     "TenantIds": [
-      "string"
+      "Tenants-1",
+      "..."
     ],
     "TenantTags": [
       "string"
@@ -672,7 +680,8 @@ Also reachable at `/api/certificates/generate`, `/api/spaces/{spaceIdentifier}/c
   },
   "CertificateDataFormat": "Pkcs12",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasPrivateKey": true,
   "Id": "string",
@@ -701,7 +710,7 @@ Also reachable at `/api/certificates/generate`, `/api/spaces/{spaceIdentifier}/c
   "SelfSignedCertificateCurve": "string",
   "SerialNumber": "string",
   "SignatureAlgorithmName": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SubjectAlternativeNames": [
     "string"
   ],
@@ -709,7 +718,8 @@ Also reachable at `/api/certificates/generate`, `/api/spaces/{spaceIdentifier}/c
   "SubjectDistinguishedName": "string",
   "SubjectOrganization": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -809,7 +819,8 @@ Also reachable at `/api/certificates/generate`, `/api/spaces/{spaceIdentifier}/c
   },
   "CertificateDataFormat": "Pkcs12",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasPrivateKey": true,
   "Id": "string",
@@ -837,7 +848,7 @@ Also reachable at `/api/certificates/generate`, `/api/spaces/{spaceIdentifier}/c
   "SelfSigned": true,
   "SerialNumber": "string",
   "SignatureAlgorithmName": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SubjectAlternativeNames": [
     "string"
   ],
@@ -845,7 +856,8 @@ Also reachable at `/api/certificates/generate`, `/api/spaces/{spaceIdentifier}/c
   "SubjectDistinguishedName": "string",
   "SubjectOrganization": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -961,7 +973,8 @@ Skip and Take are required. TotalResults is always the real count of matching ce
       },
       "CertificateDataFormat": "Pkcs12",
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasPrivateKey": true,
       "Id": "string",
@@ -989,7 +1002,7 @@ Skip and Take are required. TotalResults is always the real count of matching ce
       "SelfSigned": true,
       "SerialNumber": "string",
       "SignatureAlgorithmName": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SubjectAlternativeNames": [
         "string"
       ],
@@ -997,7 +1010,8 @@ Skip and Take are required. TotalResults is always the real count of matching ce
       "SubjectDistinguishedName": "string",
       "SubjectOrganization": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -1116,7 +1130,8 @@ Also reachable at `/api/certificates/{id}`, `/api/spaces/{spaceIdentifier}/certi
   },
   "CertificateDataFormat": "Pkcs12",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasPrivateKey": true,
   "Id": "string",
@@ -1144,7 +1159,7 @@ Also reachable at `/api/certificates/{id}`, `/api/spaces/{spaceIdentifier}/certi
   "SelfSigned": true,
   "SerialNumber": "string",
   "SignatureAlgorithmName": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SubjectAlternativeNames": [
     "string"
   ],
@@ -1152,7 +1167,8 @@ Also reachable at `/api/certificates/{id}`, `/api/spaces/{spaceIdentifier}/certi
   "SubjectDistinguishedName": "string",
   "SubjectOrganization": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -1203,14 +1219,16 @@ Modifies an existing certificate
 ```json
 {
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
-  "Id": "string",
+  "Id": "Certificates-1",
   "Name": "string",
   "Notes": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -1308,7 +1326,8 @@ Modifies an existing certificate
   },
   "CertificateDataFormat": "Pkcs12",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasPrivateKey": true,
   "Id": "string",
@@ -1336,7 +1355,7 @@ Modifies an existing certificate
   "SelfSigned": true,
   "SerialNumber": "string",
   "SignatureAlgorithmName": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SubjectAlternativeNames": [
     "string"
   ],
@@ -1344,7 +1363,8 @@ Modifies an existing certificate
   "SubjectDistinguishedName": "string",
   "SubjectOrganization": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -1476,9 +1496,9 @@ Also reachable at `/api/certificates/{id}/replace`, `/api/spaces/{spaceIdentifie
 ```json
 {
   "CertificateData": "string",
-  "Id": "string",
+  "Id": "Certificates-1",
   "Password": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1571,7 +1591,8 @@ Also reachable at `/api/certificates/{id}/replace`, `/api/spaces/{spaceIdentifie
   },
   "CertificateDataFormat": "Pkcs12",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasPrivateKey": true,
   "Id": "string",
@@ -1599,7 +1620,7 @@ Also reachable at `/api/certificates/{id}/replace`, `/api/spaces/{spaceIdentifie
   "SelfSigned": true,
   "SerialNumber": "string",
   "SignatureAlgorithmName": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SubjectAlternativeNames": [
     "string"
   ],
@@ -1607,7 +1628,8 @@ Also reachable at `/api/certificates/{id}/replace`, `/api/spaces/{spaceIdentifie
   "SubjectDistinguishedName": "string",
   "SubjectOrganization": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -1829,7 +1851,8 @@ Get the usages of a certificate
         "Links": {}
       },
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasLatestCalamari": true,
       "HealthStatus": "Healthy",
@@ -1854,10 +1877,11 @@ Get the usages of a certificate
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -1883,7 +1907,7 @@ Get the usages of a certificate
         "additionalProp3": "string"
       },
       "Name": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -1903,14 +1927,14 @@ Get the usages of a certificate
       "AutoDeployReleaseOverrides": [
         {}
       ],
-      "ClonedFromProjectId": "string",
+      "ClonedFromProjectId": "Projects-1",
       "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
       "DefaultGuidedFailureMode": "EnvironmentDefault",
       "DefaultPowerShellEdition": "string",
       "DefaultToSkipIfAlreadyInstalled": true,
       "DeploymentChangesTemplate": "string",
       "DeploymentProcessId": "string",
-      "DeprovisioningRunbookId": "string",
+      "DeprovisioningRunbookId": "Runbooks-1",
       "Description": "string",
       "DiscreteChannelRelease": true,
       "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -1958,14 +1982,14 @@ Get the usages of a certificate
         "Slug": "string",
         "VersionMask": "string"
       },
-      "ProvisioningRunbookId": "string",
+      "ProvisioningRunbookId": "Runbooks-1",
       "ReleaseCreationStrategy": {
         "ChannelId": "string",
         "ReleaseCreationPackage": {}
       },
       "ReleaseNotesTemplate": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -2010,7 +2034,7 @@ Get the usages of a certificate
         ]
       },
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TenantTags": [
         "string"
       ]

--- a/src/pages/docs/api/channels.md
+++ b/src/pages/docs/api/channels.md
@@ -90,8 +90,8 @@ Also reachable at `/api/channels`, `/api/spaces/{spaceIdentifier}/channels`.
   "IsDefault": true,
   "LifecycleId": "string",
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -112,7 +112,7 @@ Also reachable at `/api/channels`, `/api/spaces/{spaceIdentifier}/channels`.
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -206,8 +206,8 @@ Also reachable at `/api/channels`, `/api/spaces/{spaceIdentifier}/channels`.
     "additionalProp3": "string"
   },
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -228,7 +228,7 @@ Also reachable at `/api/channels`, `/api/spaces/{spaceIdentifier}/channels`.
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -340,8 +340,8 @@ Lists all of the channels in the supplied Octopus Deploy Space. The results will
       "additionalProp3": "string"
     },
     "Name": "string",
-    "ParentEnvironmentId": "string",
-    "ProjectId": "string",
+    "ParentEnvironmentId": "Environments-1",
+    "ProjectId": "Projects-1",
     "Rules": [
       {
         "ActionPackages": [
@@ -358,7 +358,7 @@ Lists all of the channels in the supplied Octopus Deploy Space. The results will
       }
     ],
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TenantTags": [
       "string"
     ],
@@ -732,12 +732,12 @@ Also reachable at `/api/channels/{id}`, `/api/spaces/{spaceIdentifier}/channels/
       ]
     }
   ],
-  "Id": "string",
+  "Id": "Channels-1",
   "IsDefault": true,
   "LifecycleId": "string",
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -758,7 +758,7 @@ Also reachable at `/api/channels/{id}`, `/api/spaces/{spaceIdentifier}/channels/
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -851,8 +851,8 @@ Also reachable at `/api/channels/{id}`, `/api/spaces/{spaceIdentifier}/channels/
     "additionalProp3": "string"
   },
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -873,7 +873,7 @@ Also reachable at `/api/channels/{id}`, `/api/spaces/{spaceIdentifier}/channels/
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -998,13 +998,13 @@ Lists all the channels for the given project
         "additionalProp3": "string"
       },
       "Name": "string",
-      "ParentEnvironmentId": "string",
-      "ProjectId": "string",
+      "ParentEnvironmentId": "Environments-1",
+      "ProjectId": "Projects-1",
       "Rules": [
         {}
       ],
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TenantTags": [
         "string"
       ],
@@ -1112,8 +1112,8 @@ Also reachable at `/api/projects/{projectId}/channels`, `/api/spaces/{spaceIdent
   "IsDefault": true,
   "LifecycleId": "string",
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -1134,7 +1134,7 @@ Also reachable at `/api/projects/{projectId}/channels`, `/api/spaces/{spaceIdent
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -1228,8 +1228,8 @@ Also reachable at `/api/projects/{projectId}/channels`, `/api/spaces/{spaceIdent
     "additionalProp3": "string"
   },
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -1250,7 +1250,7 @@ Also reachable at `/api/projects/{projectId}/channels`, `/api/spaces/{spaceIdent
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -1428,8 +1428,8 @@ Also reachable at `/api/projects/{projectId}/channels/{id}`, `/api/spaces/{space
     "additionalProp3": "string"
   },
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -1450,7 +1450,7 @@ Also reachable at `/api/projects/{projectId}/channels/{id}`, `/api/spaces/{space
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -1545,12 +1545,12 @@ Also reachable at `/api/projects/{projectId}/channels/{id}`, `/api/spaces/{space
       ]
     }
   ],
-  "Id": "string",
+  "Id": "Channels-1",
   "IsDefault": true,
   "LifecycleId": "string",
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -1571,7 +1571,7 @@ Also reachable at `/api/projects/{projectId}/channels/{id}`, `/api/spaces/{space
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -1664,8 +1664,8 @@ Also reachable at `/api/projects/{projectId}/channels/{id}`, `/api/spaces/{space
     "additionalProp3": "string"
   },
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -1686,7 +1686,7 @@ Also reachable at `/api/projects/{projectId}/channels/{id}`, `/api/spaces/{space
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],
@@ -1844,13 +1844,13 @@ Lists all of the Channels in the supplied Octopus Deploy Space, from all project
         "additionalProp3": "string"
       },
       "Name": "string",
-      "ParentEnvironmentId": "string",
-      "ProjectId": "string",
+      "ParentEnvironmentId": "Environments-1",
+      "ProjectId": "Projects-1",
       "Rules": [
         {}
       ],
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TenantTags": [
         "string"
       ],
@@ -1973,8 +1973,8 @@ Also reachable at `/api/channels/{id}`, `/api/spaces/{spaceIdentifier}/channels/
     "additionalProp3": "string"
   },
   "Name": "string",
-  "ParentEnvironmentId": "string",
-  "ProjectId": "string",
+  "ParentEnvironmentId": "Environments-1",
+  "ProjectId": "Projects-1",
   "Rules": [
     {
       "ActionPackages": [
@@ -1995,7 +1995,7 @@ Also reachable at `/api/channels/{id}`, `/api/spaces/{spaceIdentifier}/channels/
     }
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ],

--- a/src/pages/docs/api/community-action-templates.md
+++ b/src/pages/docs/api/community-action-templates.md
@@ -385,7 +385,7 @@ Also reachable at `/api/communityactiontemplates/{id}/actiontemplate`.
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -552,7 +552,7 @@ Also reachable at `/api/communityactiontemplates/{id}/installation`.
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```
@@ -719,7 +719,7 @@ Also reachable at `/api/communityactiontemplates/{id}/installation`.
       "Value": "string"
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": 0
 }
 ```

--- a/src/pages/docs/api/dashboard-configuration.md
+++ b/src/pages/docs/api/dashboard-configuration.md
@@ -47,7 +47,8 @@ Gets the dashboard configuration of the authenticated user for the current space
   "HideInactiveProjects": true,
   "Id": "string",
   "IncludedEnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "IncludedEnvironmentTags": [
     "string"
@@ -56,13 +57,15 @@ Gets the dashboard configuration of the authenticated user for the current space
     "string"
   ],
   "IncludedProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
   "IncludedProjectTags": [
     "string"
   ],
   "IncludedTenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "IncludedTenantTags": [
     "string"
@@ -75,7 +78,7 @@ Gets the dashboard configuration of the authenticated user for the current space
     "additionalProp3": "string"
   },
   "ProjectLimit": 0,
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -121,7 +124,8 @@ Modifies the dashboard configuration for the current user per space
 {
   "HideInactiveProjects": true,
   "IncludedEnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "IncludedEnvironmentTags": [
     "string"
@@ -130,19 +134,21 @@ Modifies the dashboard configuration for the current user per space
     "string"
   ],
   "IncludedProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
   "IncludedProjectTags": [
     "string"
   ],
   "IncludedTenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "IncludedTenantTags": [
     "string"
   ],
   "ProjectLimit": 0,
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -176,7 +182,8 @@ Modifies the dashboard configuration for the current user per space
   "HideInactiveProjects": true,
   "Id": "string",
   "IncludedEnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "IncludedEnvironmentTags": [
     "string"
@@ -185,13 +192,15 @@ Modifies the dashboard configuration for the current user per space
     "string"
   ],
   "IncludedProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
   "IncludedProjectTags": [
     "string"
   ],
   "IncludedTenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "IncludedTenantTags": [
     "string"
@@ -204,7 +213,7 @@ Modifies the dashboard configuration for the current user per space
     "additionalProp3": "string"
   },
   "ProjectLimit": 0,
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/dashboard.md
+++ b/src/pages/docs/api/dashboard.md
@@ -148,17 +148,17 @@ Also reachable at `/api/dashboard`, `/api/spaces/{spaceIdentifier}/dashboard`.
   "IsFiltered": true,
   "Items": [
     {
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "CompletedTime": "2020-01-01T00:00:00.000Z",
       "Created": "2020-01-01T00:00:00.000Z",
-      "DeploymentId": "string",
+      "DeploymentId": "Deployments-1",
       "Duration": "string",
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ErrorMessage": "string",
       "HasPendingInterruptions": true,
       "HasPendingPreconditions": true,
       "HasWarningsOrErrors": true,
-      "Id": "string",
+      "Id": "Deployments-1",
       "IsCompleted": true,
       "IsCurrent": true,
       "IsPrevious": true,
@@ -175,14 +175,14 @@ Also reachable at `/api/dashboard`, `/api/spaces/{spaceIdentifier}/dashboard`.
       "PendingPreconditionTypes": [
         "string"
       ],
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
-      "ReleaseId": "string",
+      "ReleaseId": "Releases-1",
       "ReleaseVersion": "string",
       "StartTime": "2020-01-01T00:00:00.000Z",
       "State": "Queued",
       "TaskId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
   "LastModifiedBy": "string",
@@ -195,7 +195,8 @@ Also reachable at `/api/dashboard`, `/api/spaces/{spaceIdentifier}/dashboard`.
   "ProjectGroups": [
     {
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "LastModifiedBy": "string",
@@ -213,7 +214,8 @@ Also reachable at `/api/dashboard`, `/api/spaces/{spaceIdentifier}/dashboard`.
     {
       "CanPerformUntenantedDeployment": true,
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsDisabled": true,
@@ -402,17 +404,17 @@ Also reachable at `/api/dashboard/dynamic`, `/api/spaces/{spaceIdentifier}/dashb
   "IsFiltered": true,
   "Items": [
     {
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "CompletedTime": "2020-01-01T00:00:00.000Z",
       "Created": "2020-01-01T00:00:00.000Z",
-      "DeploymentId": "string",
+      "DeploymentId": "Deployments-1",
       "Duration": "string",
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ErrorMessage": "string",
       "HasPendingInterruptions": true,
       "HasPendingPreconditions": true,
       "HasWarningsOrErrors": true,
-      "Id": "string",
+      "Id": "Deployments-1",
       "IsCompleted": true,
       "IsCurrent": true,
       "IsPrevious": true,
@@ -429,14 +431,14 @@ Also reachable at `/api/dashboard/dynamic`, `/api/spaces/{spaceIdentifier}/dashb
       "PendingPreconditionTypes": [
         "string"
       ],
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
-      "ReleaseId": "string",
+      "ReleaseId": "Releases-1",
       "ReleaseVersion": "string",
       "StartTime": "2020-01-01T00:00:00.000Z",
       "State": "Queued",
       "TaskId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
   "LastModifiedBy": "string",
@@ -449,7 +451,8 @@ Also reachable at `/api/dashboard/dynamic`, `/api/spaces/{spaceIdentifier}/dashb
   "ProjectGroups": [
     {
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "LastModifiedBy": "string",
@@ -467,7 +470,8 @@ Also reachable at `/api/dashboard/dynamic`, `/api/spaces/{spaceIdentifier}/dashb
     {
       "CanPerformUntenantedDeployment": true,
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsDisabled": true,

--- a/src/pages/docs/api/deployment-freeze.md
+++ b/src/pages/docs/api/deployment-freeze.md
@@ -192,9 +192,9 @@ Gets a paginated set of DeploymentFreezes.
   "Start": "2020-01-01T00:00:00.000Z",
   "TenantProjectEnvironmentScope": [
     {
-      "EnvironmentId": "string",
-      "ProjectId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "ProjectId": "Projects-1",
+      "TenantId": "Tenants-1"
     }
   ]
 }
@@ -273,9 +273,9 @@ Gets a paginated set of DeploymentFreezes.
   "Start": "2020-01-01T00:00:00.000Z",
   "TenantProjectEnvironmentScope": [
     {
-      "EnvironmentId": "string",
-      "ProjectId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "ProjectId": "Projects-1",
+      "TenantId": "Tenants-1"
     }
   ]
 }
@@ -351,9 +351,9 @@ Gets a paginated set of DeploymentFreezes.
   "Start": "2020-01-01T00:00:00.000Z",
   "TenantProjectEnvironmentScope": [
     {
-      "EnvironmentId": "string",
-      "ProjectId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "ProjectId": "Projects-1",
+      "TenantId": "Tenants-1"
     }
   ]
 }
@@ -423,9 +423,9 @@ Gets a paginated set of DeploymentFreezes.
   "Start": "2020-01-01T00:00:00.000Z",
   "TenantProjectEnvironmentScope": [
     {
-      "EnvironmentId": "string",
-      "ProjectId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "ProjectId": "Projects-1",
+      "TenantId": "Tenants-1"
     }
   ]
 }
@@ -539,7 +539,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
       }
     ],
     "ChangesMarkdown": "string",
-    "ChannelId": "string",
+    "ChannelId": "Channels-1",
     "Comments": "string",
     "Created": "2020-01-01T00:00:00.000Z",
     "DebugMode": "string",
@@ -549,7 +549,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
       "string"
     ],
     "DeploymentProcessId": "string",
-    "EnvironmentId": "string",
+    "EnvironmentId": "Environments-1",
     "ExcludedMachineIds": [
       "string"
     ],
@@ -570,7 +570,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
       "additionalProp2": "string",
       "additionalProp3": "string"
     },
-    "Id": "string",
+    "Id": "Deployments-1",
     "LastModifiedBy": "string",
     "LastModifiedOn": "2020-01-01T00:00:00.000Z",
     "Links": {
@@ -581,22 +581,22 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
     "ManifestVariableSetId": "string",
     "Name": "string",
     "Priority": "string",
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "QueueTime": "2020-01-01T00:00:00.000Z",
     "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-    "ReleaseId": "string",
+    "ReleaseId": "Releases-1",
     "SkipActions": [
       "string"
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "SpecificMachineIds": [
       "string"
     ],
     "SpecificTargetTagIds": [
       "string"
     ],
-    "TaskId": "string",
-    "TenantId": "string",
+    "TaskId": "ServerTasks-1",
+    "TenantId": "Tenants-1",
     "TentacleRetentionPeriod": {
       "QuantityToKeep": 0,
       "ShouldKeepForever": true,
@@ -609,7 +609,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
     "string"
   ],
   "Reason": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -696,7 +696,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
       }
     ],
     "ChangesMarkdown": "string",
-    "ChannelId": "string",
+    "ChannelId": "Channels-1",
     "Comments": "string",
     "Created": "2020-01-01T00:00:00.000Z",
     "DebugMode": "string",
@@ -706,7 +706,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
       "string"
     ],
     "DeploymentProcessId": "string",
-    "EnvironmentId": "string",
+    "EnvironmentId": "Environments-1",
     "ExcludedMachineIds": [
       "string"
     ],
@@ -727,7 +727,7 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
       "additionalProp2": "string",
       "additionalProp3": "string"
     },
-    "Id": "string",
+    "Id": "Deployments-1",
     "LastModifiedBy": "string",
     "LastModifiedOn": "2020-01-01T00:00:00.000Z",
     "Links": {
@@ -738,22 +738,22 @@ Also reachable at `/api/deployments/override`, `/api/spaces/{spaceIdentifier}/de
     "ManifestVariableSetId": "string",
     "Name": "string",
     "Priority": "string",
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "QueueTime": "2020-01-01T00:00:00.000Z",
     "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-    "ReleaseId": "string",
+    "ReleaseId": "Releases-1",
     "SkipActions": [
       "string"
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "SpecificMachineIds": [
       "string"
     ],
     "SpecificTargetTagIds": [
       "string"
     ],
-    "TaskId": "string",
-    "TenantId": "string",
+    "TaskId": "ServerTasks-1",
+    "TenantId": "Tenants-1",
     "TentacleRetentionPeriod": {
       "QuantityToKeep": 0,
       "ShouldKeepForever": true,

--- a/src/pages/docs/api/deployment-processes.md
+++ b/src/pages/docs/api/deployment-processes.md
@@ -75,8 +75,8 @@ Lists all the deployment processes in the supplied Octopus Deploy Space, sorted 
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
-      "SpaceId": "string",
+      "ProjectId": "Projects-1",
+      "SpaceId": "Spaces-1",
       "Steps": [
         {}
       ],
@@ -275,8 +275,8 @@ Also reachable at `/api/deploymentprocesses/{id}`, `/api/spaces/{spaceIdentifier
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -356,8 +356,8 @@ Also reachable at `/api/projects/{projectId}/deploymentprocesses`, `/api/spaces/
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -423,8 +423,8 @@ Modifies a deployment process. Only allowed for deployment processes owned by a 
 {
   "ChangeDescription": "string",
   "LastSnapshotId": "string",
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -493,8 +493,8 @@ Modifies a deployment process. Only allowed for deployment processes owned by a 
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -576,8 +576,8 @@ This request returns the deployment process with all process template usages res
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -822,8 +822,8 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/deploymentprocesses`, `/ap
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -892,8 +892,8 @@ Modifies a deployment process. Only allowed for deployment processes owned by a 
   "ChangeDescription": "string",
   "GitRef": "string",
   "LastSnapshotId": "string",
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -962,8 +962,8 @@ Modifies a deployment process. Only allowed for deployment processes owned by a 
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -1046,8 +1046,8 @@ This request returns the deployment process with all process template usages res
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -1299,8 +1299,8 @@ Modifies a deployment process. Only allowed for deployment processes owned by a 
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -1369,8 +1369,8 @@ Modifies a deployment process. Only allowed for deployment processes owned by a 
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [

--- a/src/pages/docs/api/deployment-settings.md
+++ b/src/pages/docs/api/deployment-settings.md
@@ -76,9 +76,9 @@ Also reachable at `/api/projects/{projectId}/deploymentsettings`, `/api/spaces/{
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",
@@ -162,9 +162,9 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/deploymentsettings`, `/api
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",
@@ -250,9 +250,9 @@ Modifies deployment settings for a project.
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
   "GitRef": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",
@@ -323,9 +323,9 @@ Modifies deployment settings for a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",
@@ -412,9 +412,9 @@ Also reachable at `/api/deploymentsettings/{id}`, `/api/spaces/{spaceIdentifier}
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",
@@ -499,9 +499,9 @@ Modifies deployment settings for a project.
   "DeploymentChangesTemplate": "string",
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",
@@ -572,9 +572,9 @@ Modifies deployment settings for a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotesTemplate": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "VersioningStrategy": {
     "DonorPackage": {
       "DeploymentAction": "string",

--- a/src/pages/docs/api/deployment-target-tags.md
+++ b/src/pages/docs/api/deployment-target-tags.md
@@ -28,7 +28,7 @@ Also reachable at `/api/deploymentTargetTags/{tag}`, `/api/spaces/{spaceIdentifi
 :::api-example{label="Response"}
 ```json
 {
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tag": "string"
 }
 ```
@@ -73,7 +73,7 @@ Gets a paginated list of DeploymentTargetTag.
   "Count": 0,
   "DeploymentTargetTags": [
     {
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Tag": "string"
     }
   ]
@@ -102,7 +102,7 @@ Also reachable at `/api/deploymenttargettags`, `/api/spaces/{spaceIdentifier}/de
 :::api-example{label="Request"}
 ```json
 {
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tag": "string"
 }
 ```
@@ -118,7 +118,7 @@ Also reachable at `/api/deploymenttargettags`, `/api/spaces/{spaceIdentifier}/de
 :::api-example{label="Response"}
 ```json
 {
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tag": "string"
 }
 ```

--- a/src/pages/docs/api/deployment-targets.md
+++ b/src/pages/docs/api/deployment-targets.md
@@ -119,7 +119,8 @@ Also reachable at `/api/machines`, `/api/spaces/{spaceIdentifier}/machines`.
         "Links": {}
       },
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasLatestCalamari": true,
       "HealthStatus": "Healthy",
@@ -144,10 +145,11 @@ Also reachable at `/api/machines`, `/api/spaces/{spaceIdentifier}/machines`.
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -229,7 +231,8 @@ Creates a new deployment target.
     }
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "IsDisabled": true,
   "MachinePolicyId": "string",
@@ -239,9 +242,10 @@ Creates a new deployment target.
   ],
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -318,7 +322,8 @@ Creates a new deployment target.
     }
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasLatestCalamari": true,
   "HealthStatus": "Healthy",
@@ -343,10 +348,11 @@ Creates a new deployment target.
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -444,7 +450,8 @@ Lists all of the Deployment Targets in the supplied Space. The results will be s
       }
     },
     "EnvironmentIds": [
-      "string"
+      "Environments-1",
+      "..."
     ],
     "HasLatestCalamari": true,
     "HealthStatus": "Healthy",
@@ -469,10 +476,11 @@ Lists all of the Deployment Targets in the supplied Space. The results will be s
     "ShellVersion": "string",
     "SkipInitialHealthCheck": true,
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "StatusSummary": "string",
     "TenantIds": [
-      "string"
+      "Tenants-1",
+      "..."
     ],
     "TenantTags": [
       "string"
@@ -558,7 +566,8 @@ Lists all of the Deployment Targets in the supplied Space. The results will be s
         "Links": {}
       },
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasLatestCalamari": true,
       "HealthStatus": "Healthy",
@@ -583,10 +592,11 @@ Lists all of the Deployment Targets in the supplied Space. The results will be s
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -815,7 +825,8 @@ Also reachable at `/api/machines/v2`, `/api/spaces/{spaceIdentifier}/machines/v2
         "Architecture": "string",
         "Endpoint": {},
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "HasLatestCalamari": true,
         "HealthStatus": "Healthy",
@@ -836,10 +847,11 @@ Also reachable at `/api/machines/v2`, `/api/spaces/{spaceIdentifier}/machines/v2
         "ShellVersion": "string",
         "SkipInitialHealthCheck": true,
         "Slug": "string",
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "StatusSummary": "string",
         "TenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
         "TenantTags": [
           "string"
@@ -941,7 +953,8 @@ Also reachable at `/api/machines/{id}`, `/api/spaces/{spaceIdentifier}/machines/
     }
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasLatestCalamari": true,
   "HealthStatus": "Healthy",
@@ -966,10 +979,11 @@ Also reachable at `/api/machines/{id}`, `/api/spaces/{spaceIdentifier}/machines/
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -1042,7 +1056,7 @@ Also reachable at `/api/machines/{id}/latestdeployments`, `/api/spaces/{spaceIde
   "ItemType": "string",
   "Items": [
     {
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectLogo": "string",
       "ProjectName": "string",
       "ServerTask": {
@@ -1072,11 +1086,11 @@ Also reachable at `/api/machines/{id}/latestdeployments`, `/api/spaces/{spaceIde
         "PendingPreconditionTypes": [
           "string"
         ],
-        "ProjectId": "string",
+        "ProjectId": "Projects-1",
         "QueueTime": "2020-01-01T00:00:00.000Z",
         "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
         "ServerNode": "string",
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "StartTime": "2020-01-01T00:00:00.000Z",
         "State": "Queued"
       }
@@ -1233,11 +1247,11 @@ Get a history of related Tasks (ie. Deployments) for a Deployment Target.
       "PendingPreconditionTypes": [
         "string"
       ],
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "ServerNode": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StartTime": "2020-01-01T00:00:00.000Z",
       "State": "Queued"
     }
@@ -1336,11 +1350,11 @@ Get a history of related Tasks (ie. Deployments) for a Deployment Target.
         "PendingPreconditionTypes": [
           "string"
         ],
-        "ProjectId": "string",
+        "ProjectId": "Projects-1",
         "QueueTime": "2020-01-01T00:00:00.000Z",
         "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
         "ServerNode": "string",
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "StartTime": "2020-01-01T00:00:00.000Z",
         "State": "Queued"
       }
@@ -1466,19 +1480,21 @@ Also reachable at `/api/machines/{machineid}`, `/api/spaces/{spaceIdentifier}/ma
     }
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "IsDisabled": true,
-  "MachineId": "string",
-  "MachinePolicyId": "string",
+  "MachineId": "Machines-1",
+  "MachinePolicyId": "MachinePolicies-1",
   "Name": "string",
   "Roles": [
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"
@@ -1555,7 +1571,8 @@ Also reachable at `/api/machines/{machineid}`, `/api/spaces/{spaceIdentifier}/ma
     }
   },
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "HasLatestCalamari": true,
   "HealthStatus": "Healthy",
@@ -1580,10 +1597,11 @@ Also reachable at `/api/machines/{machineid}`, `/api/spaces/{spaceIdentifier}/ma
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTags": [
     "string"

--- a/src/pages/docs/api/deployments.md
+++ b/src/pages/docs/api/deployments.md
@@ -124,7 +124,7 @@ Lists all of the Deployments in the supplied Space. The results will be sorted f
         {}
       ],
       "ChangesMarkdown": "string",
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "Comments": "string",
       "Created": "2020-01-01T00:00:00.000Z",
       "DebugMode": "string",
@@ -134,7 +134,7 @@ Lists all of the Deployments in the supplied Space. The results will be sorted f
         "string"
       ],
       "DeploymentProcessId": "string",
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -155,7 +155,7 @@ Lists all of the Deployments in the supplied Space. The results will be sorted f
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "Id": "string",
+      "Id": "Deployments-1",
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
       "Links": {
@@ -166,22 +166,22 @@ Lists all of the Deployments in the supplied Space. The results will be sorted f
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-      "ReleaseId": "string",
+      "ReleaseId": "Releases-1",
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -309,7 +309,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
     }
   ],
   "ChangesMarkdown": "string",
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "Comments": "string",
   "Created": "2020-01-01T00:00:00.000Z",
   "DebugMode": "string",
@@ -319,7 +319,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
     "string"
   ],
   "DeploymentProcessId": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -329,7 +329,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -343,7 +343,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Deployments-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -354,22 +354,22 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "ReleaseId": "string",
+  "ReleaseId": "Releases-1",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -476,7 +476,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
     }
   ],
   "ChangesMarkdown": "string",
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "Comments": "string",
   "Created": "2020-01-01T00:00:00.000Z",
   "DebugMode": "string",
@@ -486,7 +486,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
     "string"
   ],
   "DeploymentProcessId": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -496,7 +496,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -510,7 +510,7 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Deployments-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -521,22 +521,22 @@ Also reachable at `/api/deployments`, `/api/spaces/{spaceIdentifier}/deployments
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "ReleaseId": "string",
+  "ReleaseId": "Releases-1",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -630,7 +630,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/deployments/create/tenanted/v1`
   "SkipStepNames": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpaceIdOrName": "string",
   "SpecificMachineNames": [
     "string"
@@ -668,8 +668,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/deployments/create/tenanted/v1`
 {
   "DeploymentServerTasks": [
     {
-      "DeploymentId": "string",
-      "ServerTaskId": "string"
+      "DeploymentId": "Deployments-1",
+      "ServerTaskId": "ServerTasks-1"
     }
   ]
 }
@@ -756,7 +756,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/deployments/create/untenanted/v
   "SkipStepNames": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpaceIdOrName": "string",
   "SpecificMachineNames": [
     "string"
@@ -788,8 +788,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/deployments/create/untenanted/v
 {
   "DeploymentServerTasks": [
     {
-      "DeploymentId": "string",
-      "ServerTaskId": "string"
+      "DeploymentId": "Deployments-1",
+      "ServerTaskId": "ServerTasks-1"
     }
   ]
 }
@@ -899,7 +899,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
     }
   ],
   "ChangesMarkdown": "string",
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "Comments": "string",
   "Created": "2020-01-01T00:00:00.000Z",
   "DebugMode": "string",
@@ -909,7 +909,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
     "string"
   ],
   "DeploymentProcessId": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -919,7 +919,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -933,7 +933,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Deployments-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -944,22 +944,22 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "ReleaseId": "string",
+  "ReleaseId": "Releases-1",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -1053,7 +1053,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
       }
     ],
     "ChangesMarkdown": "string",
-    "ChannelId": "string",
+    "ChannelId": "Channels-1",
     "Comments": "string",
     "Created": "2020-01-01T00:00:00.000Z",
     "DebugMode": "string",
@@ -1063,7 +1063,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
       "string"
     ],
     "DeploymentProcessId": "string",
-    "EnvironmentId": "string",
+    "EnvironmentId": "Environments-1",
     "ExcludedMachineIds": [
       "string"
     ],
@@ -1084,7 +1084,7 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
       "additionalProp2": "string",
       "additionalProp3": "string"
     },
-    "Id": "string",
+    "Id": "Deployments-1",
     "LastModifiedBy": "string",
     "LastModifiedOn": "2020-01-01T00:00:00.000Z",
     "Links": {
@@ -1095,22 +1095,22 @@ Also reachable at `/api/deployments/v1`, `/api/spaces/{spaceIdentifier}/deployme
     "ManifestVariableSetId": "string",
     "Name": "string",
     "Priority": "string",
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "QueueTime": "2020-01-01T00:00:00.000Z",
     "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-    "ReleaseId": "string",
+    "ReleaseId": "Releases-1",
     "SkipActions": [
       "string"
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "SpecificMachineIds": [
       "string"
     ],
     "SpecificTargetTagIds": [
       "string"
     ],
-    "TaskId": "string",
-    "TenantId": "string",
+    "TaskId": "ServerTasks-1",
+    "TenantId": "Tenants-1",
     "TentacleRetentionPeriod": {
       "QuantityToKeep": 0,
       "ShouldKeepForever": true,
@@ -1230,7 +1230,7 @@ Also reachable at `/api/deployments/{id}`, `/api/spaces/{spaceIdentifier}/deploy
     }
   ],
   "ChangesMarkdown": "string",
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "Comments": "string",
   "Created": "2020-01-01T00:00:00.000Z",
   "DebugMode": "string",
@@ -1240,7 +1240,7 @@ Also reachable at `/api/deployments/{id}`, `/api/spaces/{spaceIdentifier}/deploy
     "string"
   ],
   "DeploymentProcessId": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -1250,7 +1250,7 @@ Also reachable at `/api/deployments/{id}`, `/api/spaces/{spaceIdentifier}/deploy
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -1264,7 +1264,7 @@ Also reachable at `/api/deployments/{id}`, `/api/spaces/{spaceIdentifier}/deploy
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Deployments-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -1275,22 +1275,22 @@ Also reachable at `/api/deployments/{id}`, `/api/spaces/{spaceIdentifier}/deploy
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "ReleaseId": "string",
+  "ReleaseId": "Releases-1",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,

--- a/src/pages/docs/api/environments.md
+++ b/src/pages/docs/api/environments.md
@@ -99,7 +99,7 @@ Lists all of the environments in the supplied Octopus Deploy Space. The results 
       "Name": "string",
       "Slug": "string",
       "SortOrder": 0,
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "UseGuidedFailure": true
     }
   ],
@@ -160,7 +160,7 @@ Also reachable at `/api/environments`, `/api/spaces/{spaceIdentifier}/environmen
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -221,7 +221,7 @@ Also reachable at `/api/environments`, `/api/spaces/{spaceIdentifier}/environmen
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -305,7 +305,7 @@ Lists the name and ID of all of the environments in the supplied Space. The resu
     "Name": "string",
     "Slug": "string",
     "SortOrder": 0,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "UseGuidedFailure": true
   }
 ]
@@ -387,7 +387,7 @@ Lists the name and ID of all of the environments in the supplied Space. The resu
       "Name": "string",
       "Slug": "string",
       "SortOrder": 0,
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "UseGuidedFailure": true
     }
   ]
@@ -508,7 +508,7 @@ Also reachable at `/api/environments/summary`, `/api/spaces/{spaceIdentifier}/en
         "Name": "string",
         "Slug": "string",
         "SortOrder": 0,
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "UseGuidedFailure": true
       },
       "MachineEndpointSummaries": {
@@ -650,10 +650,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/environments/summary/v2`.
         "EnvironmentTags": [
           "string"
         ],
-        "Id": "string",
+        "Id": "Environments-1",
         "Name": "string",
         "Slug": "string",
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "Type": "string"
       },
       "MachineEndpointSummaries": {
@@ -786,7 +786,7 @@ Lists all of the environments in the supplied Octopus Deploy Space. The results 
         "Name": "string",
         "Slug": "string",
         "SortOrder": 0,
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "UseGuidedFailure": true
       }
     ],
@@ -864,10 +864,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/environments/v2`.
       "EnvironmentTags": [
         "string"
       ],
-      "Id": "string",
+      "Id": "Environments-1",
       "Name": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Type": "string"
     }
   ],
@@ -911,7 +911,7 @@ Also reachable at `/api/environments/{environmentId}`, `/api/spaces/{spaceIdenti
 {
   "AllowDynamicInfrastructure": true,
   "Description": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "EnvironmentTags": [
     "string"
   ],
@@ -924,7 +924,7 @@ Also reachable at `/api/environments/{environmentId}`, `/api/spaces/{spaceIdenti
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -985,7 +985,7 @@ Also reachable at `/api/environments/{environmentId}`, `/api/spaces/{spaceIdenti
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -1141,7 +1141,7 @@ Also reachable at `/api/environments/{id}`, `/api/spaces/{spaceIdentifier}/envir
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -1262,7 +1262,8 @@ Also reachable at `/api/environments/{id}/machines`, `/api/spaces/{spaceIdentifi
         "Links": {}
       },
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasLatestCalamari": true,
       "HealthStatus": "Healthy",
@@ -1287,10 +1288,11 @@ Also reachable at `/api/environments/{id}/machines`, `/api/spaces/{spaceIdentifi
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -1351,10 +1353,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/environments/{id}/v2`.
   "EnvironmentTags": [
     "string"
   ],
-  "Id": "string",
+  "Id": "Environments-1",
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Type": "string"
 }
 ```
@@ -1416,10 +1418,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
       "EnvironmentTags": [
         "string"
       ],
-      "Id": "string",
+      "Id": "Environments-1",
       "Name": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Type": "string"
     }
   ],

--- a/src/pages/docs/api/ephemeral-environments.md
+++ b/src/pages/docs/api/ephemeral-environments.md
@@ -30,8 +30,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/environments/ephemeral/{id}/dep
 {
   "DeprovisioningRuns": [
     {
-      "RunbookRunId": "string",
-      "TaskId": "string"
+      "RunbookRunId": "RunbookRuns-1",
+      "TaskId": "ServerTasks-1"
     }
   ]
 }
@@ -60,8 +60,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
 ```json
 {
   "EnvironmentName": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -75,7 +75,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
 :::api-example{label="Response"}
 ```json
 {
-  "Id": "string"
+  "Id": "Environments-1"
 }
 ```
 :::
@@ -104,8 +104,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
 ```json
 {
   "DeprovisioningRun": {
-    "RunbookRunId": "string",
-    "TaskId": "string"
+    "RunbookRunId": "RunbookRuns-1",
+    "TaskId": "ServerTasks-1"
   }
 }
 ```
@@ -157,8 +157,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
 ```json
 {
   "DeprovisioningRun": {
-    "RunbookRunId": "string",
-    "TaskId": "string"
+    "RunbookRunId": "RunbookRuns-1",
+    "TaskId": "ServerTasks-1"
   }
 }
 ```
@@ -210,8 +210,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
 ```json
 {
   "ProvisioningRun": {
-    "RunbookRunId": "string",
-    "TaskId": "string"
+    "RunbookRunId": "RunbookRuns-1",
+    "TaskId": "ServerTasks-1"
   }
 }
 ```

--- a/src/pages/docs/api/events.md
+++ b/src/pages/docs/api/events.md
@@ -316,7 +316,7 @@ Also reachable at `/api/events/{id}`, `/api/spaces/{spaceIdentifier}/events/{id}
   "RelatedDocumentIds": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UserAgent": "string",
   "UserId": "string",
   "Username": "string"

--- a/src/pages/docs/api/feeds.md
+++ b/src/pages/docs/api/feeds.md
@@ -86,7 +86,7 @@ Also reachable at `/api/feeds`, `/api/spaces/{spaceIdentifier}/feeds`.
         "Server"
       ],
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -173,7 +173,7 @@ Also reachable at `/api/feeds`, `/api/spaces/{spaceIdentifier}/feeds`.
     "Server"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -215,7 +215,7 @@ Also reachable at `/api/feeds`, `/api/spaces/{spaceIdentifier}/feeds`.
     "Server"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -269,7 +269,7 @@ Also reachable at `/api/feeds/all`, `/api/spaces/{spaceIdentifier}/feeds/all`.
       "Server"
     ],
     "Slug": "string",
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 ]
 ```
@@ -366,7 +366,7 @@ Also reachable at `/api/feeds/{id}`, `/api/spaces/{spaceIdentifier}/feeds/{id}`.
     "Server"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -439,13 +439,13 @@ Also reachable at `/api/feeds/{id}`, `/api/spaces/{spaceIdentifier}/feeds/{id}`.
     "Version": "string"
   },
   "FeedType": "None",
-  "Id": "string",
+  "Id": "Feeds-1",
   "Name": "string",
   "PackageAcquisitionLocationOptions": [
     "Server"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -487,7 +487,7 @@ Also reachable at `/api/feeds/{id}`, `/api/spaces/{spaceIdentifier}/feeds/{id}`.
     "Server"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/git-hub.md
+++ b/src/pages/docs/api/git-hub.md
@@ -134,7 +134,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/github/connections`.
   "RepositoryIds": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -259,7 +259,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/github/connections/{id}`.
       "Visibility": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Status": "string",
   "StatusUserMessage": "string",
   "UnknownRepositories": [
@@ -296,7 +296,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/github/connections/{id}`.
   "RepositoryIds": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -358,7 +358,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/github/connections/{id}/recover
   "RepositoryIds": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -399,7 +399,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/github/connections/{id}/recover
   "RepositoryIds": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/icons.md
+++ b/src/pages/docs/api/icons.md
@@ -91,7 +91,7 @@ title: Icons
 {
   "IconColor": "string",
   "IconId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -135,8 +135,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/logo/icon`
 {
   "IconColor": "string",
   "IconId": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -180,8 +180,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/logo/icon`.
 {
   "IconColor": "string",
   "IconId": "string",
-  "SpaceId": "string",
-  "TenantId": "string"
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1"
 }
 ```
 :::

--- a/src/pages/docs/api/insights.md
+++ b/src/pages/docs/api/insights.md
@@ -77,7 +77,8 @@ Returns a paginated list of the Insights Reports in the supplied Octopus Deploy 
     {
       "AllTenants": true,
       "ChannelIds": [
-        "string"
+        "Channels-1",
+        "..."
       ],
       "Description": "string",
       "EnvironmentGroups": [
@@ -85,7 +86,7 @@ Returns a paginated list of the Insights Reports in the supplied Octopus Deploy 
       ],
       "IconColor": "string",
       "IconId": "string",
-      "Id": "string",
+      "Id": "InsightsReports-1",
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
       "Links": {
@@ -95,14 +96,17 @@ Returns a paginated list of the Insights Reports in the supplied Octopus Deploy 
       },
       "Name": "string",
       "ProjectGroupIds": [
-        "string"
+        "ProjectGroups-1",
+        "..."
       ],
       "ProjectIds": [
-        "string"
+        "Projects-1",
+        "..."
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantMode": "Untenanted",
       "TenantTags": [
@@ -173,27 +177,32 @@ Creates a new Insights Report.
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -241,20 +250,22 @@ Creates a new Insights Report.
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
   "IconColor": "string",
   "IconId": "string",
-  "Id": "string",
+  "Id": "InsightsReports-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -264,14 +275,17 @@ Creates a new Insights Report.
   },
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -329,27 +343,32 @@ Creates a new Insights Report.
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -396,20 +415,22 @@ Creates a new Insights Report.
   "Report": {
     "AllTenants": true,
     "ChannelIds": [
-      "string"
+      "Channels-1",
+      "..."
     ],
     "Description": "string",
     "EnvironmentGroups": [
       {
         "Environments": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "Name": "string"
       }
     ],
     "IconColor": "string",
     "IconId": "string",
-    "Id": "string",
+    "Id": "InsightsReports-1",
     "LastModifiedBy": "string",
     "LastModifiedOn": "2020-01-01T00:00:00.000Z",
     "Links": {
@@ -419,14 +440,17 @@ Creates a new Insights Report.
     },
     "Name": "string",
     "ProjectGroupIds": [
-      "string"
+      "ProjectGroups-1",
+      "..."
     ],
     "ProjectIds": [
-      "string"
+      "Projects-1",
+      "..."
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TenantIds": [
-      "string"
+      "Tenants-1",
+      "..."
     ],
     "TenantMode": "Untenanted",
     "TenantTags": [
@@ -487,20 +511,22 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{id}`.
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
   "IconColor": "string",
   "IconId": "string",
-  "Id": "string",
+  "Id": "InsightsReports-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -510,14 +536,17 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{id}`.
   },
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -581,28 +610,33 @@ Updates an existing Insights Report
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
-  "Id": "string",
+  "Id": "InsightsReports-1",
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -650,20 +684,22 @@ Updates an existing Insights Report
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
   "IconColor": "string",
   "IconId": "string",
-  "Id": "string",
+  "Id": "InsightsReports-1",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
   "Links": {
@@ -673,14 +709,17 @@ Updates an existing Insights Report
   },
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -758,20 +797,22 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{id}/v1`.
   "Report": {
     "AllTenants": true,
     "ChannelIds": [
-      "string"
+      "Channels-1",
+      "..."
     ],
     "Description": "string",
     "EnvironmentGroups": [
       {
         "Environments": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "Name": "string"
       }
     ],
     "IconColor": "string",
     "IconId": "string",
-    "Id": "string",
+    "Id": "InsightsReports-1",
     "LastModifiedBy": "string",
     "LastModifiedOn": "2020-01-01T00:00:00.000Z",
     "Links": {
@@ -781,14 +822,17 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{id}/v1`.
     },
     "Name": "string",
     "ProjectGroupIds": [
-      "string"
+      "ProjectGroups-1",
+      "..."
     ],
     "ProjectIds": [
-      "string"
+      "Projects-1",
+      "..."
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TenantIds": [
-      "string"
+      "Tenants-1",
+      "..."
     ],
     "TenantMode": "Untenanted",
     "TenantTags": [
@@ -853,28 +897,33 @@ Updates an existing Insights Report
 {
   "AllTenants": true,
   "ChannelIds": [
-    "string"
+    "Channels-1",
+    "..."
   ],
   "Description": "string",
   "EnvironmentGroups": [
     {
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Name": "string"
     }
   ],
-  "Id": "string",
+  "Id": "InsightsReports-1",
   "Name": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantMode": "Untenanted",
   "TenantTags": [
@@ -921,20 +970,22 @@ Updates an existing Insights Report
   "Report": {
     "AllTenants": true,
     "ChannelIds": [
-      "string"
+      "Channels-1",
+      "..."
     ],
     "Description": "string",
     "EnvironmentGroups": [
       {
         "Environments": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "Name": "string"
       }
     ],
     "IconColor": "string",
     "IconId": "string",
-    "Id": "string",
+    "Id": "InsightsReports-1",
     "LastModifiedBy": "string",
     "LastModifiedOn": "2020-01-01T00:00:00.000Z",
     "Links": {
@@ -944,14 +995,17 @@ Updates an existing Insights Report
     },
     "Name": "string",
     "ProjectGroupIds": [
-      "string"
+      "ProjectGroups-1",
+      "..."
     ],
     "ProjectIds": [
-      "string"
+      "Projects-1",
+      "..."
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TenantIds": [
-      "string"
+      "Tenants-1",
+      "..."
     ],
     "TenantMode": "Untenanted",
     "TenantTags": [
@@ -1024,16 +1078,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{reportId}/dep
   "ReportName": "string",
   "Streams": [
     {
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "ChannelName": "string",
       "Deployments": [
         {}
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "EnvironmentName": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
-      "TenantId": "string",
+      "TenantId": "Tenants-1",
       "TenantName": "string"
     }
   ]
@@ -1108,8 +1162,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{reportId}/log
 {
   "IconColor": "string",
   "IconId": "string",
-  "ReportId": "string",
-  "SpaceId": "string"
+  "ReportId": "InsightsReports-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1153,8 +1207,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/insights/reports/{reportId}/log
 {
   "IconColor": "string",
   "IconId": "string",
-  "ReportId": "string",
-  "SpaceId": "string"
+  "ReportId": "InsightsReports-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1323,16 +1377,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/insights/d
   "ProjectName": "string",
   "Streams": [
     {
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "ChannelName": "string",
       "Deployments": [
         {}
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "EnvironmentName": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
-      "TenantId": "string",
+      "TenantId": "Tenants-1",
       "TenantName": "string"
     }
   ]

--- a/src/pages/docs/api/interruptions.md
+++ b/src/pages/docs/api/interruptions.md
@@ -121,7 +121,7 @@ Also reachable at `/api/interruptions`, `/api/spaces/{spaceIdentifier}/interrupt
         "string"
       ],
       "ResponsibleUserId": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TaskId": "string",
       "Title": "string",
       "Type": "ManualIntervention"
@@ -242,7 +242,7 @@ Also reachable at `/api/interruptions/{id}`, `/api/spaces/{spaceIdentifier}/inte
   },
   "PullRequests": [
     {
-      "Id": "string",
+      "Id": "InterruptionPullRequests-1",
       "InterruptionId": "string",
       "Number": 0,
       "RepositoryUrl": "string",
@@ -258,7 +258,7 @@ Also reachable at `/api/interruptions/{id}`, `/api/spaces/{spaceIdentifier}/inte
     "string"
   ],
   "ResponsibleUserId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TaskId": "string",
   "Title": "string",
   "Type": "ManualIntervention"
@@ -399,7 +399,7 @@ Also reachable at `/api/interruptions/{id}/submit`, `/api/spaces/{spaceIdentifie
   "Instructions": "string",
   "Notes": "string",
   "Result": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -491,7 +491,7 @@ Also reachable at `/api/interruptions/{id}/submit`, `/api/spaces/{spaceIdentifie
   },
   "PullRequests": [
     {
-      "Id": "string",
+      "Id": "InterruptionPullRequests-1",
       "InterruptionId": "string",
       "Number": 0,
       "RepositoryUrl": "string",
@@ -507,7 +507,7 @@ Also reachable at `/api/interruptions/{id}/submit`, `/api/spaces/{spaceIdentifie
     "string"
   ],
   "ResponsibleUserId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TaskId": "string",
   "Title": "string",
   "Type": "ManualIntervention"

--- a/src/pages/docs/api/invitations.md
+++ b/src/pages/docs/api/invitations.md
@@ -27,9 +27,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/invitations`, `/api/users
 ```json
 {
   "AddToTeamIds": [
-    "string"
+    "Teams-1",
+    "..."
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -60,7 +61,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/invitations`, `/api/users
     "string"
   ],
   "Expires": "2020-01-01T00:00:00.000Z",
-  "Id": "string",
+  "Id": "Invitations-1",
   "InvitationCode": "string",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -69,7 +70,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/invitations`, `/api/users
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -113,7 +114,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/invitations/{id}`, `/api/
     "string"
   ],
   "Expires": "2020-01-01T00:00:00.000Z",
-  "Id": "string",
+  "Id": "Invitations-1",
   "InvitationCode": "string",
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -122,7 +123,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/invitations/{id}`, `/api/
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/library-variable-sets.md
+++ b/src/pages/docs/api/library-variable-sets.md
@@ -87,7 +87,7 @@ Also reachable at `/api/libraryvariablesets`, `/api/spaces/{spaceIdentifier}/lib
         "additionalProp3": "string"
       },
       "Name": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -145,7 +145,7 @@ Also reachable at `/api/libraryvariablesets`, `/api/spaces/{spaceIdentifier}/lib
   "ContentType": "Variables",
   "Description": "string",
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -215,7 +215,7 @@ Also reachable at `/api/libraryvariablesets`, `/api/spaces/{spaceIdentifier}/lib
     "additionalProp3": "string"
   },
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -308,7 +308,7 @@ Lists all the Library Variable Sets in the supplied Space. The results will be s
       "additionalProp3": "string"
     },
     "Name": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Templates": [
       {
         "DefaultValue": {},
@@ -390,7 +390,7 @@ Lists all the Library Variable Sets in the supplied Space. The results will be s
         "additionalProp3": "string"
       },
       "Name": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -464,7 +464,7 @@ Lists all the Library Variable Sets in the supplied Space. The results will be s
         "additionalProp3": "string"
       },
       "Name": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -540,7 +540,7 @@ Lists all the Library Variable Sets in the supplied Space. The results will be s
         "additionalProp3": "string"
       },
       "Name": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -611,7 +611,7 @@ Also reachable at `/api/libraryvariablesets/{id}`, `/api/spaces/{spaceIdentifier
     "additionalProp3": "string"
   },
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -669,9 +669,9 @@ Also reachable at `/api/libraryvariablesets/{id}`, `/api/spaces/{spaceIdentifier
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "LibraryVariableSets-1",
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -742,7 +742,7 @@ Also reachable at `/api/libraryvariablesets/{id}`, `/api/spaces/{spaceIdentifier
     "additionalProp3": "string"
   },
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -820,7 +820,7 @@ Also reachable at `/api/libraryvariablesets/{id}/usages`, `/api/spaces/{spaceIde
   "Projects": [
     {
       "IsCurrentlyBeingUsedInProject": true,
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "ProjectSlug": "string",
       "Releases": [

--- a/src/pages/docs/api/lifecycles.md
+++ b/src/pages/docs/api/lifecycles.md
@@ -87,7 +87,7 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
         "Unit": "Days"
       },
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TentacleRetentionPolicy": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -164,7 +164,8 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsOptionalPhase": true,
@@ -172,7 +173,8 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "ReleaseRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -195,7 +197,7 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
     "Unit": "Days"
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TentacleRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -261,7 +263,8 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsOptionalPhase": true,
@@ -269,7 +272,8 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "ReleaseRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -292,7 +296,7 @@ Also reachable at `/api/lifecycles`, `/api/spaces/{spaceIdentifier}/lifecycles`.
     "Unit": "Days"
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TentacleRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -369,7 +373,8 @@ Also reachable at `/api/lifecycles/all`, `/api/spaces/{spaceIdentifier}/lifecycl
     "Phases": [
       {
         "AutomaticDeploymentTargets": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "Id": "string",
         "IsOptionalPhase": true,
@@ -377,7 +382,8 @@ Also reachable at `/api/lifecycles/all`, `/api/spaces/{spaceIdentifier}/lifecycl
         "MinimumEnvironmentsBeforePromotion": 0,
         "Name": "string",
         "OptionalDeploymentTargets": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "ReleaseRetentionPolicy": {},
         "TentacleRetentionPolicy": {}
@@ -390,7 +396,7 @@ Also reachable at `/api/lifecycles/all`, `/api/spaces/{spaceIdentifier}/lifecycl
       "Unit": "Days"
     },
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TentacleRetentionPolicy": {
       "QuantityToKeep": 0,
       "ShouldKeepForever": true,
@@ -474,7 +480,8 @@ Also reachable at `/api/lifecycles/previews`, `/api/spaces/{spaceIdentifier}/lif
     "Phases": [
       {
         "AutomaticDeploymentTargets": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "Id": "string",
         "IsOptionalPhase": true,
@@ -482,7 +489,8 @@ Also reachable at `/api/lifecycles/previews`, `/api/spaces/{spaceIdentifier}/lif
         "MinimumEnvironmentsBeforePromotion": 0,
         "Name": "string",
         "OptionalDeploymentTargets": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "ReleaseRetentionPolicy": {},
         "TentacleRetentionPolicy": {}
@@ -495,7 +503,7 @@ Also reachable at `/api/lifecycles/previews`, `/api/spaces/{spaceIdentifier}/lif
       "Unit": "Days"
     },
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TentacleRetentionPolicy": {
       "QuantityToKeep": 0,
       "ShouldKeepForever": true,
@@ -575,7 +583,8 @@ This request does not support getting Lifecycles that belong to Templated Projec
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsOptionalPhase": true,
@@ -583,7 +592,8 @@ This request does not support getting Lifecycles that belong to Templated Projec
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "ReleaseRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -606,7 +616,7 @@ This request does not support getting Lifecycles that belong to Templated Projec
     "Unit": "Days"
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TentacleRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -670,12 +680,13 @@ Also reachable at `/api/lifecycles/{id}`, `/api/spaces/{spaceIdentifier}/lifecyc
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "Lifecycles-1",
   "Name": "string",
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsOptionalPhase": true,
@@ -683,7 +694,8 @@ Also reachable at `/api/lifecycles/{id}`, `/api/spaces/{spaceIdentifier}/lifecyc
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "ReleaseRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -706,7 +718,7 @@ Also reachable at `/api/lifecycles/{id}`, `/api/spaces/{spaceIdentifier}/lifecyc
     "Unit": "Days"
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TentacleRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -772,7 +784,8 @@ Also reachable at `/api/lifecycles/{id}`, `/api/spaces/{spaceIdentifier}/lifecyc
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsOptionalPhase": true,
@@ -780,7 +793,8 @@ Also reachable at `/api/lifecycles/{id}`, `/api/spaces/{spaceIdentifier}/lifecyc
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "ReleaseRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -803,7 +817,7 @@ Also reachable at `/api/lifecycles/{id}`, `/api/spaces/{spaceIdentifier}/lifecyc
     "Unit": "Days"
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TentacleRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -905,7 +919,8 @@ Also reachable at `/api/lifecycles/{id}/preview`, `/api/spaces/{spaceIdentifier}
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "IsOptionalPhase": true,
@@ -913,7 +928,8 @@ Also reachable at `/api/lifecycles/{id}/preview`, `/api/spaces/{spaceIdentifier}
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "ReleaseRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -936,7 +952,7 @@ Also reachable at `/api/lifecycles/{id}/preview`, `/api/spaces/{spaceIdentifier}
     "Unit": "Days"
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TentacleRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -1055,17 +1071,17 @@ Also reachable at `/api/lifecycles/{id}/projects`, `/api/spaces/{spaceIdentifier
       {
         "EnvironmentId": "string",
         "ReleaseId": "string",
-        "TenantId": "string"
+        "TenantId": "Tenants-1"
       }
     ],
-    "ClonedFromProjectId": "string",
+    "ClonedFromProjectId": "Projects-1",
     "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
     "DefaultGuidedFailureMode": "EnvironmentDefault",
     "DefaultPowerShellEdition": "string",
     "DefaultToSkipIfAlreadyInstalled": true,
     "DeploymentChangesTemplate": "string",
     "DeploymentProcessId": "string",
-    "DeprovisioningRunbookId": "string",
+    "DeprovisioningRunbookId": "Runbooks-1",
     "Description": "string",
     "DiscreteChannelRelease": true,
     "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -1116,7 +1132,7 @@ Also reachable at `/api/lifecycles/{id}/projects`, `/api/spaces/{spaceIdentifier
       "Slug": "string",
       "VersionMask": "string"
     },
-    "ProvisioningRunbookId": "string",
+    "ProvisioningRunbookId": "Runbooks-1",
     "ReleaseCreationStrategy": {
       "ChannelId": "string",
       "ReleaseCreationPackage": {
@@ -1126,7 +1142,7 @@ Also reachable at `/api/lifecycles/{id}/projects`, `/api/spaces/{spaceIdentifier
     },
     "ReleaseNotesTemplate": "string",
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Templates": [
       {
         "DefaultValue": {},

--- a/src/pages/docs/api/machine-policies.md
+++ b/src/pages/docs/api/machine-policies.md
@@ -129,7 +129,7 @@ Also reachable at `/api/machinepolicies`, `/api/spaces/{spaceIdentifier}/machine
       },
       "Name": "string",
       "PollingRequestQueueTimeout": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -264,7 +264,7 @@ Also reachable at `/api/machinepolicies`, `/api/spaces/{spaceIdentifier}/machine
   },
   "Name": "string",
   "PollingRequestQueueTimeout": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -393,7 +393,7 @@ Also reachable at `/api/machinepolicies`, `/api/spaces/{spaceIdentifier}/machine
   },
   "Name": "string",
   "PollingRequestQueueTimeout": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -533,7 +533,7 @@ Also reachable at `/api/machinepolicies/all`, `/api/spaces/{spaceIdentifier}/mac
     },
     "Name": "string",
     "PollingRequestQueueTimeout": "string",
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 ]
 ```
@@ -673,7 +673,7 @@ Also reachable at `/api/machinepolicies/template`, `/api/spaces/{spaceIdentifier
   },
   "Name": "string",
   "PollingRequestQueueTimeout": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -815,7 +815,7 @@ Also reachable at `/api/machinepolicies/{id}`, `/api/spaces/{spaceIdentifier}/ma
   },
   "Name": "string",
   "PollingRequestQueueTimeout": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -901,7 +901,7 @@ Also reachable at `/api/machinepolicies/{id}`, `/api/spaces/{spaceIdentifier}/ma
   "ConnectionRetrySleepInterval": "string",
   "ConnectionRetryTimeLimit": "string",
   "Description": "string",
-  "Id": "string",
+  "Id": "MachinePolicies-1",
   "IsDefault": true,
   "MachineCleanupPolicy": {
     "DeleteMachinesBehavior": "DoNotDelete",
@@ -944,7 +944,7 @@ Also reachable at `/api/machinepolicies/{id}`, `/api/spaces/{spaceIdentifier}/ma
   },
   "Name": "string",
   "PollingRequestQueueTimeout": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1073,7 +1073,7 @@ Also reachable at `/api/machinepolicies/{id}`, `/api/spaces/{spaceIdentifier}/ma
   },
   "Name": "string",
   "PollingRequestQueueTimeout": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1183,7 +1183,8 @@ Also reachable at `/api/machinepolicies/{id}/machines`, `/api/spaces/{spaceIdent
         "Links": {}
       },
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "HasLatestCalamari": true,
       "HealthStatus": "Healthy",
@@ -1208,10 +1209,11 @@ Also reachable at `/api/machinepolicies/{id}/machines`, `/api/spaces/{spaceIdent
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "TenantTags": [
         "string"
@@ -1361,12 +1363,13 @@ Also reachable at `/api/machinepolicies/{id}/workers`, `/api/spaces/{spaceIdenti
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "Thumbprint": "string",
       "Uri": "string",
       "WorkerPoolIds": [
-        "string"
+        "WorkerPools-1",
+        "..."
       ]
     }
   ],

--- a/src/pages/docs/api/migrations.md
+++ b/src/pages/docs/api/migrations.md
@@ -34,7 +34,7 @@ The migration API provides the ability to back-up and restore parts of an Octopu
   "IsDryRun": true,
   "IsEncryptedPackage": true,
   "OverwriteExisting": true,
-  "PackageFeedSpaceId": "string",
+  "PackageFeedSpaceId": "Spaces-1",
   "PackageId": "string",
   "PackageVersion": "string",
   "Password": "string",
@@ -124,7 +124,7 @@ The migration API provides the ability to back-up and restore parts of an Octopu
 {
   "DestinationApiKey": "string",
   "DestinationPackageFeed": "string",
-  "DestinationPackageFeedSpaceId": "string",
+  "DestinationPackageFeedSpaceId": "Spaces-1",
   "EncryptPackage": true,
   "FailureCallbackUri": "string",
   "IgnoreCertificates": true,
@@ -136,9 +136,10 @@ The migration API provides the ability to back-up and restore parts of an Octopu
   "PackageVersion": "string",
   "Password": "string",
   "Projects": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SuccessCallbackUri": "string"
 }
 ```
@@ -201,7 +202,7 @@ The migration API provides the ability to back-up and restore parts of an Octopu
   "Projects": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SuccessCallbackUri": "string",
   "TaskId": "string"
 }

--- a/src/pages/docs/api/observability.md
+++ b/src/pages/docs/api/observability.md
@@ -29,9 +29,9 @@ Also reachable at `/api/spaces/{spaceIdentifier}/observability/agents`, `/api/sp
 ```json
 {
   "InstallationId": "00000000-0000-0000-0000-000000000000",
-  "MachineId": "string",
+  "MachineId": "Machines-1",
   "PreserveAuthenticationToken": true,
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -57,10 +57,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/observability/agents`, `/api/sp
   "AuthenticationToken": "string",
   "CertificateThumbprint": "string",
   "Resource": {
-    "Id": "string",
+    "Id": "KubernetesMonitors-1",
     "InstallationId": "00000000-0000-0000-0000-000000000000",
-    "MachineId": "string",
-    "SpaceId": "string"
+    "MachineId": "Machines-1",
+    "SpaceId": "Spaces-1"
   }
 }
 ```
@@ -90,11 +90,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/observability/events/sessions`.
 ```json
 {
   "DesiredOrKubernetesMonitoredResourceId": "string",
-  "EnvironmentId": "string",
-  "MachineId": "string",
-  "ProjectId": "string",
-  "SpaceId": "string",
-  "TenantId": "string"
+  "EnvironmentId": "Environments-1",
+  "MachineId": "Machines-1",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1"
 }
 ```
 :::
@@ -201,10 +201,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/observability/kubernetes-monito
 ```json
 {
   "Resource": {
-    "Id": "string",
+    "Id": "KubernetesMonitors-1",
     "InstallationId": "00000000-0000-0000-0000-000000000000",
-    "MachineId": "string",
-    "SpaceId": "string"
+    "MachineId": "Machines-1",
+    "SpaceId": "Spaces-1"
   }
 }
 ```
@@ -263,13 +263,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/observability/logs/sessions`.
 {
   "ContainerName": "string",
   "DesiredOrKubernetesMonitoredResourceId": "string",
-  "EnvironmentId": "string",
-  "MachineId": "string",
+  "EnvironmentId": "Environments-1",
+  "MachineId": "Machines-1",
   "PodName": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ShowPreviousContainer": true,
-  "SpaceId": "string",
-  "TenantId": "string"
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1"
 }
 ```
 :::
@@ -374,7 +374,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/environmen
 {
   "MachineStatuses": [
     {
-      "MachineId": "string",
+      "MachineId": "Machines-1",
       "Resources": [
         {}
       ],

--- a/src/pages/docs/api/octopus-server-nodes.md
+++ b/src/pages/docs/api/octopus-server-nodes.md
@@ -308,7 +308,7 @@ Modifies an existing Octopus Server node.
 :::api-example{label="Request"}
 ```json
 {
-  "Id": "string",
+  "Id": "OctopusServerNodes-1",
   "IsInMaintenanceMode": true,
   "MaxConcurrentTasks": 0
 }

--- a/src/pages/docs/api/packages.md
+++ b/src/pages/docs/api/packages.md
@@ -334,7 +334,7 @@ Also reachable at `/api/packages/bulk`, `/api/spaces/{spaceIdentifier}/packages/
   "Ids": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -367,7 +367,7 @@ Also reachable at `/api/packages/bulk/v1`, `/api/spaces/{spaceIdentifier}/packag
   "Ids": [
     "string"
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/parent-environments.md
+++ b/src/pages/docs/api/parent-environments.md
@@ -37,7 +37,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/parentEnvironments`.
   "Description": "string",
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -52,7 +52,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/parentEnvironments`.
 :::api-example{label="Response"}
 ```json
 {
-  "Id": "string"
+  "Id": "Environments-1"
 }
 ```
 :::
@@ -90,11 +90,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/parentEnvironments/{environment
     "ExpiryHours": 0
   },
   "Description": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -125,11 +125,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/parentEnvironments/{environment
     "ExpiryHours": 0
   },
   "Description": "string",
-  "Id": "string",
+  "Id": "Environments-1",
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```
@@ -172,11 +172,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/parentEnvironments/{id}`.
     "ExpiryHours": 0
   },
   "Description": "string",
-  "Id": "string",
+  "Id": "Environments-1",
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "UseGuidedFailure": true
 }
 ```

--- a/src/pages/docs/api/platform-hub.md
+++ b/src/pages/docs/api/platform-hub.md
@@ -48,7 +48,7 @@ title: Platform Hub
       "Details": {
         "AccountType": "string"
       },
-      "Id": "string",
+      "Id": "Accounts-1",
       "Name": "string",
       "Slug": "string"
     }
@@ -96,7 +96,7 @@ title: Platform Hub
 :::api-example{label="Response"}
 ```json
 {
-  "Id": "string"
+  "Id": "Accounts-1"
 }
 ```
 :::
@@ -130,7 +130,7 @@ title: Platform Hub
   "Details": {
     "AccountType": "string"
   },
-  "Id": "string",
+  "Id": "Accounts-1",
   "Name": "string",
   "Slug": "string"
 }
@@ -162,7 +162,7 @@ title: Platform Hub
   "Details": {
     "AccountType": "string"
   },
-  "Id": "string",
+  "Id": "Accounts-1",
   "Name": "string",
   "Slug": "string"
 }

--- a/src/pages/docs/api/process-templates.md
+++ b/src/pages/docs/api/process-templates.md
@@ -24,7 +24,8 @@ title: Process Templates
 ```json
 {
   "IndividuallySharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "SharedToAllSpaces": true
 }
@@ -108,7 +109,7 @@ title: Process Templates
       "Color": "string",
       "Id": "string"
     },
-    "Id": "string",
+    "Id": "ProcessTemplateVersion-1",
     "IsPreRelease": true,
     "Name": "string",
     "Parameters": [
@@ -451,7 +452,8 @@ title: Process Templates
 {
   "GitRef": "string",
   "IndividuallySharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "ShareToAllSpaces": true,
   "Slug": "string"
@@ -471,10 +473,12 @@ title: Process Templates
 ```json
 {
   "IndividuallySharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "IndividuallyUnsharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "SharedToAllSpaces": true
 }
@@ -587,7 +591,7 @@ title: Process Templates
     "Color": "string",
     "Id": "string"
   },
-  "Id": "string",
+  "Id": "ProcessTemplateVersion-1",
   "IsPreRelease": true,
   "Name": "string",
   "Parameters": [

--- a/src/pages/docs/api/progression.md
+++ b/src/pages/docs/api/progression.md
@@ -97,7 +97,7 @@ Also reachable at `/api/progression/runbooks/taskRuns`, `/api/spaces/{spaceIdent
       "CompletedTime": "2020-01-01T00:00:00.000Z",
       "Created": "2020-01-01T00:00:00.000Z",
       "Duration": "string",
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ErrorMessage": "string",
       "GitReference": {
         "GitCommit": "string",
@@ -121,7 +121,7 @@ Also reachable at `/api/progression/runbooks/taskRuns`, `/api/spaces/{spaceIdent
       "PendingPreconditionTypes": [
         "string"
       ],
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "RunBy": "string",
       "RunName": "string",
@@ -132,7 +132,7 @@ Also reachable at `/api/progression/runbooks/taskRuns`, `/api/spaces/{spaceIdent
       "StartTime": "2020-01-01T00:00:00.000Z",
       "State": "Queued",
       "TaskId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -203,7 +203,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "CompletedTime": "2020-01-01T00:00:00.000Z",
         "Created": "2020-01-01T00:00:00.000Z",
         "Duration": "string",
-        "EnvironmentId": "string",
+        "EnvironmentId": "Environments-1",
         "ErrorMessage": "string",
         "GitReference": {},
         "HasPendingInterruptions": true,
@@ -220,7 +220,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "PendingPreconditionTypes": [
           "string"
         ],
-        "ProjectId": "string",
+        "ProjectId": "Projects-1",
         "QueueTime": "2020-01-01T00:00:00.000Z",
         "RunBy": "string",
         "RunName": "string",
@@ -231,7 +231,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "StartTime": "2020-01-01T00:00:00.000Z",
         "State": "Queued",
         "TaskId": "string",
-        "TenantId": "string"
+        "TenantId": "Tenants-1"
       }
     ],
     "additionalProp2": [
@@ -239,7 +239,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "CompletedTime": "2020-01-01T00:00:00.000Z",
         "Created": "2020-01-01T00:00:00.000Z",
         "Duration": "string",
-        "EnvironmentId": "string",
+        "EnvironmentId": "Environments-1",
         "ErrorMessage": "string",
         "GitReference": {},
         "HasPendingInterruptions": true,
@@ -256,7 +256,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "PendingPreconditionTypes": [
           "string"
         ],
-        "ProjectId": "string",
+        "ProjectId": "Projects-1",
         "QueueTime": "2020-01-01T00:00:00.000Z",
         "RunBy": "string",
         "RunName": "string",
@@ -267,7 +267,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "StartTime": "2020-01-01T00:00:00.000Z",
         "State": "Queued",
         "TaskId": "string",
-        "TenantId": "string"
+        "TenantId": "Tenants-1"
       }
     ],
     "additionalProp3": [
@@ -275,7 +275,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "CompletedTime": "2020-01-01T00:00:00.000Z",
         "Created": "2020-01-01T00:00:00.000Z",
         "Duration": "string",
-        "EnvironmentId": "string",
+        "EnvironmentId": "Environments-1",
         "ErrorMessage": "string",
         "GitReference": {},
         "HasPendingInterruptions": true,
@@ -292,7 +292,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "PendingPreconditionTypes": [
           "string"
         ],
-        "ProjectId": "string",
+        "ProjectId": "Projects-1",
         "QueueTime": "2020-01-01T00:00:00.000Z",
         "RunBy": "string",
         "RunName": "string",
@@ -303,7 +303,7 @@ Also reachable at `/api/progression/runbooks/{runbookId}`, `/api/spaces/{spaceId
         "StartTime": "2020-01-01T00:00:00.000Z",
         "State": "Queued",
         "TaskId": "string",
-        "TenantId": "string"
+        "TenantId": "Tenants-1"
       }
     ]
   }
@@ -497,13 +497,13 @@ Also reachable at `/api/progression/{projectId}`, `/api/projects/{projectId}/pro
         "LifecycleId": "string",
         "Links": {},
         "Name": "string",
-        "ParentEnvironmentId": "string",
-        "ProjectId": "string",
+        "ParentEnvironmentId": "Environments-1",
+        "ProjectId": "Projects-1",
         "Rules": [
           {}
         ],
         "Slug": "string",
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "TenantTags": [
           "string"
         ],
@@ -522,16 +522,17 @@ Also reachable at `/api/progression/{projectId}`, `/api/projects/{projectId}/pro
       },
       "HasUnresolvedDefect": true,
       "NextDeployments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Release": {
         "Assembled": "2020-01-01T00:00:00.000Z",
         "BuildInformation": [
           {}
         ],
-        "ChannelId": "string",
+        "ChannelId": "Channels-1",
         "CustomFields": {},
-        "Id": "string",
+        "Id": "Releases-1",
         "IgnoreChannelRules": true,
         "LastModifiedBy": "string",
         "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -540,7 +541,7 @@ Also reachable at `/api/progression/{projectId}`, `/api/projects/{projectId}/pro
         ],
         "Links": {},
         "ProjectDeploymentProcessSnapshotId": "string",
-        "ProjectId": "string",
+        "ProjectId": "Projects-1",
         "ProjectVariableSetSnapshotId": "string",
         "ReleaseNotes": "string",
         "SelectedGitResources": [
@@ -549,7 +550,8 @@ Also reachable at `/api/progression/{projectId}`, `/api/projects/{projectId}/pro
         "SelectedPackages": [
           {}
         ],
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
+        "VariableSnapshotConcurrencyToken": "string",
         "Version": "string",
         "VersionControlReference": {}
       },
@@ -653,7 +655,8 @@ Also reachable at `/api/projects/{projectId}/progression/v1`, `/api/spaces/{spac
         "Deployments": {},
         "HasUnresolvedDefect": true,
         "NextDeployments": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "Release": {},
         "ReleaseRetentionPeriod": {},

--- a/src/pages/docs/api/project-groups.md
+++ b/src/pages/docs/api/project-groups.md
@@ -87,7 +87,7 @@ Also reachable at `/api/projectgroups`, `/api/spaces/{spaceIdentifier}/projectgr
       "Name": "string",
       "RetentionPolicyId": "string",
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -132,7 +132,7 @@ Also reachable at `/api/projectgroups`, `/api/spaces/{spaceIdentifier}/projectgr
   "Description": "string",
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -177,7 +177,7 @@ Also reachable at `/api/projectgroups`, `/api/spaces/{spaceIdentifier}/projectgr
   "Name": "string",
   "RetentionPolicyId": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -233,7 +233,7 @@ Also reachable at `/api/projectgroups/all`, `/api/spaces/{spaceIdentifier}/proje
     "Name": "string",
     "RetentionPolicyId": "string",
     "Slug": "string",
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 ]
 ```
@@ -292,7 +292,7 @@ Also reachable at `/api/projectgroups/{id}`, `/api/spaces/{spaceIdentifier}/proj
   "Name": "string",
   "RetentionPolicyId": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -326,10 +326,10 @@ Also reachable at `/api/projectgroups/{id}`, `/api/spaces/{spaceIdentifier}/proj
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "ProjectGroups-1",
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -374,7 +374,7 @@ Also reachable at `/api/projectgroups/{id}`, `/api/spaces/{spaceIdentifier}/proj
   "Name": "string",
   "RetentionPolicyId": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -497,14 +497,14 @@ Also reachable at `/api/projectgroups/{id}/projects`, `/api/spaces/{spaceIdentif
       "AutoDeployReleaseOverrides": [
         {}
       ],
-      "ClonedFromProjectId": "string",
+      "ClonedFromProjectId": "Projects-1",
       "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
       "DefaultGuidedFailureMode": "EnvironmentDefault",
       "DefaultPowerShellEdition": "string",
       "DefaultToSkipIfAlreadyInstalled": true,
       "DeploymentChangesTemplate": "string",
       "DeploymentProcessId": "string",
-      "DeprovisioningRunbookId": "string",
+      "DeprovisioningRunbookId": "Runbooks-1",
       "Description": "string",
       "DiscreteChannelRelease": true,
       "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -552,14 +552,14 @@ Also reachable at `/api/projectgroups/{id}/projects`, `/api/spaces/{spaceIdentif
         "Slug": "string",
         "VersionMask": "string"
       },
-      "ProvisioningRunbookId": "string",
+      "ProvisioningRunbookId": "Runbooks-1",
       "ReleaseCreationStrategy": {
         "ChannelId": "string",
         "ReleaseCreationPackage": {}
       },
       "ReleaseNotesTemplate": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],

--- a/src/pages/docs/api/project-templates.md
+++ b/src/pages/docs/api/project-templates.md
@@ -27,7 +27,8 @@ title: Project Templates
 {
   "GitRef": "string",
   "IndividuallySharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "ShareToAllSpaces": true,
   "Slug": "string"
@@ -47,10 +48,12 @@ title: Project Templates
 ```json
 {
   "IndividuallySharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "IndividuallyUnsharedSpaceIds": [
-    "string"
+    "Spaces-1",
+    "..."
   ],
   "SharedToAllSpaces": true
 }

--- a/src/pages/docs/api/project-triggers.md
+++ b/src/pages/docs/api/project-triggers.md
@@ -104,7 +104,7 @@ Also reachable at `/api/projects/{projectId}/triggers`, `/api/spaces/{spaceIdent
       },
       "Name": "string",
       "ProjectId": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -198,8 +198,8 @@ Also reachable at `/api/projects/{projectId}/triggers`, `/api/spaces/{spaceIdent
   },
   "IsDisabled": true,
   "Name": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -281,7 +281,7 @@ Also reachable at `/api/projects/{projectId}/triggers`, `/api/spaces/{spaceIdent
   },
   "Name": "string",
   "ProjectId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -378,7 +378,7 @@ Also reachable at `/api/projects/{projectId}/triggers/{id}`, `/api/spaces/{space
   },
   "Name": "string",
   "ProjectId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -463,11 +463,11 @@ Updates an existing project trigger
       "additionalProp3": "string"
     }
   },
-  "Id": "string",
+  "Id": "ProjectTriggers-1",
   "IsDisabled": true,
   "Name": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -549,7 +549,7 @@ Updates an existing project trigger
   },
   "Name": "string",
   "ProjectId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -668,7 +668,7 @@ Gets all the Project Triggers in the supplied Octopus Deploy Space, sorted by Id
       },
       "Name": "string",
       "ProjectId": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -760,8 +760,8 @@ Also reachable at `/api/projecttriggers`, `/api/spaces/{spaceIdentifier}/project
   },
   "IsDisabled": true,
   "Name": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -843,7 +843,7 @@ Also reachable at `/api/projecttriggers`, `/api/spaces/{spaceIdentifier}/project
   },
   "Name": "string",
   "ProjectId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -938,7 +938,7 @@ Also reachable at `/api/projecttriggers/{id}`, `/api/spaces/{spaceIdentifier}/pr
   },
   "Name": "string",
   "ProjectId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1021,11 +1021,11 @@ Updates an existing project trigger
       "additionalProp3": "string"
     }
   },
-  "Id": "string",
+  "Id": "ProjectTriggers-1",
   "IsDisabled": true,
   "Name": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1107,7 +1107,7 @@ Updates an existing project trigger
   },
   "Name": "string",
   "ProjectId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/projects.md
+++ b/src/pages/docs/api/projects.md
@@ -109,14 +109,14 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
       "AutoDeployReleaseOverrides": [
         {}
       ],
-      "ClonedFromProjectId": "string",
+      "ClonedFromProjectId": "Projects-1",
       "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
       "DefaultGuidedFailureMode": "EnvironmentDefault",
       "DefaultPowerShellEdition": "string",
       "DefaultToSkipIfAlreadyInstalled": true,
       "DeploymentChangesTemplate": "string",
       "DeploymentProcessId": "string",
-      "DeprovisioningRunbookId": "string",
+      "DeprovisioningRunbookId": "Runbooks-1",
       "Description": "string",
       "DiscreteChannelRelease": true,
       "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -164,14 +164,14 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
         "Slug": "string",
         "VersionMask": "string"
       },
-      "ProvisioningRunbookId": "string",
+      "ProvisioningRunbookId": "Runbooks-1",
       "ReleaseCreationStrategy": {
         "ChannelId": "string",
         "ReleaseCreationPackage": {}
       },
       "ReleaseNotesTemplate": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Templates": [
         {}
       ],
@@ -280,10 +280,10 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
     {
       "EnvironmentId": "string",
       "ReleaseId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
-  "Clone": "string",
+  "Clone": "Projects-1",
   "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
   "DefaultGuidedFailureMode": "EnvironmentDefault",
   "DefaultToSkipIfAlreadyInstalled": true,
@@ -302,7 +302,7 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
     "string"
   ],
   "IsDisabled": true,
-  "LifecycleId": "string",
+  "LifecycleId": "Lifecycles-1",
   "Name": "string",
   "PersistenceSettings": {
     "Type": "Database"
@@ -315,7 +315,7 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
       "string"
     ]
   },
-  "ProjectGroupId": "string",
+  "ProjectGroupId": "ProjectGroups-1",
   "ProjectTags": [
     "string"
   ],
@@ -329,7 +329,7 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
   "ReleaseNotesTemplate": "string",
   "RetainTenantConnections": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -454,17 +454,17 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
     {
       "EnvironmentId": "string",
       "ReleaseId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
-  "ClonedFromProjectId": "string",
+  "ClonedFromProjectId": "Projects-1",
   "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
   "DefaultGuidedFailureMode": "EnvironmentDefault",
   "DefaultPowerShellEdition": "string",
   "DefaultToSkipIfAlreadyInstalled": true,
   "DeploymentChangesTemplate": "string",
   "DeploymentProcessId": "string",
-  "DeprovisioningRunbookId": "string",
+  "DeprovisioningRunbookId": "Runbooks-1",
   "Description": "string",
   "DiscreteChannelRelease": true,
   "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -515,7 +515,7 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
     "Slug": "string",
     "VersionMask": "string"
   },
-  "ProvisioningRunbookId": "string",
+  "ProvisioningRunbookId": "Runbooks-1",
   "ReleaseCreationStrategy": {
     "ChannelId": "string",
     "ReleaseCreationPackage": {
@@ -525,7 +525,7 @@ Also reachable at `/api/projects`, `/api/spaces/{spaceIdentifier}/projects`.
   },
   "ReleaseNotesTemplate": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -668,17 +668,17 @@ Also reachable at `/api/projects/all`, `/api/spaces/{spaceIdentifier}/projects/a
       {
         "EnvironmentId": "string",
         "ReleaseId": "string",
-        "TenantId": "string"
+        "TenantId": "Tenants-1"
       }
     ],
-    "ClonedFromProjectId": "string",
+    "ClonedFromProjectId": "Projects-1",
     "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
     "DefaultGuidedFailureMode": "EnvironmentDefault",
     "DefaultPowerShellEdition": "string",
     "DefaultToSkipIfAlreadyInstalled": true,
     "DeploymentChangesTemplate": "string",
     "DeploymentProcessId": "string",
-    "DeprovisioningRunbookId": "string",
+    "DeprovisioningRunbookId": "Runbooks-1",
     "Description": "string",
     "DiscreteChannelRelease": true,
     "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -729,7 +729,7 @@ Also reachable at `/api/projects/all`, `/api/spaces/{spaceIdentifier}/projects/a
       "Slug": "string",
       "VersionMask": "string"
     },
-    "ProvisioningRunbookId": "string",
+    "ProvisioningRunbookId": "Runbooks-1",
     "ReleaseCreationStrategy": {
       "ChannelId": "string",
       "ReleaseCreationPackage": {
@@ -739,7 +739,7 @@ Also reachable at `/api/projects/all`, `/api/spaces/{spaceIdentifier}/projects/a
     },
     "ReleaseNotesTemplate": "string",
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Templates": [
       {
         "DefaultValue": {},
@@ -893,17 +893,17 @@ Also reachable at `/api/projects/{projectId}`, `/api/projects/{projectId}/{unuse
     {
       "EnvironmentId": "string",
       "ReleaseId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
-  "ClonedFromProjectId": "string",
+  "ClonedFromProjectId": "Projects-1",
   "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
   "DefaultGuidedFailureMode": "EnvironmentDefault",
   "DefaultPowerShellEdition": "string",
   "DefaultToSkipIfAlreadyInstalled": true,
   "DeploymentChangesTemplate": "string",
   "DeploymentProcessId": "string",
-  "DeprovisioningRunbookId": "string",
+  "DeprovisioningRunbookId": "Runbooks-1",
   "Description": "string",
   "DiscreteChannelRelease": true,
   "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -954,7 +954,7 @@ Also reachable at `/api/projects/{projectId}`, `/api/projects/{projectId}/{unuse
     "Slug": "string",
     "VersionMask": "string"
   },
-  "ProvisioningRunbookId": "string",
+  "ProvisioningRunbookId": "Runbooks-1",
   "ReleaseCreationStrategy": {
     "ChannelId": "string",
     "ReleaseCreationPackage": {
@@ -964,7 +964,7 @@ Also reachable at `/api/projects/{projectId}`, `/api/projects/{projectId}/{unuse
   },
   "ReleaseNotesTemplate": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -1088,17 +1088,17 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
     {
       "EnvironmentId": "string",
       "ReleaseId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
   "ChangeDescription": "string",
-  "ClonedFromProjectId": "string",
+  "ClonedFromProjectId": "Projects-1",
   "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
   "DefaultGuidedFailureMode": "EnvironmentDefault",
   "DefaultPowerShellEdition": "string",
   "DefaultToSkipIfAlreadyInstalled": true,
   "DeploymentChangesTemplate": "string",
-  "DeprovisioningRunbookId": "string",
+  "DeprovisioningRunbookId": "Runbooks-1",
   "Description": "string",
   "DiscreteChannelRelease": true,
   "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -1114,7 +1114,7 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
   ],
   "IsBadgesEnabled": true,
   "IsDisabled": true,
-  "LifecycleId": "string",
+  "LifecycleId": "Lifecycles-1",
   "Name": "string",
   "PersistenceSettings": {
     "Type": "Database"
@@ -1127,12 +1127,12 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
       "string"
     ]
   },
-  "ProjectGroupId": "string",
-  "ProjectId": "string",
+  "ProjectGroupId": "ProjectGroups-1",
+  "ProjectId": "Projects-1",
   "ProjectTags": [
     "string"
   ],
-  "ProvisioningRunbookId": "string",
+  "ProvisioningRunbookId": "Runbooks-1",
   "ReleaseCreationStrategy": {
     "ChannelId": "string",
     "ReleaseCreationPackage": {
@@ -1142,7 +1142,7 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
   },
   "ReleaseNotesTemplate": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -1267,17 +1267,17 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
     {
       "EnvironmentId": "string",
       "ReleaseId": "string",
-      "TenantId": "string"
+      "TenantId": "Tenants-1"
     }
   ],
-  "ClonedFromProjectId": "string",
+  "ClonedFromProjectId": "Projects-1",
   "CombineHealthAndSyncStatusInDashboardLiveStatus": true,
   "DefaultGuidedFailureMode": "EnvironmentDefault",
   "DefaultPowerShellEdition": "string",
   "DefaultToSkipIfAlreadyInstalled": true,
   "DeploymentChangesTemplate": "string",
   "DeploymentProcessId": "string",
-  "DeprovisioningRunbookId": "string",
+  "DeprovisioningRunbookId": "Runbooks-1",
   "Description": "string",
   "DiscreteChannelRelease": true,
   "ExecuteDeploymentsOnEventBasedPipeline": true,
@@ -1328,7 +1328,7 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
     "Slug": "string",
     "VersionMask": "string"
   },
-  "ProvisioningRunbookId": "string",
+  "ProvisioningRunbookId": "Runbooks-1",
   "ReleaseCreationStrategy": {
     "ChannelId": "string",
     "ReleaseCreationPackage": {
@@ -1338,7 +1338,7 @@ Also reachable at `/api/projects/{projectId}`, `/api/spaces/{spaceIdentifier}/pr
   },
   "ReleaseNotesTemplate": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Templates": [
     {
       "DefaultValue": {
@@ -1417,8 +1417,8 @@ Also reachable at `/api/projects/{projectId}/git/connectivity-test`, `/api/space
     "Type": "Anonymous"
   },
   "DefaultBranch": "string",
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "Url": "string"
 }
 ```
@@ -1489,8 +1489,8 @@ Also reachable at `/api/projects/{projectId}/git/convert`, `/api/spaces/{spaceId
   "ChangeDescription": "string",
   "CommitMessage": "string",
   "InitialCommitBranchName": "string",
-  "ProjectId": "string",
-  "SpaceId": "string",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1",
   "VersionControlSettings": {
     "BasePath": "string",
     "ConversionState": {
@@ -1552,8 +1552,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/git/migrat
   "Branch": "string",
   "CommitMessage": "string",
   "CreateBranch": true,
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1585,7 +1585,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/git/migrat
       "RunbookName": "string"
     }
   ],
-  "ServerTaskId": "string"
+  "ServerTaskId": "ServerTasks-1"
 }
 ```
 :::
@@ -1827,8 +1827,8 @@ Also reachable at `/api/projects/{projectId}/git/validate`, `/api/spaces/{spaceI
 ```json
 {
   "GitRef": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/proxies.md
+++ b/src/pages/docs/api/proxies.md
@@ -86,7 +86,7 @@ Lists all of the Proxies in the supplied Octopus Deploy Space. The results will 
       },
       "Port": 0,
       "ProxyType": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Username": "string"
     }
   ],
@@ -146,7 +146,7 @@ Also reachable at `/api/proxies`, `/api/spaces/{spaceIdentifier}/proxies`.
   },
   "Port": 0,
   "ProxyType": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Username": "string"
 }
 ```
@@ -195,7 +195,7 @@ Also reachable at `/api/proxies`, `/api/spaces/{spaceIdentifier}/proxies`.
   },
   "Port": 0,
   "ProxyType": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Username": "string"
 }
 ```
@@ -258,7 +258,7 @@ Lists the name and ID of all of the Proxies in the supplied Octopus Deploy Space
     },
     "Port": 0,
     "ProxyType": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Username": "string"
   }
 ]
@@ -321,7 +321,7 @@ Also reachable at `/api/proxies/{id}`, `/api/spaces/{spaceIdentifier}/proxies/{i
   },
   "Port": 0,
   "ProxyType": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Username": "string"
 }
 ```
@@ -364,7 +364,7 @@ Also reachable at `/api/proxies/{id}`, `/api/spaces/{spaceIdentifier}/proxies/{i
 ```json
 {
   "Host": "string",
-  "Id": "string",
+  "Id": "Proxys-1",
   "Name": "string",
   "Password": {
     "HasValue": true,
@@ -373,7 +373,7 @@ Also reachable at `/api/proxies/{id}`, `/api/spaces/{spaceIdentifier}/proxies/{i
   },
   "Port": 0,
   "ProxyType": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Username": "string"
 }
 ```
@@ -422,7 +422,7 @@ Also reachable at `/api/proxies/{id}`, `/api/spaces/{spaceIdentifier}/proxies/{i
   },
   "Port": 0,
   "ProxyType": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Username": "string"
 }
 ```

--- a/src/pages/docs/api/releases.md
+++ b/src/pages/docs/api/releases.md
@@ -62,6 +62,8 @@ Releases will be ordered from most recent to least recent,
   - **`SelectedGitResources`** :span[array of object]{.type-label}
   - **`SelectedPackages`** :span[array of object]{.type-label}
   - **`SpaceId`** :span[string]{.type-label}
+  - **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+    Identifies the release's current variable snapshots.
   - **`Version`** :span[string]{.type-label}  
     Maximum length 349.
   - **`VersionControlReference`** :span[object]{.type-label}
@@ -87,13 +89,13 @@ Releases will be ordered from most recent to least recent,
       "BuildInformation": [
         {}
       ],
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "CustomFields": {
         "additionalProp1": "string",
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "Id": "string",
+      "Id": "Releases-1",
       "IgnoreChannelRules": true,
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -106,7 +108,7 @@ Releases will be ordered from most recent to least recent,
         "additionalProp3": "string"
       },
       "ProjectDeploymentProcessSnapshotId": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
       "ReleaseNotes": "string",
       "SelectedGitResources": [
@@ -115,7 +117,8 @@ Releases will be ordered from most recent to least recent,
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
+      "VariableSnapshotConcurrencyToken": "string",
       "Version": "string",
       "VersionControlReference": {
         "GitCommit": "string",
@@ -196,6 +199,8 @@ Releases will be ordered from most recent to least recent,
   - **`SelectedGitResources`** :span[array of object]{.type-label}
   - **`SelectedPackages`** :span[array of object]{.type-label}
   - **`SpaceId`** :span[string]{.type-label}
+  - **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+    Identifies the release's current variable snapshots.
   - **`Version`** :span[string]{.type-label}  
     Maximum length 349.
   - **`VersionControlReference`** :span[object]{.type-label}
@@ -221,13 +226,13 @@ Releases will be ordered from most recent to least recent,
       "BuildInformation": [
         {}
       ],
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "CustomFields": {
         "additionalProp1": "string",
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "Id": "string",
+      "Id": "Releases-1",
       "IgnoreChannelRules": true,
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -240,7 +245,7 @@ Releases will be ordered from most recent to least recent,
         "additionalProp3": "string"
       },
       "ProjectDeploymentProcessSnapshotId": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
       "ReleaseNotes": "string",
       "SelectedGitResources": [
@@ -249,7 +254,8 @@ Releases will be ordered from most recent to least recent,
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
+      "VariableSnapshotConcurrencyToken": "string",
       "Version": "string",
       "VersionControlReference": {
         "GitCommit": "string",
@@ -328,6 +334,8 @@ Releases will be ordered from most recent to least recent
   - **`SelectedGitResources`** :span[array of object]{.type-label}
   - **`SelectedPackages`** :span[array of object]{.type-label}
   - **`SpaceId`** :span[string]{.type-label}
+  - **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+    Identifies the release's current variable snapshots.
   - **`Version`** :span[string]{.type-label}  
     Maximum length 349.
   - **`VersionControlReference`** :span[object]{.type-label}
@@ -353,13 +361,13 @@ Releases will be ordered from most recent to least recent
       "BuildInformation": [
         {}
       ],
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "CustomFields": {
         "additionalProp1": "string",
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "Id": "string",
+      "Id": "Releases-1",
       "IgnoreChannelRules": true,
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -372,7 +380,7 @@ Releases will be ordered from most recent to least recent
         "additionalProp3": "string"
       },
       "ProjectDeploymentProcessSnapshotId": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
       "ReleaseNotes": "string",
       "SelectedGitResources": [
@@ -381,7 +389,8 @@ Releases will be ordered from most recent to least recent
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
+      "VariableSnapshotConcurrencyToken": "string",
       "Version": "string",
       "VersionControlReference": {
         "GitCommit": "string",
@@ -509,7 +518,7 @@ Also reachable at `/api/projects/{projectId}/releases/{id}/variables`, `/api/spa
         {}
       ]
     },
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Variables": [
       {
         "Description": "string",
@@ -592,6 +601,8 @@ Also reachable at `/api/projects/{projectId}/releases/{version}`, `/api/spaces/{
   - **`StepName`** :span[string]{.type-label}
   - **`Version`** :span[string]{.type-label}
 - **`SpaceId`** :span[string]{.type-label}
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  Identifies the release's current variable snapshots.
 - **`Version`** :span[string]{.type-label}  
   Maximum length 349.
 - **`VersionControlReference`** :span[object]{.type-label}
@@ -624,13 +635,13 @@ Also reachable at `/api/projects/{projectId}/releases/{version}`, `/api/spaces/{
       ]
     }
   ],
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -643,7 +654,7 @@ Also reachable at `/api/projects/{projectId}/releases/{version}`, `/api/spaces/{
     "additionalProp3": "string"
   },
   "ProjectDeploymentProcessSnapshotId": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
@@ -664,7 +675,8 @@ Also reachable at `/api/projects/{projectId}/releases/{version}`, `/api/spaces/{
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",
@@ -726,6 +738,8 @@ Lists all of the Releases in the supplied Octopus Deploy Space, from all project
   - **`SelectedGitResources`** :span[array of object]{.type-label}
   - **`SelectedPackages`** :span[array of object]{.type-label}
   - **`SpaceId`** :span[string]{.type-label}
+  - **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+    Identifies the release's current variable snapshots.
   - **`Version`** :span[string]{.type-label}  
     Maximum length 349.
   - **`VersionControlReference`** :span[object]{.type-label}
@@ -751,13 +765,13 @@ Lists all of the Releases in the supplied Octopus Deploy Space, from all project
       "BuildInformation": [
         {}
       ],
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "CustomFields": {
         "additionalProp1": "string",
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "Id": "string",
+      "Id": "Releases-1",
       "IgnoreChannelRules": true,
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -770,7 +784,7 @@ Lists all of the Releases in the supplied Octopus Deploy Space, from all project
         "additionalProp3": "string"
       },
       "ProjectDeploymentProcessSnapshotId": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
       "ReleaseNotes": "string",
       "SelectedGitResources": [
@@ -779,7 +793,8 @@ Lists all of the Releases in the supplied Octopus Deploy Space, from all project
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
+      "VariableSnapshotConcurrencyToken": "string",
       "Version": "string",
       "VersionControlReference": {
         "GitCommit": "string",
@@ -845,14 +860,14 @@ Also reachable at `/api/releases`, `/api/spaces/{spaceIdentifier}/releases`.
 ```json
 {
   "Assembled": "2020-01-01T00:00:00.000Z",
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
   "IgnoreChannelRules": true,
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
     {
@@ -872,7 +887,7 @@ Also reachable at `/api/releases`, `/api/spaces/{spaceIdentifier}/releases`.
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",
@@ -931,6 +946,8 @@ Also reachable at `/api/releases`, `/api/spaces/{spaceIdentifier}/releases`.
   - **`StepName`** :span[string]{.type-label}
   - **`Version`** :span[string]{.type-label}
 - **`SpaceId`** :span[string]{.type-label}
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  Identifies the release's current variable snapshots.
 - **`Version`** :span[string]{.type-label}  
   Maximum length 349.
 - **`VersionControlReference`** :span[object]{.type-label}
@@ -963,13 +980,13 @@ Also reachable at `/api/releases`, `/api/spaces/{spaceIdentifier}/releases`.
       ]
     }
   ],
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -982,7 +999,7 @@ Also reachable at `/api/releases`, `/api/spaces/{spaceIdentifier}/releases`.
     "additionalProp3": "string"
   },
   "ProjectDeploymentProcessSnapshotId": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
@@ -1003,7 +1020,8 @@ Also reachable at `/api/releases`, `/api/spaces/{spaceIdentifier}/releases`.
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",
@@ -1079,7 +1097,7 @@ Also reachable at `/api/releases/create/v1`, `/api/spaces/{spaceIdentifier}/rele
   "ProjectName": "string",
   "ReleaseNotes": "string",
   "ReleaseVersion": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpaceIdOrName": "string"
 }
 ```
@@ -1096,7 +1114,7 @@ Also reachable at `/api/releases/create/v1`, `/api/spaces/{spaceIdentifier}/rele
 :::api-example{label="Response"}
 ```json
 {
-  "ReleaseId": "string",
+  "ReleaseId": "Releases-1",
   "ReleaseVersion": "string"
 }
 ```
@@ -1163,6 +1181,8 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
   - **`StepName`** :span[string]{.type-label}
   - **`Version`** :span[string]{.type-label}
 - **`SpaceId`** :span[string]{.type-label}
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  Identifies the release's current variable snapshots.
 - **`Version`** :span[string]{.type-label}  
   Maximum length 349.
 - **`VersionControlReference`** :span[object]{.type-label}
@@ -1195,13 +1215,13 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
       ]
     }
   ],
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -1214,7 +1234,7 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
     "additionalProp3": "string"
   },
   "ProjectDeploymentProcessSnapshotId": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
@@ -1235,7 +1255,8 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",
@@ -1285,15 +1306,15 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
 :::api-example{label="Request"}
 ```json
 {
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
     {
@@ -1313,7 +1334,7 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Version": "string"
 }
 ```
@@ -1367,6 +1388,8 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
   - **`StepName`** :span[string]{.type-label}
   - **`Version`** :span[string]{.type-label}
 - **`SpaceId`** :span[string]{.type-label}
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  Identifies the release's current variable snapshots.
 - **`Version`** :span[string]{.type-label}  
   Maximum length 349.
 - **`VersionControlReference`** :span[object]{.type-label}
@@ -1399,13 +1422,13 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
       ]
     }
   ],
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -1418,7 +1441,7 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
     "additionalProp3": "string"
   },
   "ProjectDeploymentProcessSnapshotId": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
@@ -1439,7 +1462,8 @@ Also reachable at `/api/releases/{id}`, `/api/spaces/{spaceIdentifier}/releases/
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",
@@ -1531,7 +1555,7 @@ Also reachable at `/api/releases/{id}/deployments/template`, `/api/spaces/{space
   },
   "PromoteTo": [
     {
-      "Id": "string",
+      "Id": "Environments-1",
       "Links": {
         "additionalProp1": "string",
         "additionalProp2": "string",
@@ -1665,8 +1689,8 @@ Also reachable at `/api/releases/{releaseId}/defects`, `/api/spaces/{spaceIdenti
 ```json
 {
   "Description": "string",
-  "ReleaseId": "string",
-  "SpaceId": "string",
+  "ReleaseId": "Releases-1",
+  "SpaceId": "Spaces-1",
   "Status": "string"
 }
 ```
@@ -1859,7 +1883,7 @@ Deployments will be ordered from most recent to least recent.
         {}
       ],
       "ChangesMarkdown": "string",
-      "ChannelId": "string",
+      "ChannelId": "Channels-1",
       "Comments": "string",
       "Created": "2020-01-01T00:00:00.000Z",
       "DebugMode": "string",
@@ -1869,7 +1893,7 @@ Deployments will be ordered from most recent to least recent.
         "string"
       ],
       "DeploymentProcessId": "string",
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -1890,7 +1914,7 @@ Deployments will be ordered from most recent to least recent.
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "Id": "string",
+      "Id": "Deployments-1",
       "LastModifiedBy": "string",
       "LastModifiedOn": "2020-01-01T00:00:00.000Z",
       "Links": {
@@ -1901,22 +1925,22 @@ Deployments will be ordered from most recent to least recent.
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-      "ReleaseId": "string",
+      "ReleaseId": "Releases-1",
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -2109,13 +2133,13 @@ Also reachable at `/api/releases/{releaseId}/deployments/previews`, `/api/spaces
 {
   "DeploymentPreviews": [
     {
-      "EnvironmentId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "TenantId": "Tenants-1"
     }
   ],
   "IncludeDisabledSteps": true,
-  "ReleaseId": "string",
-  "SpaceId": "string"
+  "ReleaseId": "Releases-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2319,13 +2343,15 @@ Also reachable at `/api/releases/{releaseId}/progression`, `/api/spaces/{spaceId
     "additionalProp3": "string"
   },
   "NextDeployments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "NextDeploymentsMinimumRequired": 0,
   "Phases": [
     {
       "AutomaticDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Blocked": true,
       "Deployments": [
@@ -2337,7 +2363,8 @@ Also reachable at `/api/releases/{releaseId}/progression`, `/api/spaces/{spaceId
       "MinimumEnvironmentsBeforePromotion": 0,
       "Name": "string",
       "OptionalDeploymentTargets": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Progress": "Pending"
     }
@@ -2373,9 +2400,9 @@ Only the release notes are changed and everything else about the Release is left
 :::api-example{label="Request"}
 ```json
 {
-  "ReleaseId": "string",
+  "ReleaseId": "Releases-1",
   "ReleaseNotes": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2428,6 +2455,8 @@ Only the release notes are changed and everything else about the Release is left
   - **`StepName`** :span[string]{.type-label}
   - **`Version`** :span[string]{.type-label}
 - **`SpaceId`** :span[string]{.type-label}
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  Identifies the release's current variable snapshots.
 - **`Version`** :span[string]{.type-label}  
   Maximum length 349.
 - **`VersionControlReference`** :span[object]{.type-label}
@@ -2460,13 +2489,13 @@ Only the release notes are changed and everything else about the Release is left
       ]
     }
   ],
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -2479,7 +2508,7 @@ Only the release notes are changed and everything else about the Release is left
     "additionalProp3": "string"
   },
   "ProjectDeploymentProcessSnapshotId": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
@@ -2500,7 +2529,8 @@ Only the release notes are changed and everything else about the Release is left
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",
@@ -2521,6 +2551,23 @@ Also reachable at `/api/releases/{releaseId}/snapshot-variables`, `/api/spaces/{
 
 - **`releaseId`** :span[string]{.type-label} *(required)*
 - **`spaceId`** :span[string]{.type-label} *(required)*
+
+**Request Body**
+
+- **`ReleaseId`** :span[string]{.type-label} *(required)*
+- **`SpaceId`** :span[string]{.type-label} *(required)*
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  The VariableSnapshotConcurrencyToken read from the release. When supplied, the update fails with a conflict if the release's variable snapshots have changed since. Omit to skip the check.
+
+:::api-example{label="Request"}
+```json
+{
+  "ReleaseId": "Releases-1",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string"
+}
+```
+:::
 
 **Response**
 
@@ -2570,6 +2617,8 @@ Also reachable at `/api/releases/{releaseId}/snapshot-variables`, `/api/spaces/{
   - **`StepName`** :span[string]{.type-label}
   - **`Version`** :span[string]{.type-label}
 - **`SpaceId`** :span[string]{.type-label}
+- **`VariableSnapshotConcurrencyToken`** :span[string]{.type-label}  
+  Identifies the release's current variable snapshots.
 - **`Version`** :span[string]{.type-label}  
   Maximum length 349.
 - **`VersionControlReference`** :span[object]{.type-label}
@@ -2602,13 +2651,13 @@ Also reachable at `/api/releases/{releaseId}/snapshot-variables`, `/api/spaces/{
       ]
     }
   ],
-  "ChannelId": "string",
+  "ChannelId": "Channels-1",
   "CustomFields": {
     "additionalProp1": "string",
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "Id": "string",
+  "Id": "Releases-1",
   "IgnoreChannelRules": true,
   "LastModifiedBy": "string",
   "LastModifiedOn": "2020-01-01T00:00:00.000Z",
@@ -2621,7 +2670,7 @@ Also reachable at `/api/releases/{releaseId}/snapshot-variables`, `/api/spaces/{
     "additionalProp3": "string"
   },
   "ProjectDeploymentProcessSnapshotId": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
   "ReleaseNotes": "string",
   "SelectedGitResources": [
@@ -2642,7 +2691,8 @@ Also reachable at `/api/releases/{releaseId}/snapshot-variables`, `/api/spaces/{
       "Version": "string"
     }
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
+  "VariableSnapshotConcurrencyToken": "string",
   "Version": "string",
   "VersionControlReference": {
     "GitCommit": "string",

--- a/src/pages/docs/api/retention.md
+++ b/src/pages/docs/api/retention.md
@@ -87,8 +87,8 @@ Also reachable at `/api/retentionpolicies`, `/api/spaces/{spaceIdentifier}/reten
 {
   "Id": "string",
   "Name": "string",
-  "RetentionType": "string",
-  "SpaceId": "string"
+  "RetentionType": "LifecycleRelease",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -118,9 +118,9 @@ Also reachable at `/api/retentionpolicies/{id}`, `/api/spaces/{spaceIdentifier}/
 :::api-example{label="Request"}
 ```json
 {
-  "Id": "string",
-  "RetentionType": "string",
-  "SpaceId": "string"
+  "Id": "RetentionPolicies-1",
+  "RetentionType": "LifecycleRelease",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -139,8 +139,8 @@ Also reachable at `/api/retentionpolicies/{id}`, `/api/spaces/{spaceIdentifier}/
 {
   "Id": "string",
   "Name": "string",
-  "RetentionType": "string",
-  "SpaceId": "string"
+  "RetentionType": "LifecycleRelease",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::

--- a/src/pages/docs/api/runbook-processes.md
+++ b/src/pages/docs/api/runbook-processes.md
@@ -73,9 +73,9 @@ Also reachable at `/api/projects/{projectId}/runbookProcesses`, `/api/spaces/{sp
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "RunbookId": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Steps": [
         {}
       ],
@@ -155,9 +155,9 @@ Also reachable at `/api/projects/{projectId}/runbookProcesses/{id}`, `/api/space
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -240,9 +240,9 @@ Only allowed for Runbook Processes owned by a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -312,9 +312,9 @@ Only allowed for Runbook Processes owned by a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -512,9 +512,9 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbookProcesses/{id}`, `/
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -605,9 +605,9 @@ Only allowed for Runbook Processes owned by a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -677,9 +677,9 @@ Only allowed for Runbook Processes owned by a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -770,9 +770,9 @@ Also reachable at `/api/runbookProcesses`, `/api/spaces/{spaceIdentifier}/runboo
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "RunbookId": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Steps": [
         {}
       ],
@@ -851,9 +851,9 @@ Also reachable at `/api/runbookProcesses/{id}`, `/api/spaces/{spaceIdentifier}/r
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -935,9 +935,9 @@ Only allowed for Runbook Processes owned by a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [
@@ -1007,9 +1007,9 @@ Only allowed for Runbook Processes owned by a project.
     "additionalProp2": "string",
     "additionalProp3": "string"
   },
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookId": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Steps": [
     {
       "Actions": [

--- a/src/pages/docs/api/runbook-runs.md
+++ b/src/pages/docs/api/runbook-runs.md
@@ -129,7 +129,7 @@ Lists all of the runbookRuns in the supplied Octopus Deploy Space, from projects
       "DeployedToMachineIds": [
         "string"
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -161,7 +161,7 @@ Lists all of the runbookRuns in the supplied Octopus Deploy Space, from projects
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "RunbookId": "string",
@@ -170,15 +170,15 @@ Lists all of the runbookRuns in the supplied Octopus Deploy Space, from projects
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -252,7 +252,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns`, `/api/spaces/{spaceId
   ],
   "Comments": "string",
   "DebugMode": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -267,22 +267,22 @@ Also reachable at `/api/projects/{projectId}/runbookRuns`, `/api/spaces/{spaceId
     "additionalProp3": "string"
   },
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "RunbookSnapshotId": "string",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "UseGuidedFailure": true
 }
 ```
@@ -368,7 +368,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns`, `/api/spaces/{spaceId
   "DeployedToMachineIds": [
     "string"
   ],
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -378,7 +378,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns`, `/api/spaces/{spaceId
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -403,7 +403,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns`, `/api/spaces/{spaceId
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "RunbookId": "string",
@@ -412,15 +412,15 @@ Also reachable at `/api/projects/{projectId}/runbookRuns`, `/api/spaces/{spaceId
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -527,7 +527,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns/{id}`, `/api/spaces/{sp
   "DeployedToMachineIds": [
     "string"
   ],
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -537,7 +537,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns/{id}`, `/api/spaces/{sp
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -562,7 +562,7 @@ Also reachable at `/api/projects/{projectId}/runbookRuns/{id}`, `/api/spaces/{sp
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "RunbookId": "string",
@@ -571,15 +571,15 @@ Also reachable at `/api/projects/{projectId}/runbookRuns/{id}`, `/api/spaces/{sp
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -696,7 +696,7 @@ Also reachable at `/api/projects/{projectId}/runbookruns/{runbookRunId}/retry/v1
     "DeployedToMachineIds": [
       "string"
     ],
-    "EnvironmentId": "string",
+    "EnvironmentId": "Environments-1",
     "ExcludedMachineIds": [
       "string"
     ],
@@ -728,7 +728,7 @@ Also reachable at `/api/projects/{projectId}/runbookruns/{runbookRunId}/retry/v1
     "ManifestVariableSetId": "string",
     "Name": "string",
     "Priority": "string",
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "QueueTime": "2020-01-01T00:00:00.000Z",
     "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
     "RunbookId": "string",
@@ -737,15 +737,15 @@ Also reachable at `/api/projects/{projectId}/runbookruns/{runbookRunId}/retry/v1
     "SkipActions": [
       "string"
     ],
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "SpecificMachineIds": [
       "string"
     ],
     "SpecificTargetTagIds": [
       "string"
     ],
-    "TaskId": "string",
-    "TenantId": "string",
+    "TaskId": "ServerTasks-1",
+    "TenantId": "Tenants-1",
     "TentacleRetentionPeriod": {
       "QuantityToKeep": 0,
       "ShouldKeepForever": true,
@@ -814,8 +814,8 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
 {
   "GitRef": "string",
   "Notes": "string",
-  "ProjectId": "string",
-  "RunbookId": "string",
+  "ProjectId": "Projects-1",
+  "RunbookId": "Runbooks-1",
   "Runs": [
     {
       "ChangeRequestSettings": [
@@ -823,7 +823,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
       ],
       "Comments": "string",
       "DebugMode": "string",
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -849,7 +849,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TenantId": "string",
+      "TenantId": "Tenants-1",
       "UseGuidedFailure": true
     }
   ],
@@ -871,7 +871,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -949,7 +949,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
       "DeployedToMachineIds": [
         "string"
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -981,7 +981,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "RunbookId": "string",
@@ -990,15 +990,15 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{runbookId}/run/v
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -1092,7 +1092,7 @@ Also reachable at `/api/runbook-runs/create/v1`, `/api/spaces/{spaceIdentifier}/
     "string"
   ],
   "Snapshot": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpaceIdOrName": "string",
   "SpecificMachineNames": [
     "string"
@@ -1129,8 +1129,8 @@ Also reachable at `/api/runbook-runs/create/v1`, `/api/spaces/{spaceIdentifier}/
 {
   "RunbookRunServerTasks": [
     {
-      "RunbookRunId": "string",
-      "ServerTaskId": "string"
+      "RunbookRunId": "RunbookRuns-1",
+      "ServerTaskId": "ServerTasks-1"
     }
   ]
 }
@@ -1260,7 +1260,7 @@ Lists all of the runbookRuns in the supplied Octopus Deploy Space, from projects
       "DeployedToMachineIds": [
         "string"
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -1292,7 +1292,7 @@ Lists all of the runbookRuns in the supplied Octopus Deploy Space, from projects
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "RunbookId": "string",
@@ -1301,15 +1301,15 @@ Lists all of the runbookRuns in the supplied Octopus Deploy Space, from projects
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -1382,7 +1382,7 @@ Also reachable at `/api/runbookRuns`, `/api/spaces/{spaceIdentifier}/runbookRuns
   ],
   "Comments": "string",
   "DebugMode": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -1397,22 +1397,22 @@ Also reachable at `/api/runbookRuns`, `/api/spaces/{spaceIdentifier}/runbookRuns
     "additionalProp3": "string"
   },
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "RunbookSnapshotId": "string",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "UseGuidedFailure": true
 }
 ```
@@ -1498,7 +1498,7 @@ Also reachable at `/api/runbookRuns`, `/api/spaces/{spaceIdentifier}/runbookRuns
   "DeployedToMachineIds": [
     "string"
   ],
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -1508,7 +1508,7 @@ Also reachable at `/api/runbookRuns`, `/api/spaces/{spaceIdentifier}/runbookRuns
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -1533,7 +1533,7 @@ Also reachable at `/api/runbookRuns`, `/api/spaces/{spaceIdentifier}/runbookRuns
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "RunbookId": "string",
@@ -1542,15 +1542,15 @@ Also reachable at `/api/runbookRuns`, `/api/spaces/{spaceIdentifier}/runbookRuns
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -1660,7 +1660,7 @@ Also reachable at `/api/runbookRuns/{id}`, `/api/spaces/{spaceIdentifier}/runboo
   "DeployedToMachineIds": [
     "string"
   ],
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "ExcludedMachineIds": [
     "string"
   ],
@@ -1670,7 +1670,7 @@ Also reachable at `/api/runbookRuns/{id}`, `/api/spaces/{spaceIdentifier}/runboo
   "ExecutionPlanLogContext": {
     "Steps": [
       {
-        "CorrelationId": "string",
+        "CorrelationId": "0c5a872485ac4b10857939a92d082e67",
         "Slug": "string"
       }
     ]
@@ -1695,7 +1695,7 @@ Also reachable at `/api/runbookRuns/{id}`, `/api/spaces/{spaceIdentifier}/runboo
   "ManifestVariableSetId": "string",
   "Name": "string",
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "RunbookId": "string",
@@ -1704,15 +1704,15 @@ Also reachable at `/api/runbookRuns/{id}`, `/api/spaces/{spaceIdentifier}/runboo
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TaskId": "string",
-  "TenantId": "string",
+  "TaskId": "ServerTasks-1",
+  "TenantId": "Tenants-1",
   "TentacleRetentionPeriod": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,

--- a/src/pages/docs/api/runbook-snapshots.md
+++ b/src/pages/docs/api/runbook-snapshots.md
@@ -193,16 +193,16 @@ Runbook Snapshots will be ordered from most recent to least recent.
       },
       "Name": "string",
       "Notes": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
-      "RunbookId": "string",
+      "RunbookId": "Runbooks-1",
       "SelectedGitResources": [
         {}
       ],
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -264,9 +264,9 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots`, `/api/spaces/{sp
 {
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "Publish": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -285,7 +285,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots`, `/api/spaces/{sp
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -357,9 +357,9 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots`, `/api/spaces/{sp
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -378,7 +378,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots`, `/api/spaces/{sp
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -465,9 +465,9 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{idOrName}`, `/api
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -486,7 +486,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{idOrName}`, `/api
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -537,7 +537,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}`, `/api/space
   "Id": "string",
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -556,7 +556,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}`, `/api/space
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -628,9 +628,9 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}`, `/api/space
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -649,7 +649,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}`, `/api/space
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -761,7 +761,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}/runbookRuns`,
       "DeployedToMachineIds": [
         "string"
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -793,7 +793,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}/runbookRuns`,
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "RunbookId": "string",
@@ -802,15 +802,15 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}/runbookRuns`,
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -1017,7 +1017,7 @@ Gets all of the information necessary for creating or editing a run for this sna
   },
   "PromoteTo": [
     {
-      "Id": "string",
+      "Id": "Environments-1",
       "Links": {
         "additionalProp1": "string",
         "additionalProp2": "string",
@@ -1130,9 +1130,9 @@ Update the variable snapshots associated with the runbook snapshot to the latest
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -1151,7 +1151,7 @@ Update the variable snapshots associated with the runbook snapshot to the latest
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1231,9 +1231,9 @@ Update the variable snapshots associated with the runbook snapshot to the latest
     },
     "Name": "string",
     "Notes": "string",
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "ProjectVariableSetSnapshotId": "string",
-    "RunbookId": "string",
+    "RunbookId": "Runbooks-1",
     "SelectedGitResources": [
       {
         "ActionName": "string",
@@ -1249,7 +1249,7 @@ Update the variable snapshots associated with the runbook snapshot to the latest
         "Version": "string"
       }
     ],
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 }
 ```
@@ -1359,7 +1359,7 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{id}/variables`, `
         {}
       ]
     },
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Variables": [
       {
         "Description": "string",
@@ -1414,14 +1414,14 @@ Also reachable at `/api/projects/{projectId}/runbookSnapshots/{runbookSnapshotId
 {
   "DeploymentPreviews": [
     {
-      "EnvironmentId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "TenantId": "Tenants-1"
     }
   ],
   "IncludeDisabledSteps": true,
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunbookSnapshotId": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1614,16 +1614,16 @@ Runbook Snapshots will be ordered from most recent to least recent.
       },
       "Name": "string",
       "Notes": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
-      "RunbookId": "string",
+      "RunbookId": "Runbooks-1",
       "SelectedGitResources": [
         {}
       ],
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -1755,16 +1755,16 @@ Gets a paginated list of the runbook snapshots in the supplied Octopus Deploy Sp
       },
       "Name": "string",
       "Notes": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
-      "RunbookId": "string",
+      "RunbookId": "Runbooks-1",
       "SelectedGitResources": [
         {}
       ],
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -1824,9 +1824,9 @@ Also reachable at `/api/runbookSnapshots`, `/api/spaces/{spaceIdentifier}/runboo
 {
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "Publish": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -1845,7 +1845,7 @@ Also reachable at `/api/runbookSnapshots`, `/api/spaces/{spaceIdentifier}/runboo
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1917,9 +1917,9 @@ Also reachable at `/api/runbookSnapshots`, `/api/spaces/{spaceIdentifier}/runboo
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -1938,7 +1938,7 @@ Also reachable at `/api/runbookSnapshots`, `/api/spaces/{spaceIdentifier}/runboo
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2023,9 +2023,9 @@ Also reachable at `/api/runbookSnapshots/{id}`, `/api/spaces/{spaceIdentifier}/r
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -2044,7 +2044,7 @@ Also reachable at `/api/runbookSnapshots/{id}`, `/api/spaces/{spaceIdentifier}/r
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2093,7 +2093,7 @@ Also reachable at `/api/runbookSnapshots/{id}`, `/api/spaces/{spaceIdentifier}/r
   "Id": "string",
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -2112,7 +2112,7 @@ Also reachable at `/api/runbookSnapshots/{id}`, `/api/spaces/{spaceIdentifier}/r
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2184,9 +2184,9 @@ Also reachable at `/api/runbookSnapshots/{id}`, `/api/spaces/{spaceIdentifier}/r
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -2205,7 +2205,7 @@ Also reachable at `/api/runbookSnapshots/{id}`, `/api/spaces/{spaceIdentifier}/r
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2316,7 +2316,7 @@ Also reachable at `/api/runbookSnapshots/{id}/runbookRuns`, `/api/spaces/{spaceI
       "DeployedToMachineIds": [
         "string"
       ],
-      "EnvironmentId": "string",
+      "EnvironmentId": "Environments-1",
       "ExcludedMachineIds": [
         "string"
       ],
@@ -2348,7 +2348,7 @@ Also reachable at `/api/runbookSnapshots/{id}/runbookRuns`, `/api/spaces/{spaceI
       "ManifestVariableSetId": "string",
       "Name": "string",
       "Priority": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "RunbookId": "string",
@@ -2357,15 +2357,15 @@ Also reachable at `/api/runbookSnapshots/{id}/runbookRuns`, `/api/spaces/{spaceI
       "SkipActions": [
         "string"
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "SpecificMachineIds": [
         "string"
       ],
       "SpecificTargetTagIds": [
         "string"
       ],
-      "TaskId": "string",
-      "TenantId": "string",
+      "TaskId": "ServerTasks-1",
+      "TenantId": "Tenants-1",
       "TentacleRetentionPeriod": {
         "QuantityToKeep": 0,
         "ShouldKeepForever": true,
@@ -2575,7 +2575,7 @@ Gets all of the information necessary for creating or editing a run for this sna
   },
   "PromoteTo": [
     {
-      "Id": "string",
+      "Id": "Environments-1",
       "Links": {
         "additionalProp1": "string",
         "additionalProp2": "string",
@@ -2686,9 +2686,9 @@ Update the variable snapshots associated with the runbook snapshot to the latest
   },
   "Name": "string",
   "Notes": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ProjectVariableSetSnapshotId": "string",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "SelectedGitResources": [
     {
       "ActionName": "string",
@@ -2707,7 +2707,7 @@ Update the variable snapshots associated with the runbook snapshot to the latest
       "Version": "string"
     }
   ],
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2812,16 +2812,16 @@ Runbook Snapshots will be ordered from most recent to least recent.
       },
       "Name": "string",
       "Notes": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectVariableSetSnapshotId": "string",
-      "RunbookId": "string",
+      "RunbookId": "Runbooks-1",
       "SelectedGitResources": [
         {}
       ],
       "SelectedPackages": [
         {}
       ],
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,

--- a/src/pages/docs/api/runbooks.md
+++ b/src/pages/docs/api/runbooks.md
@@ -142,7 +142,8 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
       "Description": "string",
       "EnvironmentScope": "All",
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "FailTargetDiscovery": true,
       "ForcePackageDownload": true,
@@ -156,7 +157,7 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
       },
       "MultiTenancyMode": "Untenanted",
       "Name": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "PublishedRunbookSnapshotId": "string",
       "RunRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -169,7 +170,7 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
         "string"
       ],
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -249,7 +250,7 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
 :::api-example{label="Request"}
 ```json
 {
-  "Clone": "string",
+  "Clone": "Runbooks-1",
   "ConnectivityPolicy": {
     "AllowDeploymentsToNoTargets": true,
     "ExcludeUnhealthyTargets": true,
@@ -262,12 +263,13 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ForcePackageDownload": true,
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -275,12 +277,12 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
     "Strategy": "string",
     "Unit": "Days"
   },
-  "RunbookProcessId": "string",
+  "RunbookProcessId": "RunbookProcess-Runbooks-1",
   "RunbookTags": [
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -347,7 +349,8 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -361,7 +364,7 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -374,7 +377,7 @@ Also reachable at `/api/projects/{projectId}/runbooks`, `/api/spaces/{spaceIdent
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -452,7 +455,8 @@ Also reachable at `/api/projects/{projectId}/runbooks/all/v2`, `/api/spaces/{spa
       "Description": "string",
       "EnvironmentScope": "All",
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "FailTargetDiscovery": true,
       "ForcePackageDownload": true,
@@ -466,7 +470,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/all/v2`, `/api/spaces/{spa
       },
       "MultiTenancyMode": "Untenanted",
       "Name": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "PublishedRunbookSnapshotId": "string",
       "RunRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -479,7 +483,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/all/v2`, `/api/spaces/{spa
         "string"
       ],
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ]
 }
@@ -542,12 +546,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/runbooks/v
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ForcePackageDownload": true,
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -558,7 +563,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/runbooks/v
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -577,9 +582,9 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/runbooks/v
 :::api-example{label="Response"}
 ```json
 {
-  "Id": "string",
+  "Id": "Runbooks-1",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "Slug": "string"
 }
 ```
@@ -660,7 +665,8 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -674,7 +680,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -687,7 +693,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -773,14 +779,15 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
-  "Id": "string",
+  "Id": "Runbooks-1",
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -793,7 +800,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -860,7 +867,8 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -874,7 +882,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -887,7 +895,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}`, `/api/spaces/{space
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -980,7 +988,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}/environments`, `/api/
     "Name": "string",
     "Slug": "string",
     "SortOrder": 0,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "UseGuidedFailure": true
   }
 ]
@@ -1028,10 +1036,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/runbooks/{
       "EnvironmentTags": [
         "string"
       ],
-      "Id": "string",
+      "Id": "Environments-1",
       "Name": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Type": "string"
     }
   ]
@@ -1103,7 +1111,7 @@ Also reachable at `/api/projects/{projectId}/runbooks/{id}/runbookRunTemplate`, 
   },
   "PromoteTo": [
     {
-      "Id": "string",
+      "Id": "Environments-1",
       "Links": {
         "additionalProp1": "string",
         "additionalProp2": "string",
@@ -1443,9 +1451,10 @@ Also reachable at `/api/projects/{projectId}/runbooks/{runbookId}/run`, `/api/sp
   ],
   "Comments": "string",
   "DebugMode": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ExcludedMachineIds": [
     "string"
@@ -1461,24 +1470,25 @@ Also reachable at `/api/projects/{projectId}/runbooks/{runbookId}/run`, `/api/sp
     "additionalProp3": "string"
   },
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "RunbookSnapshotNameOrId": "string",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTagNames": [
     "string"
@@ -1530,14 +1540,14 @@ Gets a list of Runbook Run Previews that describes what steps will/won't be run 
 {
   "DeploymentPreviews": [
     {
-      "EnvironmentId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "TenantId": "Tenants-1"
     }
   ],
   "IncludeDisabledSteps": true,
-  "ProjectId": "string",
-  "RunbookId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "RunbookId": "Runbooks-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1839,7 +1849,8 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks`, `/api/spaces/{s
       "Description": "string",
       "EnvironmentScope": "All",
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "FailTargetDiscovery": true,
       "ForcePackageDownload": true,
@@ -1853,7 +1864,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks`, `/api/spaces/{s
       },
       "MultiTenancyMode": "Untenanted",
       "Name": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "PublishedRunbookSnapshotId": "string",
       "RunRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -1866,7 +1877,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks`, `/api/spaces/{s
         "string"
       ],
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -1944,13 +1955,14 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/r
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ForcePackageDownload": true,
   "GitRef": "string",
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
     "ShouldKeepForever": true,
@@ -1961,7 +1973,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/r
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1983,9 +1995,9 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/r
 ```json
 {
   "GitRef": "string",
-  "Id": "string",
+  "Id": "Runbooks-1",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "Slug": "string"
 }
 ```
@@ -2067,7 +2079,8 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -2081,7 +2094,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -2094,7 +2107,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2187,15 +2200,16 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
   "GitRef": "string",
-  "Id": "string",
+  "Id": "Runbooks-1",
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -2208,7 +2222,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2275,7 +2289,8 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -2289,7 +2304,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -2302,7 +2317,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2342,9 +2357,9 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}`, `/api/spac
 {
   "ChangeDescription": "string",
   "GitRef": "string",
-  "Id": "string",
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "Id": "Runbooks-1",
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -2426,7 +2441,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}/environments
     "Name": "string",
     "Slug": "string",
     "SortOrder": 0,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "UseGuidedFailure": true
   }
 ]
@@ -2475,10 +2490,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/r
       "EnvironmentTags": [
         "string"
       ],
-      "Id": "string",
+      "Id": "Environments-1",
       "Name": "string",
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Type": "string"
     }
   ]
@@ -2552,7 +2567,7 @@ Also reachable at `/api/projects/{projectId}/{gitRef}/runbooks/{id}/runbookRunTe
   },
   "PromoteTo": [
     {
-      "Id": "string",
+      "Id": "Environments-1",
       "Links": {
         "additionalProp1": "string",
         "additionalProp2": "string",
@@ -2855,15 +2870,15 @@ Gets a list of Runbook Run Previews that describes what steps will/won't be run 
 {
   "DeploymentPreviews": [
     {
-      "EnvironmentId": "string",
-      "TenantId": "string"
+      "EnvironmentId": "Environments-1",
+      "TenantId": "Tenants-1"
     }
   ],
   "GitRef": "string",
   "IncludeDisabledSteps": true,
-  "ProjectId": "string",
-  "RunbookId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "RunbookId": "Runbooks-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -3162,7 +3177,8 @@ Gets a paginated list of the Runbooks in the supplied Octopus Deploy Space (sort
       "Description": "string",
       "EnvironmentScope": "All",
       "Environments": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "FailTargetDiscovery": true,
       "ForcePackageDownload": true,
@@ -3176,7 +3192,7 @@ Gets a paginated list of the Runbooks in the supplied Octopus Deploy Space (sort
       },
       "MultiTenancyMode": "Untenanted",
       "Name": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "PublishedRunbookSnapshotId": "string",
       "RunRetentionPolicy": {
         "QuantityToKeep": 0,
@@ -3189,7 +3205,7 @@ Gets a paginated list of the Runbooks in the supplied Octopus Deploy Space (sort
         "string"
       ],
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -3267,7 +3283,7 @@ Also reachable at `/api/runbooks`, `/api/spaces/{spaceIdentifier}/runbooks`.
 :::api-example{label="Request"}
 ```json
 {
-  "Clone": "string",
+  "Clone": "Runbooks-1",
   "ConnectivityPolicy": {
     "AllowDeploymentsToNoTargets": true,
     "ExcludeUnhealthyTargets": true,
@@ -3280,12 +3296,13 @@ Also reachable at `/api/runbooks`, `/api/spaces/{spaceIdentifier}/runbooks`.
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ForcePackageDownload": true,
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -3293,12 +3310,12 @@ Also reachable at `/api/runbooks`, `/api/spaces/{spaceIdentifier}/runbooks`.
     "Strategy": "string",
     "Unit": "Days"
   },
-  "RunbookProcessId": "string",
+  "RunbookProcessId": "RunbookProcess-Runbooks-1",
   "RunbookTags": [
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -3365,7 +3382,8 @@ Also reachable at `/api/runbooks`, `/api/spaces/{spaceIdentifier}/runbooks`.
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -3379,7 +3397,7 @@ Also reachable at `/api/runbooks`, `/api/spaces/{spaceIdentifier}/runbooks`.
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -3392,7 +3410,7 @@ Also reachable at `/api/runbooks`, `/api/spaces/{spaceIdentifier}/runbooks`.
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -3480,7 +3498,8 @@ Lists all of the Runbooks in the supplied Space. The results will be sorted alph
     "Description": "string",
     "EnvironmentScope": "All",
     "Environments": [
-      "string"
+      "Environments-1",
+      "..."
     ],
     "FailTargetDiscovery": true,
     "ForcePackageDownload": true,
@@ -3494,7 +3513,7 @@ Lists all of the Runbooks in the supplied Space. The results will be sorted alph
     },
     "MultiTenancyMode": "Untenanted",
     "Name": "string",
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "PublishedRunbookSnapshotId": "string",
     "RunRetentionPolicy": {
       "QuantityToKeep": 0,
@@ -3507,7 +3526,7 @@ Lists all of the Runbooks in the supplied Space. The results will be sorted alph
       "string"
     ],
     "Slug": "string",
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 ]
 ```
@@ -3591,7 +3610,8 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -3605,7 +3625,7 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -3618,7 +3638,7 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -3702,14 +3722,15 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
-  "Id": "string",
+  "Id": "Runbooks-1",
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -3722,7 +3743,7 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -3789,7 +3810,8 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
   "Description": "string",
   "EnvironmentScope": "All",
   "Environments": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "FailTargetDiscovery": true,
   "ForcePackageDownload": true,
@@ -3803,7 +3825,7 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
   },
   "MultiTenancyMode": "Untenanted",
   "Name": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "PublishedRunbookSnapshotId": "string",
   "RunRetentionPolicy": {
     "QuantityToKeep": 0,
@@ -3816,7 +3838,7 @@ Also reachable at `/api/runbooks/{id}`, `/api/spaces/{spaceIdentifier}/runbooks/
     "string"
   ],
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -3911,7 +3933,7 @@ Also reachable at `/api/runbooks/{id}/environments`, `/api/spaces/{spaceIdentifi
     "Name": "string",
     "Slug": "string",
     "SortOrder": 0,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "UseGuidedFailure": true
   }
 ]
@@ -3985,7 +4007,7 @@ Also reachable at `/api/runbooks/{id}/runbookRunTemplate`, `/api/spaces/{spaceId
   },
   "PromoteTo": [
     {
-      "Id": "string",
+      "Id": "Environments-1",
       "Links": {
         "additionalProp1": "string",
         "additionalProp2": "string",
@@ -4323,9 +4345,10 @@ Also reachable at `/api/runbooks/{runbookId}/run`, `/api/spaces/{spaceIdentifier
   ],
   "Comments": "string",
   "DebugMode": "string",
-  "EnvironmentId": "string",
+  "EnvironmentId": "Environments-1",
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ExcludedMachineIds": [
     "string"
@@ -4341,24 +4364,25 @@ Also reachable at `/api/runbooks/{runbookId}/run`, `/api/spaces/{spaceIdentifier
     "additionalProp3": "string"
   },
   "Priority": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "RunbookId": "string",
+  "RunbookId": "Runbooks-1",
   "RunbookSnapshotNameOrId": "string",
   "SkipActions": [
     "string"
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "SpecificMachineIds": [
     "string"
   ],
   "SpecificTargetTagIds": [
     "string"
   ],
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "TenantTagNames": [
     "string"

--- a/src/pages/docs/api/scheduled-jobs.md
+++ b/src/pages/docs/api/scheduled-jobs.md
@@ -166,7 +166,7 @@ title: Scheduled Jobs
   "ActivityLog": {
     "Children": [],
     "Ended": "2020-01-01T00:00:00.000Z",
-    "Id": "string",
+    "Id": "0c5a872485ac4b10857939a92d082e67",
     "LogElements": [
       {
         "Category": "Trace",

--- a/src/pages/docs/api/scoped-user-roles.md
+++ b/src/pages/docs/api/scoped-user-roles.md
@@ -66,7 +66,8 @@ Also reachable at `/api/scopeduserroles`, `/api/spaces/{spaceIdentifier}/scopedu
   "Items": [
     {
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "LastModifiedBy": "string",
@@ -80,12 +81,14 @@ Also reachable at `/api/scopeduserroles`, `/api/spaces/{spaceIdentifier}/scopedu
         "string"
       ],
       "ProjectIds": [
-        "string"
+        "Projects-1",
+        "..."
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TeamId": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "UserRoleId": "string"
     }
@@ -131,18 +134,22 @@ Also reachable at `/api/scopeduserroles`, `/api/spaces/{spaceIdentifier}/scopedu
 ```json
 {
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TeamId": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "UserRoleId": "string"
 }
@@ -173,7 +180,8 @@ Also reachable at `/api/scopeduserroles`, `/api/spaces/{spaceIdentifier}/scopedu
 ```json
 {
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "LastModifiedBy": "string",
@@ -187,12 +195,14 @@ Also reachable at `/api/scopeduserroles`, `/api/spaces/{spaceIdentifier}/scopedu
     "string"
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TeamId": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "UserRoleId": "string"
 }
@@ -235,7 +245,8 @@ Also reachable at `/api/scopeduserroles/{id}`, `/api/spaces/{spaceIdentifier}/sc
 ```json
 {
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "LastModifiedBy": "string",
@@ -249,12 +260,14 @@ Also reachable at `/api/scopeduserroles/{id}`, `/api/spaces/{spaceIdentifier}/sc
     "string"
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TeamId": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "UserRoleId": "string"
 }
@@ -291,19 +304,23 @@ Also reachable at `/api/scopeduserroles/{id}`, `/api/spaces/{spaceIdentifier}/sc
 ```json
 {
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "ProjectGroupIds": [
-    "string"
+    "ProjectGroups-1",
+    "..."
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TeamId": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "UserRoleId": "string"
 }
@@ -334,7 +351,8 @@ Also reachable at `/api/scopeduserroles/{id}`, `/api/spaces/{spaceIdentifier}/sc
 ```json
 {
   "EnvironmentIds": [
-    "string"
+    "Environments-1",
+    "..."
   ],
   "Id": "string",
   "LastModifiedBy": "string",
@@ -348,12 +366,14 @@ Also reachable at `/api/scopeduserroles/{id}`, `/api/spaces/{spaceIdentifier}/sc
     "string"
   ],
   "ProjectIds": [
-    "string"
+    "Projects-1",
+    "..."
   ],
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TeamId": "string",
   "TenantIds": [
-    "string"
+    "Tenants-1",
+    "..."
   ],
   "UserRoleId": "string"
 }

--- a/src/pages/docs/api/service-account-oidc-identities.md
+++ b/src/pages/docs/api/service-account-oidc-identities.md
@@ -33,7 +33,7 @@ title: Service Account Oidc Identities
   "Audience": "string",
   "Issuer": "string",
   "Name": "string",
-  "ServiceAccountId": "string",
+  "ServiceAccountId": "Users-1",
   "Subject": "string"
 }
 ```
@@ -102,7 +102,7 @@ Gets a paginated set of ServiceAccountOidcIdentities.
       "Id": "string",
       "Issuer": "string",
       "Name": "string",
-      "ServiceAccountId": "string",
+      "ServiceAccountId": "Users-1",
       "Subject": "string"
     }
   ],
@@ -145,7 +145,7 @@ Gets a ServiceAccountOidcIdentity by its id.
   "Id": "string",
   "Issuer": "string",
   "Name": "string",
-  "ServiceAccountId": "string",
+  "ServiceAccountId": "Users-1",
   "Subject": "string"
 }
 ```
@@ -184,7 +184,7 @@ Gets a ServiceAccountOidcIdentity by its id.
   "Id": "string",
   "Issuer": "string",
   "Name": "string",
-  "ServiceAccountId": "string",
+  "ServiceAccountId": "Users-1",
   "Subject": "string"
 }
 ```

--- a/src/pages/docs/api/spaces.md
+++ b/src/pages/docs/api/spaces.md
@@ -83,7 +83,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials`.
         ],
         "Enabled": true
       },
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -146,7 +146,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -227,7 +227,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/v1`.
         "Links": {},
         "Name": "string",
         "RepositoryRestrictions": {},
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ItemsPerPage": 0,
@@ -291,7 +291,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/v1`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -377,7 +377,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/v2`.
         ],
         "Enabled": true
       },
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -427,7 +427,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/v2`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -503,7 +503,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -556,7 +556,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -627,7 +627,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}/usage`.
   "Projects": [
     {
       "Name": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "RepositoryUrl": "string",
       "Slug": "string"
     }
@@ -669,7 +669,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}/usage/v1`.
   "Projects": [
     {
       "Name": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "RepositoryUrl": "string",
       "Slug": "string"
     }
@@ -733,7 +733,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}/v1`.
       ],
       "Enabled": true
     },
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 }
 ```
@@ -787,7 +787,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}/v1`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -872,7 +872,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}/v2`.
       ],
       "Enabled": true
     },
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 }
 ```
@@ -920,7 +920,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/git-credentials/{id}/v2`.
     ],
     "Enabled": true
   },
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -1079,7 +1079,8 @@ Lists all of the Spaces in the supplied Octopus Deploy Space. The results will b
       "Name": "string",
       "Slug": "string",
       "SpaceManagersTeamMembers": [
-        "string"
+        "Users-1",
+        "..."
       ],
       "SpaceManagersTeams": [
         "string"
@@ -1126,7 +1127,8 @@ Lists all of the Spaces in the supplied Octopus Deploy Space. The results will b
   "Name": "string",
   "Slug": "string",
   "SpaceManagersTeamMembers": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "SpaceManagersTeams": [
     "string"
@@ -1192,7 +1194,8 @@ Lists all of the Spaces in the supplied Octopus Deploy Space. The results will b
   "Name": "string",
   "Slug": "string",
   "SpaceManagersTeamMembers": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "SpaceManagersTeams": [
     "string"
@@ -1270,7 +1273,8 @@ Lists all Spaces. The results will be sorted alphabetically by name.
     "Name": "string",
     "Slug": "string",
     "SpaceManagersTeamMembers": [
-      "string"
+      "Users-1",
+      "..."
     ],
     "SpaceManagersTeams": [
       "string"
@@ -1305,7 +1309,8 @@ Lists all Spaces. The results will be sorted alphabetically by name.
   "Name": "string",
   "Slug": "string",
   "SpaceManagersTeamMembers": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "SpaceManagersTeams": [
     "string"
@@ -1367,7 +1372,8 @@ Lists all Spaces. The results will be sorted alphabetically by name.
     "Name": "string",
     "Slug": "string",
     "SpaceManagersTeamMembers": [
-      "string"
+      "Users-1",
+      "..."
     ],
     "SpaceManagersTeams": [
       "string"
@@ -1443,7 +1449,8 @@ Lists all Spaces. The results will be sorted alphabetically by name.
   "Name": "string",
   "Slug": "string",
   "SpaceManagersTeamMembers": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "SpaceManagersTeams": [
     "string"
@@ -1478,12 +1485,13 @@ Lists all Spaces. The results will be sorted alphabetically by name.
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "Spaces-1",
   "IsDefault": true,
   "Name": "string",
   "Slug": "string",
   "SpaceManagersTeamMembers": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "SpaceManagersTeams": [
     "string"
@@ -1549,7 +1557,8 @@ Lists all Spaces. The results will be sorted alphabetically by name.
   "Name": "string",
   "Slug": "string",
   "SpaceManagersTeamMembers": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "SpaceManagersTeams": [
     "string"
@@ -1757,7 +1766,8 @@ Also reachable at `/api/spaces/{id}/search`, `/api/spaces/{spaceIdentifier}/spac
     "Name": "string",
     "Slug": "string",
     "SpaceManagersTeamMembers": [
-      "string"
+      "Users-1",
+      "..."
     ],
     "SpaceManagersTeams": [
       "string"

--- a/src/pages/docs/api/ssh-known-hosts.md
+++ b/src/pages/docs/api/ssh-known-hosts.md
@@ -37,7 +37,7 @@ title: Ssh Known Hosts
   "Resources": [
     {
       "Host": "string",
-      "Id": "string",
+      "Id": "SshKnownHosts-1",
       "KeyType": "string",
       "PublicKey": "string"
     }
@@ -81,7 +81,7 @@ title: Ssh Known Hosts
   "AddedResources": [
     {
       "Host": "string",
-      "Id": "string",
+      "Id": "SshKnownHosts-1",
       "KeyType": "string",
       "PublicKey": "string"
     }

--- a/src/pages/docs/api/subscriptions.md
+++ b/src/pages/docs/api/subscriptions.md
@@ -107,7 +107,7 @@ Lists all of the Subscriptions in the supplied Octopus Deploy Space. The results
         "additionalProp3": "string"
       },
       "Name": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Type": "Event"
     }
   ],
@@ -211,7 +211,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions`, `/api/subscript
         "string"
       ],
       "Tenants": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "Users": [
         "string"
@@ -246,7 +247,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions`, `/api/subscript
   },
   "IsDisabled": true,
   "Name": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -335,7 +336,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions`, `/api/subscript
         "string"
       ],
       "Tenants": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "Users": [
         "string"
@@ -378,7 +380,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions`, `/api/subscript
     "additionalProp3": "string"
   },
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Type": "Event"
 }
 ```
@@ -482,7 +484,8 @@ Lists all the Subscriptions in the supplied Octopus Deploy Space
           "string"
         ],
         "Tenants": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
         "Users": [
           "string"
@@ -521,7 +524,7 @@ Lists all the Subscriptions in the supplied Octopus Deploy Space
       "additionalProp3": "string"
     },
     "Name": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Type": "Event"
   }
 ]
@@ -625,7 +628,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions/{id}`, `/api/subs
         "string"
       ],
       "Tenants": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "Users": [
         "string"
@@ -668,7 +672,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions/{id}`, `/api/subs
     "additionalProp3": "string"
   },
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Type": "Event"
 }
 ```
@@ -765,7 +769,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions/{id}`, `/api/subs
         "string"
       ],
       "Tenants": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "Users": [
         "string"
@@ -798,10 +803,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions/{id}`, `/api/subs
     "WebhookTimeout": "string",
     "WebhookURI": "https://example.com"
   },
-  "Id": "string",
+  "Id": "Subscriptions-1",
   "IsDisabled": true,
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Type": "Event"
 }
 ```
@@ -891,7 +896,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions/{id}`, `/api/subs
         "string"
       ],
       "Tenants": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "Users": [
         "string"
@@ -934,7 +940,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/subscriptions/{id}`, `/api/subs
     "additionalProp3": "string"
   },
   "Name": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Type": "Event"
 }
 ```

--- a/src/pages/docs/api/tag-sets.md
+++ b/src/pages/docs/api/tag-sets.md
@@ -98,7 +98,7 @@ Lists all of the Tag Sets in the supplied Octopus Deploy Space. The results will
         "string"
       ],
       "SortOrder": 0,
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "Tags": [
         {}
       ],
@@ -165,7 +165,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tagsets`, `/api/tagsets`.
     "string"
   ],
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tags": [
     {
       "CanonicalTagName": "string",
@@ -237,7 +237,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tagsets`, `/api/tagsets`.
     "string"
   ],
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tags": [
     {
       "CanonicalTagName": "string",
@@ -326,7 +326,7 @@ Lists the details of all of the Tag Sets in the supplied Octopus Deploy Space. T
       "string"
     ],
     "SortOrder": 0,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Tags": [
       {
         "CanonicalTagName": "string",
@@ -439,7 +439,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tagsets/{id}`, `/api/tagsets/{i
     "string"
   ],
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tags": [
     {
       "CanonicalTagName": "string",
@@ -499,13 +499,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tagsets/{id}`, `/api/tagsets/{i
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "TagSets-1",
   "Name": "string",
   "Scopes": [
     "string"
   ],
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tags": [
     {
       "CanonicalTagName": "string",
@@ -577,7 +577,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tagsets/{id}`, `/api/tagsets/{i
     "string"
   ],
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Tags": [
     {
       "CanonicalTagName": "string",

--- a/src/pages/docs/api/tasks.md
+++ b/src/pages/docs/api/tasks.md
@@ -182,11 +182,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks`, `/api/tasks`.
       "PendingPreconditionTypes": [
         "string"
       ],
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "ServerNode": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StartTime": "2020-01-01T00:00:00.000Z",
       "State": "Queued"
     }
@@ -241,7 +241,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks`, `/api/tasks`.
   "Name": "string",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Weight": 0
 }
 ```
@@ -347,11 +347,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks`, `/api/tasks`.
   "PendingPreconditionTypes": [
     "string"
   ],
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "ServerNode": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StartTime": "2020-01-01T00:00:00.000Z",
   "State": "Queued"
 }
@@ -471,11 +471,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/rerun/{id}`, `/api/tasks/
   "PendingPreconditionTypes": [
     "string"
   ],
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "ServerNode": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StartTime": "2020-01-01T00:00:00.000Z",
   "State": "Queued"
 }
@@ -629,11 +629,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}`, `/api/tasks/{id}`.
   "PendingPreconditionTypes": [
     "string"
   ],
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "ServerNode": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StartTime": "2020-01-01T00:00:00.000Z",
   "State": "Queued"
 }
@@ -753,11 +753,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}/cancel`, `/api/tasks
   "PendingPreconditionTypes": [
     "string"
   ],
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "ServerNode": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StartTime": "2020-01-01T00:00:00.000Z",
   "State": "Queued"
 }
@@ -882,7 +882,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}/details`, `/api/task
     {
       "Children": [],
       "Ended": "2020-01-01T00:00:00.000Z",
-      "Id": "string",
+      "Id": "0c5a872485ac4b10857939a92d082e67",
       "LogElements": [
         {}
       ],
@@ -942,11 +942,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}/details`, `/api/task
     "PendingPreconditionTypes": [
       "string"
     ],
-    "ProjectId": "string",
+    "ProjectId": "Projects-1",
     "QueueTime": "2020-01-01T00:00:00.000Z",
     "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
     "ServerNode": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "StartTime": "2020-01-01T00:00:00.000Z",
     "State": "Queued"
   }
@@ -1106,11 +1106,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}/queued-behind`, `/ap
       "PendingPreconditionTypes": [
         "string"
       ],
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "QueueTime": "2020-01-01T00:00:00.000Z",
       "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
       "ServerNode": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StartTime": "2020-01-01T00:00:00.000Z",
       "State": "Queued"
     }
@@ -1181,9 +1181,9 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}/state`, `/api/tasks/
 :::api-example{label="Request"}
 ```json
 {
-  "Id": "string",
+  "Id": "ServerTasks-1",
   "Reason": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "State": "Queued"
 }
 ```
@@ -1289,11 +1289,11 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tasks/{id}/state`, `/api/tasks/
   "PendingPreconditionTypes": [
     "string"
   ],
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "ServerNode": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StartTime": "2020-01-01T00:00:00.000Z",
   "State": "Queued"
 }

--- a/src/pages/docs/api/team-memberships.md
+++ b/src/pages/docs/api/team-memberships.md
@@ -49,10 +49,10 @@ Lists all Teams a user is a member of, including any from external auth-provider
       }
     ],
     "IsDirectlyAssigned": true,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TeamId": "string",
     "TeamName": "string",
-    "UserId": "string"
+    "UserId": "Users-1"
   }
 ]
 ```
@@ -97,13 +97,14 @@ Lists all the Users that would belong to the specified Team, including informati
       "Id": "string"
     }
   ],
-  "Id": "string",
+  "Id": "Teams-1",
   "MemberUserIds": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -134,10 +135,10 @@ Lists all the Users that would belong to the specified Team, including informati
       }
     ],
     "IsDirectlyAssigned": true,
-    "SpaceId": "string",
-    "TeamId": "string",
+    "SpaceId": "Spaces-1",
+    "TeamId": "Teams-1",
     "TeamName": "string",
-    "UserId": "string"
+    "UserId": "Users-1"
   }
 ]
 ```

--- a/src/pages/docs/api/teams.md
+++ b/src/pages/docs/api/teams.md
@@ -99,11 +99,12 @@ Lists all of the Teams in the system or Octopus Deploy Space (if provided). The 
         "additionalProp3": "string"
       },
       "MemberUserIds": [
-        "string"
+        "Users-1",
+        "..."
       ],
       "Name": "string",
       "Slug": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ],
   "ItemsPerPage": 0,
@@ -162,11 +163,12 @@ Also reachable at `/api/spaces/{spaceIdentifier}/teams`, `/api/teams`.
     }
   ],
   "MemberUserIds": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -228,11 +230,12 @@ Also reachable at `/api/spaces/{spaceIdentifier}/teams`, `/api/teams`.
     "additionalProp3": "string"
   },
   "MemberUserIds": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -307,11 +310,12 @@ Lists all of the Teams in the supplied Octopus Deploy Space. The results will be
       "additionalProp3": "string"
     },
     "MemberUserIds": [
-      "string"
+      "Users-1",
+      "..."
     ],
     "Name": "string",
     "Slug": "string",
-    "SpaceId": "string"
+    "SpaceId": "Spaces-1"
   }
 ]
 ```
@@ -387,11 +391,12 @@ Also reachable at `/api/spaces/{spaceIdentifier}/teams/{id}`, `/api/teams/{id}`.
     "additionalProp3": "string"
   },
   "MemberUserIds": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -438,13 +443,14 @@ The Everyone Team is treated as a special case and its members and external grou
       "Id": "string"
     }
   ],
-  "Id": "string",
+  "Id": "Teams-1",
   "MemberUserIds": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -506,11 +512,12 @@ The Everyone Team is treated as a special case and its members and external grou
     "additionalProp3": "string"
   },
   "MemberUserIds": [
-    "string"
+    "Users-1",
+    "..."
   ],
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string"
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -593,7 +600,8 @@ List all the Scoped User Roles for the Team. Results will be sorted by Space Id 
   "Items": [
     {
       "EnvironmentIds": [
-        "string"
+        "Environments-1",
+        "..."
       ],
       "Id": "string",
       "LastModifiedBy": "string",
@@ -607,12 +615,14 @@ List all the Scoped User Roles for the Team. Results will be sorted by Space Id 
         "string"
       ],
       "ProjectIds": [
-        "string"
+        "Projects-1",
+        "..."
       ],
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TeamId": "string",
       "TenantIds": [
-        "string"
+        "Tenants-1",
+        "..."
       ],
       "UserRoleId": "string"
     }

--- a/src/pages/docs/api/telemetry.md
+++ b/src/pages/docs/api/telemetry.md
@@ -123,11 +123,11 @@ title: Telemetry
   "PendingPreconditionTypes": [
     "string"
   ],
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "QueueTime": "2020-01-01T00:00:00.000Z",
   "QueueTimeExpiry": "2020-01-01T00:00:00.000Z",
   "ServerNode": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StartTime": "2020-01-01T00:00:00.000Z",
   "State": "Queued"
 }

--- a/src/pages/docs/api/tenants.md
+++ b/src/pages/docs/api/tenants.md
@@ -115,7 +115,7 @@ Lists all of the tenants in the supplied Octopus Deploy Space. The results will 
         ]
       },
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "TenantTags": [
         "string"
       ]
@@ -167,7 +167,7 @@ Creates a new Tenant, optionally cloning an existing tenant if the clone query s
 :::api-example{label="Request"}
 ```json
 {
-  "Clone": "string",
+  "Clone": "Tenants-1",
   "Description": "string",
   "IsDisabled": true,
   "Name": "string",
@@ -183,7 +183,7 @@ Creates a new Tenant, optionally cloning an existing tenant if the clone query s
     ]
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -253,7 +253,7 @@ Creates a new Tenant, optionally cloning an existing tenant if the clone query s
     ]
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -352,7 +352,7 @@ Lists all of the tenants in the supplied Octopus Deploy Space. The results will 
       ]
     },
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "TenantTags": [
       "string"
     ]
@@ -502,7 +502,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/variables-missing`, `/a
     },
     "MissingVariables": [
       {
-        "EnvironmentId": "string",
+        "EnvironmentId": "Environments-1",
         "LibraryVariableSetId": "string",
         "Links": {},
         "ProjectId": "string",
@@ -510,7 +510,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/variables-missing`, `/a
         "VariableTemplateName": "string"
       }
     ],
-    "TenantId": "string"
+    "TenantId": "Tenants-1"
   }
 ]
 ```
@@ -590,7 +590,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}`, `/api/tenants/{i
     ]
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -630,7 +630,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}`, `/api/tenants/{i
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "Tenants-1",
   "IsDisabled": true,
   "Name": "string",
   "ProjectEnvironments": {
@@ -645,7 +645,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}`, `/api/tenants/{i
     ]
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -715,7 +715,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}`, `/api/tenants/{i
     ]
   },
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantTags": [
     "string"
   ]
@@ -957,8 +957,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     }
   },
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "TenantName": "string"
 }
 ```
@@ -990,10 +990,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
 ```json
 {
   "ConcurrencyToken": "string",
-  "Id": "string",
+  "Id": "Tenants-1",
   "LibraryVariables": {
     "additionalProp1": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1010,7 +1010,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     },
     "additionalProp2": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1027,7 +1027,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     },
     "additionalProp3": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1051,7 +1051,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1068,7 +1068,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1085,7 +1085,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1097,7 +1097,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantName": "string"
 }
 ```
@@ -1240,8 +1240,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     }
   },
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "TenantName": "string"
 }
 ```
@@ -1271,10 +1271,10 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
 ```json
 {
   "ConcurrencyToken": "string",
-  "Id": "string",
+  "Id": "Tenants-1",
   "LibraryVariables": {
     "additionalProp1": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1291,7 +1291,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     },
     "additionalProp2": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1308,7 +1308,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     },
     "additionalProp3": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1332,7 +1332,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1349,7 +1349,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1366,7 +1366,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1378,7 +1378,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantName": "string"
 }
 ```
@@ -1521,8 +1521,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{id}/variables`, `/api/
       }
     }
   },
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "TenantName": "string"
 }
 ```
@@ -1555,10 +1555,10 @@ Also reachable at `/api/tenants/{id}/variables`.
 ```json
 {
   "ConcurrencyToken": "string",
-  "Id": "string",
+  "Id": "Tenants-1",
   "LibraryVariables": {
     "additionalProp1": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1575,7 +1575,7 @@ Also reachable at `/api/tenants/{id}/variables`.
       }
     },
     "additionalProp2": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1592,7 +1592,7 @@ Also reachable at `/api/tenants/{id}/variables`.
       }
     },
     "additionalProp3": {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Links": {
         "additionalProp1": "string",
@@ -1616,7 +1616,7 @@ Also reachable at `/api/tenants/{id}/variables`.
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1633,7 +1633,7 @@ Also reachable at `/api/tenants/{id}/variables`.
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1650,7 +1650,7 @@ Also reachable at `/api/tenants/{id}/variables`.
         "additionalProp2": "string",
         "additionalProp3": "string"
       },
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Templates": [
         {}
@@ -1662,7 +1662,7 @@ Also reachable at `/api/tenants/{id}/variables`.
       }
     }
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "TenantName": "string"
 }
 ```
@@ -1805,8 +1805,8 @@ Also reachable at `/api/tenants/{id}/variables`.
       }
     }
   },
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "TenantName": "string"
 }
 ```
@@ -1861,11 +1861,12 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/commonvariab
   "ConcurrencyToken": "string",
   "MissingVariables": [
     {
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -1884,15 +1885,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/commonvariab
       }
     }
   ],
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -1946,15 +1948,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/commonvariab
 ```json
 {
   "ConcurrencyToken": "string",
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
       "OwnerId": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "TemplateId": "string",
@@ -1991,15 +1994,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/commonvariab
 ```json
 {
   "ConcurrencyToken": "string",
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2051,15 +2055,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/commonvariab
 ```json
 {
   "ConcurrencyToken": "string",
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
       "OwnerId": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "TemplateId": "string",
@@ -2096,15 +2101,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/commonvariab
 ```json
 {
   "ConcurrencyToken": "string",
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2159,15 +2165,16 @@ Also reachable at `/api/tenants/{tenantId}/commonvariables`.
 ```json
 {
   "ConcurrencyToken": "string",
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
       "OwnerId": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "TemplateId": "string",
@@ -2204,15 +2211,16 @@ Also reachable at `/api/tenants/{tenantId}/commonvariables`.
 ```json
 {
   "ConcurrencyToken": "string",
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "LibraryVariableSetId": "string",
+      "LibraryVariableSetId": "LibraryVariableSets-1",
       "LibraryVariableSetName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2284,11 +2292,12 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/projectvaria
   "ConcurrencyToken": "string",
   "MissingVariables": [
     {
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2307,15 +2316,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/projectvaria
       }
     }
   ],
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2369,15 +2379,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/projectvaria
 ```json
 {
   "ConcurrencyToken": "string",
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
       "OwnerId": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "TemplateId": "string",
@@ -2414,15 +2425,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/projectvaria
 ```json
 {
   "ConcurrencyToken": "string",
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2474,15 +2486,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/projectvaria
 ```json
 {
   "ConcurrencyToken": "string",
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
       "OwnerId": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "TemplateId": "string",
@@ -2519,15 +2532,16 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenants/{tenantId}/projectvaria
 ```json
 {
   "ConcurrencyToken": "string",
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2582,15 +2596,16 @@ Also reachable at `/api/tenants/{tenantId}/projectvariables`.
 ```json
 {
   "ConcurrencyToken": "string",
-  "SpaceId": "string",
-  "TenantId": "string",
+  "SpaceId": "Spaces-1",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
       "OwnerId": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "TemplateId": "string",
@@ -2627,15 +2642,16 @@ Also reachable at `/api/tenants/{tenantId}/projectvariables`.
 ```json
 {
   "ConcurrencyToken": "string",
-  "TenantId": "string",
+  "TenantId": "Tenants-1",
   "Variables": [
     {
       "Id": "string",
-      "ProjectId": "string",
+      "ProjectId": "Projects-1",
       "ProjectName": "string",
       "Scope": {
         "EnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ]
       },
       "Template": {
@@ -2764,8 +2780,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/tenantvariables/all`, `/api/ten
         "Variables": {}
       }
     },
-    "SpaceId": "string",
-    "TenantId": "string",
+    "SpaceId": "Spaces-1",
+    "TenantId": "Tenants-1",
     "TenantName": "string"
   }
 ]

--- a/src/pages/docs/api/user-permissions.md
+++ b/src/pages/docs/api/user-permissions.md
@@ -208,2364 +208,2781 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/{id}/permissions`, `/api/
     "AccountCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AccountDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AccountEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AccountView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AdministerSystem": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AiAgentTranscriptView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ApprovalPolicyAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuildInformationAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuildInformationPush": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuiltInFeedAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuiltInFeedDownload": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuiltInFeedPush": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateExportPrivateKey": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ConfigureServer": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DefectReport": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DefectResolve": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeployedResourceAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentFreezeAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EventRetentionDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EventRetentionView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EventView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "FeatureToggleEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "FeedEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "FeedView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "GitCredentialEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "GitCredentialView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InterruptionSubmit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InterruptionView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InterruptionViewSubmitResponsible": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "PlatformHubEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "PlatformHubView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProcessEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProcessView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RetentionAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookRunCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookRunDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookRunView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookSnapshotCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SshKnownHostsAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SshKnownHostsView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TagSetCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TagSetDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TagSetEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TargetTagAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TargetTagView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskCancel": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskPrioritize": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TelemetryView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserInvite": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserRoleEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserRoleView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableEditUnscoped": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableViewUnscoped": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "WorkerEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "WorkerView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ]
   },
@@ -2580,7 +2997,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/{id}/permissions`, `/api/
       "Id": "string",
       "IsDirectlyAssigned": true,
       "Name": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ]
 }
@@ -2794,2364 +3211,2781 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/{id}/permissions/configur
     "AccountCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AccountDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AccountEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AccountView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ActionTemplateView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AdministerSystem": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "AiAgentTranscriptView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ApprovalPolicyAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ArtifactView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuildInformationAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuildInformationPush": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuiltInFeedAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuiltInFeedDownload": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "BuiltInFeedPush": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateExportPrivateKey": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "CertificateView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ConfigureServer": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DefectReport": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DefectResolve": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeployedResourceAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentFreezeAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "DeploymentView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EnvironmentView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EventRetentionDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EventRetentionView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "EventView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "FeatureToggleEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "FeedEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "FeedView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "GitCredentialEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "GitCredentialView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InsightsReportView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InterruptionSubmit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InterruptionView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "InterruptionViewSubmitResponsible": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LibraryVariableSetView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "LifecycleView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachinePolicyView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "MachineView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "PlatformHubEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "PlatformHubView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProcessEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProcessView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectGroupView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProjectView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ProxyView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "ReleaseView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RetentionAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookRunCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookRunDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookRunView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookSnapshotCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "RunbookView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SpaceView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SshKnownHostsAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SshKnownHostsView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "SubscriptionView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TagSetCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TagSetDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TagSetEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TargetTagAdminister": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TargetTagView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskCancel": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskPrioritize": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TaskView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TeamView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TelemetryView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TenantView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerCreate": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerDelete": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "TriggerView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserInvite": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserRoleEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserRoleView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "UserView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableEditUnscoped": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "VariableViewUnscoped": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "WorkerEdit": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ],
     "WorkerView": [
       {
         "RestrictedToEnvironmentIds": [
-          "string"
+          "Environments-1",
+          "..."
         ],
         "RestrictedToProjectGroupIds": [
           "string"
         ],
         "RestrictedToProjectIds": [
-          "string"
+          "Projects-1",
+          "..."
         ],
         "RestrictedToTenantIds": [
-          "string"
+          "Tenants-1",
+          "..."
         ],
-        "SpaceId": "string"
+        "SpaceId": "Spaces-1"
       }
     ]
   },
@@ -5166,7 +6000,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/users/{id}/permissions/configur
       "Id": "string",
       "IsDirectlyAssigned": true,
       "Name": "string",
-      "SpaceId": "string"
+      "SpaceId": "Spaces-1"
     }
   ]
 }

--- a/src/pages/docs/api/users.md
+++ b/src/pages/docs/api/users.md
@@ -826,7 +826,7 @@ Logs out the current user.
 {
   "DisplayName": "string",
   "EmailAddress": "string",
-  "Id": "string",
+  "Id": "Users-1",
   "Identities": [
     {
       "Claims": {

--- a/src/pages/docs/api/variables.md
+++ b/src/pages/docs/api/variables.md
@@ -62,8 +62,8 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/git/migrat
   "Branch": "string",
   "CommitMessage": "string",
   "CreateBranch": true,
-  "ProjectId": "string",
-  "SpaceId": "string"
+  "ProjectId": "Projects-1",
+  "SpaceId": "Spaces-1"
 }
 ```
 :::
@@ -213,7 +213,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/variables`
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -344,7 +344,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/variables`
 ```json
 {
   "ChangeDescription": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ScopeValues": {
     "Actions": [
       {
@@ -414,7 +414,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/variables`
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -645,7 +645,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/v
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -779,7 +779,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/v
 {
   "ChangeDescription": "string",
   "GitRef": "string",
-  "ProjectId": "string",
+  "ProjectId": "Projects-1",
   "ScopeValues": {
     "Actions": [
       {
@@ -849,7 +849,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/projects/{projectId}/{gitRef}/v
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -1051,7 +1051,7 @@ Lists all the Variable Sets in the supplied Space.
         {}
       ]
     },
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "Variables": [
       {
         "Description": "string",
@@ -1263,7 +1263,7 @@ Lists the evaluated Variables for a deployment.
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -1483,7 +1483,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/variables/{id}`, `/api/variable
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -1700,7 +1700,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/variables/{id}`, `/api/variable
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",
@@ -1907,7 +1907,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/variables/{id}`, `/api/variable
       }
     ]
   },
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "Variables": [
     {
       "Description": "string",

--- a/src/pages/docs/api/worker-pools.md
+++ b/src/pages/docs/api/worker-pools.md
@@ -92,7 +92,7 @@ Lists the name and ID of of the Worker Pools in the supplied Octopus Deploy Spac
       "Name": "string",
       "Slug": "string",
       "SortOrder": 0,
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "WorkerPoolType": "StaticWorkerPool"
     }
   ],
@@ -145,7 +145,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workerpools`, `/api/workerpools
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerPoolType": "StaticWorkerPool",
   "WorkerType": "string"
 }
@@ -195,7 +195,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workerpools`, `/api/workerpools
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerPoolType": "StaticWorkerPool"
 }
 ```
@@ -263,7 +263,7 @@ Lists the name and ID of of the Worker Pools in the supplied Octopus Deploy Spac
     "Name": "string",
     "Slug": "string",
     "SortOrder": 0,
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "WorkerPoolType": "StaticWorkerPool"
   }
 ]
@@ -452,7 +452,7 @@ Lists all worker pools, including a summary of machine information.
         "Name": "string",
         "Slug": "string",
         "SortOrder": 0,
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "WorkerPoolType": "StaticWorkerPool"
       }
     }
@@ -552,7 +552,7 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workerpools/{id}`, `/api/worker
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerPoolType": "StaticWorkerPool"
 }
 ```
@@ -594,11 +594,11 @@ Updates an existing worker pool.
 ```json
 {
   "Description": "string",
-  "Id": "string",
+  "Id": "WorkerPools-1",
   "IsDefault": true,
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerType": "string"
 }
 ```
@@ -647,7 +647,7 @@ Updates an existing worker pool.
   "Name": "string",
   "Slug": "string",
   "SortOrder": 0,
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerPoolType": "StaticWorkerPool"
 }
 ```
@@ -779,12 +779,13 @@ Lists all of the machines that belong to the given worker pool.
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "Thumbprint": "string",
       "Uri": "string",
       "WorkerPoolIds": [
-        "string"
+        "WorkerPools-1",
+        "..."
       ]
     }
   ],

--- a/src/pages/docs/api/worker-task-leases.md
+++ b/src/pages/docs/api/worker-task-leases.md
@@ -56,11 +56,11 @@ Gets a paginated set of WorkerTaskLeases.
         "Exclusive": true,
         "Id": "string",
         "Name": "string",
-        "ServerTaskId": "string",
-        "SpaceId": "string",
+        "ServerTaskId": "ServerTasks-1",
+        "SpaceId": "Spaces-1",
         "TakenAt": "2020-01-01T00:00:00.000Z",
-        "WorkerId": "string",
-        "WorkerPoolId": "string"
+        "WorkerId": "Workers-1",
+        "WorkerPoolId": "WorkerPools-1"
       }
     ],
     "ItemsPerPage": 0,

--- a/src/pages/docs/api/workers.md
+++ b/src/pages/docs/api/workers.md
@@ -123,12 +123,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers`, `/api/workers`.
       "ShellVersion": "string",
       "SkipInitialHealthCheck": true,
       "Slug": "string",
-      "SpaceId": "string",
+      "SpaceId": "Spaces-1",
       "StatusSummary": "string",
       "Thumbprint": "string",
       "Uri": "string",
       "WorkerPoolIds": [
-        "string"
+        "WorkerPools-1",
+        "..."
       ]
     }
   ],
@@ -200,13 +201,14 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers`, `/api/workers`.
     }
   },
   "IsDisabled": true,
-  "MachinePolicyId": "string",
+  "MachinePolicyId": "MachinePolicies-1",
   "Name": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerPoolIds": [
-    "string"
+    "WorkerPools-1",
+    "..."
   ]
 }
 ```
@@ -291,12 +293,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers`, `/api/workers`.
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "Thumbprint": "string",
   "Uri": "string",
   "WorkerPoolIds": [
-    "string"
+    "WorkerPools-1",
+    "..."
   ]
 }
 ```
@@ -402,12 +405,13 @@ Lists all of the Workers in the supplied Space. The results will be sorted alpha
     "ShellVersion": "string",
     "SkipInitialHealthCheck": true,
     "Slug": "string",
-    "SpaceId": "string",
+    "SpaceId": "Spaces-1",
     "StatusSummary": "string",
     "Thumbprint": "string",
     "Uri": "string",
     "WorkerPoolIds": [
-      "string"
+      "WorkerPools-1",
+      "..."
     ]
   }
 ]
@@ -516,12 +520,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers/discover`, `/api/worker
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "Thumbprint": "string",
   "Uri": "string",
   "WorkerPoolIds": [
-    "string"
+    "WorkerPools-1",
+    "..."
   ]
 }
 ```
@@ -649,12 +654,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers/v2`, `/api/workers/v2`.
         "ShellVersion": "string",
         "SkipInitialHealthCheck": true,
         "Slug": "string",
-        "SpaceId": "string",
+        "SpaceId": "Spaces-1",
         "StatusSummary": "string",
         "Thumbprint": "string",
         "Uri": "string",
         "WorkerPoolIds": [
-          "string"
+          "WorkerPools-1",
+          "..."
         ]
       }
     ],
@@ -759,12 +765,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers/{id}`, `/api/workers/{i
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "Thumbprint": "string",
   "Uri": "string",
   "WorkerPoolIds": [
-    "string"
+    "WorkerPools-1",
+    "..."
   ]
 }
 ```
@@ -825,14 +832,15 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers/{id}`, `/api/workers/{i
       "additionalProp3": "string"
     }
   },
-  "Id": "string",
+  "Id": "Machines-1",
   "IsDisabled": true,
-  "MachinePolicyId": "string",
+  "MachinePolicyId": "MachinePolicies-1",
   "Name": "string",
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "WorkerPoolIds": [
-    "string"
+    "WorkerPools-1",
+    "..."
   ]
 }
 ```
@@ -917,12 +925,13 @@ Also reachable at `/api/spaces/{spaceIdentifier}/workers/{id}`, `/api/workers/{i
   "ShellVersion": "string",
   "SkipInitialHealthCheck": true,
   "Slug": "string",
-  "SpaceId": "string",
+  "SpaceId": "Spaces-1",
   "StatusSummary": "string",
   "Thumbprint": "string",
   "Uri": "string",
   "WorkerPoolIds": [
-    "string"
+    "WorkerPools-1",
+    "..."
   ]
 }
 ```


### PR DESCRIPTION
# Background

The docs site now has two distict sections; the main docs, and the api docs.

API docs have a different layout with different column sizing, and they also have their own specific navigation tree, which is tailored to the API, and does things like rendering icons next to GET/POST/PUT requests.

Previously, the layout dictated which area/navigation tree a page was put in. If a page wanted to be in the API tree, then it was forced to use the API's column structure. We want to mix in user-written pages along with the auto-generated ones, and forcing user-written pages to use the API column structure just looks bad.

Also, in future, we intend to have areas for "Learn" and "CLI", which would have their own nav trees

# Results

This PR adds the formal concept of an `area`. The area is now what dictates which navigation tree a page appears in, and we can use different layouts within any given area.

- Pages can now specify an area explicitly via their yaml frontmatter. 
- If they don't, an area will in inferred from the path. Things in the `docs/api` folder get the API area, everything else gets the Docs area. 
- We can extend this to make areas for CLI/Learn later

**Note**: The TopNav hasn't been touched. We should update it so when you click "API" it takes you to the API area's landing page, but that will come later
