### PR TITLE
Add links to demo projects

### DIFF
--- a/src/pages/docs/argo-cd/steps/update-application-manifests.md
+++ b/src/pages/docs/argo-cd/steps/update-application-manifests.md
@@ -24,6 +24,10 @@ If required, the output path to which the templates are copied can be overridden
 
 The following provides instructions on how to configure an Update Manifests step, constraints on its usage, and how it executes.
 
+:::div{.hint}
+[Easy Mode - Update Argo CD Application Manifests](https://octopus.com/blog/octo-easy-mode-16-argocd-manifest-update) provides a practical example of updating Argo CD application manifests you can apply to your own Octopus instance.
+:::
+
 ## Manifest Templates
 
 1. Specify the set of input template files which can be sourced from either:

--- a/src/pages/docs/octopus-ai/claude-agent-step/index.md
+++ b/src/pages/docs/octopus-ai/claude-agent-step/index.md
@@ -15,6 +15,10 @@ The Claude Agent Step runs [Claude Code](https://code.claude.com/docs/en/overvie
 The Claude Agent Step is an **alpha** release. The configuration and behavior may change between releases, and we're actively looking for feedback on how you use it. Don't build critical, unattended automation on it yet.
 :::
 
+:::div{.hint}
+[Easy Mode - Claude Agent Step](https://octopus.com/blog/octo-easy-mode-17-claude-agent-step) provides a practical example of using the Claude Agent Step you can apply to your own Octopus instance.
+:::
+
 ## The Claude Agent Step
 
 The Claude Agent Step runs an AI agent on a worker or deployment target, with access to your deployment's context. Understanding what the step provides, and what it deliberately leaves to you, helps you decide which jobs to hand the agent and how much access to grant it.

--- a/src/pages/docs/packaging-applications/build-servers/build-information/index.mdx
+++ b/src/pages/docs/packaging-applications/build-servers/build-information/index.mdx
@@ -19,6 +19,10 @@ Build information is associated with a package and includes:
 - Commits: Details of the source commits related to the build.
 - Work items: Issue references parsed from the commit messages.
 
+:::div{.hint}
+[Easy Mode - Build Information](https://octopus.com/blog/octo-easy-mode-05-build-information) provides a practical example of build information steps you can apply to your own Octopus instance.
+:::
+
 ## Passing build information to Octopus \{#passing-build-information-to-octopus}
 
 Build information is passed to Octopus as a file using a custom format. The recommended way to supply the build information is to add the *build information* step from the Octopus Deploy plugin to your build server.

--- a/src/pages/docs/platform-hub/policies/index.md
+++ b/src/pages/docs/platform-hub/policies/index.md
@@ -15,6 +15,10 @@ Policies let you enforce deployment standards automatically. You write rules in 
 
 All policies are stored as OCL files in your Platform Hub repository. If your Platform Hub repository isn't set up yet, see [Platform Hub](/docs/platform-hub/) before continuing.
 
+:::div{.hint}
+[Easy Mode - Policies](https://octopus.com/blog/octo-easy-mode-22-policy) provides a practical example of using policies you can apply to your own Octopus instance.
+:::
+
 ## What you can enforce
 
 When a deployment or runbook run starts, Octopus passes a structured input object to the policy engine. Your Rego conditions read from that object to decide whether the execution should proceed.

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -29,7 +29,6 @@ However, if "Always Run" is selected for subsequent steps, they will proceed reg
 [Easy Mode - Manual Interventions](https://octopus.com/blog/octo-easy-mode-03-manual-intervention) provides a practical example of manual intervention steps you can apply to your own Octopus instance.
 :::
 
-
 ## Add a manual intervention step
 
 Manual intervention steps are added to deployment processes in the same way as other steps.

--- a/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
+++ b/src/pages/docs/projects/built-in-step-templates/manual-intervention-and-approvals.md
@@ -25,6 +25,11 @@ However, if "Always Run" is selected for subsequent steps, they will proceed reg
 
 [Getting Started - Manual Intervention](https://www.youtube.com/watch?v=ePQjCClGfZQ)
 
+:::div{.hint}
+[Easy Mode - Manual Interventions](https://octopus.com/blog/octo-easy-mode-03-manual-intervention) provides a practical example of manual intervention steps you can apply to your own Octopus instance.
+:::
+
+
 ## Add a manual intervention step
 
 Manual intervention steps are added to deployment processes in the same way as other steps.

--- a/src/pages/docs/projects/community-step-templates.md
+++ b/src/pages/docs/projects/community-step-templates.md
@@ -13,6 +13,10 @@ If you can't find a built-in step template that includes the actions you need, y
 
 Octopus Community step templates integration is enabled by default, but it can be disabled.
 
+:::div{.hint}
+[Easy Mode - Community Step Templates](https://octopus.com/blog/octo-easy-mode-11-community) provides a practical example of community step templates you can apply to your own Octopus instance.
+:::
+
 ## Enable or disable community step templates integration
 
 1. Navigate to **Configuration ➜ Features**.

--- a/src/pages/docs/projects/ephemeral-environments/index.md
+++ b/src/pages/docs/projects/ephemeral-environments/index.md
@@ -15,6 +15,10 @@ Ephemeral environments integrate smoothly into your existing development workflo
 
 Octopus can automatically create and deploy to an ephemeral environment from releases created within a specifically configured channel in a project, and supports provisioning and deprovisioning of associated infrastructure using Runbooks.
 
+:::div{.hint}
+[Easy Mode - Ephemeral Environments](https://octopus.com/blog/octo-easy-mode-15-ephemeral-environments) provides a practical example of ephemeral environments you can apply to your own Octopus instance.
+:::
+
 ## Getting started
 
 To configure Ephemeral Environments for your project:

--- a/src/pages/docs/projects/variables/library-variable-sets.md
+++ b/src/pages/docs/projects/variables/library-variable-sets.md
@@ -12,6 +12,10 @@ Octopus [variables](/docs/projects/variables/) can be added to variables sets, w
 
 This can be useful if you have the same variables that are used across multiple projects. Instead of defining the variables for each project, you can define a set of variables in the Variable Set and then access them from every project that needs them.
 
+:::div{.hint}
+[Easy Mode - Variable Sets](https://octopus.com/blog/octo-easy-mode-08-lvs) provides a practical example of variable sets you can apply to your own Octopus instance.
+:::
+
 ## Creating a variable set
 
 1. Navigate to **Deploy ➜ Variable Sets** and click **Add Variable Set**.

--- a/src/pages/docs/projects/variables/tenant-variables.mdx
+++ b/src/pages/docs/projects/variables/tenant-variables.mdx
@@ -21,7 +21,7 @@ There are two types of variable templates:
 - [Common templates](#adding-a-variable-template) are variable values that are common across all tenants but need a unique value per tenant. For example, website names, titles, headers, images, logo, URLs, contact information. These values don't change across projects and environments for a tenant.
 
 :::div{.hint}
-View a working example on our [samples instance](https://oc.to/samples-tenant-variables).
+[Easy Mode - Project Tenant Variables](https://octopus.com/blog/octo-easy-mode-10-project-templates) provides a practical example of project tenant variables you can apply to your own Octopus instance.
 :::
 
 ## Project templates \{#project-templates}

--- a/src/pages/docs/releases/channels/index.md
+++ b/src/pages/docs/releases/channels/index.md
@@ -25,6 +25,10 @@ When you are implementing a deployment process that uses channels you can scope 
 
 You can also define rules per channel to ensure that only package versions and Git resources which meet specific criteria are deployed to specific channels.
 
+:::div{.hint}
+[Easy Mode - Channels](https://octopus.com/blog/octo-easy-mode-12-channels) provides a practical example of channels you can apply to your own Octopus instance.
+:::
+
 ## Managing channels
 
 Every [project](/docs/projects) has a default channel.

--- a/src/pages/docs/runbooks/index.mdx
+++ b/src/pages/docs/runbooks/index.mdx
@@ -31,6 +31,10 @@ Runbooks help you:
 - Automate tasks so you don't need human intervention
 - Free your teams for more crucial work
 
+:::div{.hint}
+[Easy Mode - Runbooks](https://octopus.com/blog/octo-easy-mode-07-runbooks) provides a practical example of runbooks you can apply to your own Octopus instance.
+:::
+
 ## How runbooks work
 
 You can set permissions so anyone on a team can start a runbook, or you can limit access to specific environments. Octopus handles access control and provides a complete audit trail. This makes runbooks ideal for creating safe and secure, self-service, push-button operations. This also frees up your Ops team from time-consuming, repetitive tasks.

--- a/src/pages/docs/tenants/index.md
+++ b/src/pages/docs/tenants/index.md
@@ -37,6 +37,10 @@ Tenants let you:
 - Create release rings to easily deploy to alpha and beta tenants.
 - Build simple [tenanted deployment](https://octopus.com/use-case/tenanted-deployments) processes that can scale as you add more tenants.
 
+:::div{.hint}
+[Easy Mode - Tenants](https://octopus.com/blog/octo-easy-mode-06-tenants) provides a practical example of tenants you can apply to your own Octopus instance.
+:::
+
 ## When to use tenants {#when-to-use-tenants}
 
 Tenants simplify complex deployments if you're deploying your application more than once in an environment.

--- a/src/shared-content/releases/lifecycles.include.md
+++ b/src/shared-content/releases/lifecycles.include.md
@@ -1,5 +1,9 @@
 [Getting Started - Lifecycles](https://www.youtube.com/watch?v=ofc-u61ukRA)
 
+:::div{.hint}
+[Easy Mode - Lifecycles](https://octopus.com/blog/octo-easy-mode-13-lifecycles) provides a practical example of lifecycles you can apply to your own Octopus instance.
+:::
+
 Lifecycles give you control over the way releases of your software are promoted between your environments. You can also use them to automate deployments and set retention policies.
 
 Lifecycles are managed from the library page by navigating to **Deploy ➜ Lifecycles**:


### PR DESCRIPTION
This PR adds links to the Easy Mode blog series, which provides instructions for creating demo projects that highlight specific features. It provides a consistent set of links that replaces direct links to the sample instances where appropriate.