### PR TITLE
Stop the Playwright install step hanging the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "renovate": "renovate",
         "spellcheck": "git fetch origin main:refs/remotes/origin/main && git diff origin/main --name-only --diff-filter=ACMRTUXB | cspell --no-must-find-files --file-list stdin",
         "spellcheck-all": "cspell \"**/*.{md,mdx}\"",
-        "test": "astro build && npx playwright install --with-deps && npx playwright test",
+        "test": "astro build && npx playwright install chromium && npx playwright test",
         "watch": "onchange 'src/**/*.{js,mjs,ts,astro,css}' -- prettier --write --plugin=prettier-plugin-astro {{changed}}"
     },
     "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,8 @@ import { devices } from '@playwright/test';
 // See https://playwright.dev/docs/test-configuration
 const config: PlaywrightTestConfig = {
   testDir: './tests',
-  timeout: 30 * 60 * 1000,
+  // A hung test otherwise burns 30 minutes, times the 2 retries, on a single worker.
+  timeout: 60 * 1000,
   expect: {
     timeout: 5 * 1000
   },


### PR DESCRIPTION
`playwright install --with-deps` shells out to apt-get, which stalls when the Ubuntu mirrors are slow on a GitHub-hosted runner. Nothing bounds it, so the job runs to the 6 hour Actions ceiling. 

Only Chromium is configured, so install that alone and drop the apt call. This also skips downloading Firefox and WebKit, which were never used.

Also cuts the per-test timeout from 30 minutes to 60 seconds. The whole suite runs in 34 seconds, with the slowest test at 14.

The `build` job in OctopusDeploy/microsite-deployment has no `timeout-minutes`, so any future stall there will still run for 6 hours. Worth setting separately.

# Before

<img width="1839" height="1218" alt="image" src="https://github.com/user-attachments/assets/534543e7-bb7e-4ce9-98f0-42d041234538" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)