### PR TITLE
Document Tentacle restart requirement for poll-server

### DIFF
--- a/src/pages/docs/administration/high-availability/polling-tentacles-with-ha.mdx
+++ b/src/pages/docs/administration/high-availability/polling-tentacles-with-ha.mdx
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2023-01-01
+modDate: 2026-08-20
 title: Polling Tentacles with HA
 description: With Octopus High Availability, Polling Tentacles must poll all Octopus Server nodes in your configuration.
 navOrder: 50
@@ -68,21 +68,29 @@ The important thing to remember is that each node should be using the **same add
 
 ## Registering Polling Tentacles
 
-There are two options to add Octopus Servers to a Polling Tentacle, via the command-line or via editing the Tentacle.config file directly.
+There are two options to add Octopus Servers to a Polling Tentacle: the command line, or editing the Tentacle.config file directly.
+
+Both methods need the Tentacle service restarted afterwards. A running Tentacle doesn't pick up a new server address until it restarts.
 
 **Command line:**
 
-Configuring a Polling Tentacle via the command-line is the preferred option with the command executed once per server; an example command using the default instance can be seen below:
+The command line is the preferred option. Run the command once per server; an example command using the default instance can be seen below:
 
 ```text
 C:\Program Files\Octopus Deploy\Tentacle>Tentacle poll-server --server=https://your-octopus-url --apikey=API-YOUR-KEY
 ```
 
-For more information on this command please refer to the [Tentacle Poll Server command line options](/docs/octopus-rest-api/tentacle.exe-command-line/poll-server).
+Once you've added every node in your cluster, restart the Tentacle service:
+
+```text
+C:\Program Files\Octopus Deploy\Tentacle>Tentacle service --restart
+```
+
+For more information on these commands, see the [Tentacle poll-server](/docs/octopus-rest-api/tentacle.exe-command-line/poll-server) and [Tentacle service](/docs/octopus-rest-api/tentacle.exe-command-line/service) command line options.
 
 **Tentacle.config:**
 
-Alternatively you can edit Tentacle.config directly to add each Octopus Server (this is interpreted as a JSON array of servers). This method is not recommended as the Tentacle service for each server will need to be restarted to accept incoming connections via this method.
+Alternatively you can edit Tentacle.config directly to add each Octopus Server (this is interpreted as a JSON array of servers). This method isn't recommended, as editing the JSON array by hand is error-prone. Restart the Tentacle service after you've saved your changes.
 
 ```xml
 <set key="Tentacle.Communication.TrustedOctopusServers">

--- a/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md
+++ b/src/pages/docs/octopus-rest-api/tentacle.exe-command-line/poll-server.md
@@ -1,12 +1,16 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-06-25
+modDate: 2026-08-20
 title: Poll server
 description: Using the Tentacle.exe command line executable to configure the Octopus Server this Tentacle will poll.
 ---
 
 Configures an Octopus Server that this Tentacle will poll.
+
+:::div{.warning}
+A running Tentacle doesn't pick up this change. Restart the Tentacle service with the [service](/docs/octopus-rest-api/tentacle.exe-command-line/service) command after you run `poll-server`, or the Tentacle won't connect to the server you just added.
+:::
 
 **Poll server options**
 
@@ -45,8 +49,11 @@ Or one of the common options:
 
 ## Basic example
 
-This example configures the Octopus Server that the polling Tentacle polls:
+This example configures the Octopus Server that the polling Tentacle polls, then restarts the Tentacle service so the change takes effect:
 
 ```text
 tentacle poll-server --server="https://your-octopus-url" --apiKey="API-YOUR-KEY"
+tentacle service --restart
 ```
+
+Both commands act on the default instance. To configure a named instance, pass `--instance` to each command.


### PR DESCRIPTION
The poll-server page didn't mention that the Tentacle service needs restarting before a new server address takes effect, so add a warning callout and show the restart in the basic example.

The HA page attached the restart requirement only to the Tentacle.config method and offered the command line as the alternative that avoided it, which reads as though poll-server applies immediately. Move the restart note so it covers both methods, add the restart step to the command line example, and discourage the Tentacle.config method on the grounds that actually apply to it.