### PR TITLE
Fix and update API navigation to allow non-generated files to coexist with generated ones

### DIFF
--- a/src/components/ApiNavigation.astro
+++ b/src/components/ApiNavigation.astro
@@ -2,6 +2,7 @@
 import { accelerator } from '@lib/accelerator';
 import { Translations, Lang } from '@util/Languages';
 import { apiMenu } from '@lib/apiNavigation';
+import ApiNavigationItem from './ApiNavigationItem.astro';
 
 const stats = new accelerator.statistics('components/ApiNavigation.astro');
 stats.start();
@@ -9,14 +10,15 @@ stats.start();
 type Props = {
   lang: string;
   // Left off by a layout that lists this page's headings somewhere else, which
-  // leaves the nav as the flat list of pages with nothing under the current one.
+  // leaves the nav as the page tree with nothing under the current page.
   headings?: { depth: number; slug: string; text: string }[];
   // One entry per endpoint, in heading order, left on the frontmatter by
   // plugins/satteri-api-examples.js from the `:endpoint` directive under each
   // heading. Sections without one — and pages that never reach that plugin —
   // simply have none.
   apiMethods?:
-    { text: string; method: string | null; deprecated?: boolean }[] | null;
+    | { text: string; method: string | null; deprecated?: boolean }[]
+    | null;
 };
 const { lang, headings, apiMethods } = Astro.props satisfies Props;
 
@@ -66,10 +68,9 @@ const endpoints = (headings ?? [])
     };
   });
 
-const pages = apiMenu().map((page) => ({
-  ...page,
-  isCurrent: page.url.replace(/\/$/, '') === currentPath,
-}));
+// The hand-written pages first, then the generated reference, with a rule
+// between them.
+const { authored, generated } = apiMenu();
 
 stats.stop();
 ---
@@ -82,54 +83,33 @@ stats.stop();
   <h2 class="site-nav-title">{_(Translations.navigation.title)}</h2>
   <ul class="site-nav__list">
     {
-      pages.map((page) =>
-        page.isCurrent && endpoints.length > 0 ? (
-          <li class="site-nav__list-item">
-            <details class="site-nav__group" open>
-              {/* The summary is the page the reader is already on, so it
-                  labels the group rather than linking back to itself. */}
-              <summary class="site-nav__link" aria-current="page">
-                <span class="site-nav__label">{page.title}</span>
-              </summary>
-              <ul class="site-nav__list">
-                {endpoints.map((heading) => (
-                  <li class="site-nav__list-item">
-                    <a
-                      class:list={[
-                        'site-nav__link',
-                        'site-nav__link--heading',
-                        heading.deprecated && 'site-nav__link--deprecated',
-                      ]}
-                      href={`#${heading.slug}`}
-                    >
-                      {/* The badge is the method: an icon in the nav, where
-                          there is no room for the word beside the title. */}
-                      {heading.method && (
-                        <span
-                          class={`api-${heading.method} api-icon-only`}
-                          role="img"
-                          aria-label={METHOD_LABELS[heading.method]}
-                        />
-                      )}
-                      <span class="site-nav__label">{heading.text}</span>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </details>
-          </li>
-        ) : (
-          <li class="site-nav__list-item">
-            <a
-              class="site-nav__link"
-              href={accelerator.urlFormatter.formatAddress(page.url)}
-              aria-current={page.isCurrent ? 'page' : null}
-            >
-              <span class="site-nav__label">{page.title}</span>
-            </a>
-          </li>
-        )
+      authored.map((page) => (
+        <ApiNavigationItem
+          page={page}
+          currentPath={currentPath}
+          endpoints={endpoints}
+          methodLabels={METHOD_LABELS}
+        />
+      ))
+    }
+    {
+      authored.length > 0 && generated.length > 0 && (
+        <li class="site-nav__list-item">
+          {/* The two halves of the nav are written by different hands, and the
+              rule is where one set of pages stops and the other starts. */}
+          <hr class="site-nav__separator" />
+        </li>
       )
+    }
+    {
+      generated.map((page) => (
+        <ApiNavigationItem
+          page={page}
+          currentPath={currentPath}
+          endpoints={endpoints}
+          methodLabels={METHOD_LABELS}
+        />
+      ))
     }
   </ul>
 </nav>

--- a/src/components/ApiNavigationItem.astro
+++ b/src/components/ApiNavigationItem.astro
@@ -1,0 +1,110 @@
+---
+import { accelerator } from '@lib/accelerator';
+import type { ApiNavPage } from '@lib/apiNavigation';
+
+// One row of the API left nav, and the branch under it. Split out of
+// ApiNavigation.astro because the tree is now nested and a row has to be able
+// to render itself.
+
+export type ApiNavEndpoint = {
+  slug: string;
+  text: string;
+  method: string | null;
+  deprecated: boolean;
+};
+
+type Props = {
+  page: ApiNavPage;
+  // The reader's path, without its trailing slash. Decides which branch is
+  // open and which row is current.
+  currentPath: string;
+  // The current page's endpoints, listed under whichever row turns out to be
+  // that page. Empty for a layout that lists them somewhere else.
+  endpoints: ApiNavEndpoint[];
+  // The badge labels, by method. Passed down so the two components cannot
+  // disagree about which methods have a badge.
+  methodLabels: Record<string, string>;
+};
+const { page, currentPath, endpoints, methodLabels } =
+  Astro.props satisfies Props;
+
+const isCurrent = page.url !== null && page.path === currentPath;
+// Open the branch the reader is inside, and only that one.
+const isOpen =
+  currentPath === page.path || currentPath.startsWith(page.path + '/');
+
+const showEndpoints = isCurrent && endpoints.length > 0;
+---
+
+{
+  page.children.length > 0 && (
+    <li class="site-nav__list-item">
+      <details class="site-nav__group" open={isOpen}>
+        <summary class="site-nav__link">
+          <span class="site-nav__label">{page.title}</span>
+        </summary>
+        <ul class="site-nav__list">
+          {page.children.map((child) => (
+            <Astro.self
+              page={child}
+              currentPath={currentPath}
+              endpoints={endpoints}
+              methodLabels={methodLabels}
+            />
+          ))}
+        </ul>
+      </details>
+    </li>
+  )
+}
+{
+  page.children.length === 0 && showEndpoints && (
+    <li class="site-nav__list-item">
+      <details class="site-nav__group" open>
+        {/* The summary is the page the reader is already on, so it labels the
+            group rather than linking back to itself. */}
+        <summary class="site-nav__link" aria-current="page">
+          <span class="site-nav__label">{page.title}</span>
+        </summary>
+        <ul class="site-nav__list">
+          {endpoints.map((endpoint) => (
+            <li class="site-nav__list-item">
+              <a
+                class:list={[
+                  'site-nav__link',
+                  'site-nav__link--heading',
+                  endpoint.deprecated && 'site-nav__link--deprecated',
+                ]}
+                href={`#${endpoint.slug}`}
+              >
+                {/* The badge is the method: an icon in the nav, where there is
+                    no room for the word beside the title. */}
+                {endpoint.method && (
+                  <span
+                    class={`api-${endpoint.method} api-icon-only`}
+                    role="img"
+                    aria-label={methodLabels[endpoint.method]}
+                  />
+                )}
+                <span class="site-nav__label">{endpoint.text}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </details>
+    </li>
+  )
+}
+{
+  page.children.length === 0 && !showEndpoints && (
+    <li class="site-nav__list-item">
+      <a
+        class="site-nav__link"
+        href={accelerator.urlFormatter.formatAddress(page.url ?? '/')}
+        aria-current={isCurrent ? 'page' : null}
+      >
+        <span class="site-nav__label">{page.title}</span>
+      </a>
+    </li>
+  )
+}

--- a/src/lib/apiNavigation.ts
+++ b/src/lib/apiNavigation.ts
@@ -1,48 +1,205 @@
 import type { MarkdownInstance } from 'astro-accelerator-utils/types/Astro';
+import { PostFiltering } from 'astro-accelerator-utils';
+import { SITE } from '@config';
 import { accelerator } from './accelerator';
-import { pageArea } from './areas';
+import { AREAS, pageArea } from './areas';
+import { isGeneratedApiPath } from './generatedApiPaths';
 
 // The API reference carries its own left nav, built here from the pages in the
 // API area (see lib/areas.ts — the section they live in, not the layout they
 // render with). Those same pages are pruned out of the main site nav in
 // navigationTree.ts, so the two trees never overlap.
 //
-// Unlike the site nav, this one is flat: an entry per page, and under the page
-// the reader is on, an entry per endpoint. The endpoints come from the layout's
-// own headings rather than from here — Posts.all() reads the page set back from
-// a JSON cache, which leaves the frontmatter intact but drops getHeadings().
+// The tree follows the folders the pages live in, the same way the docs nav
+// does: /docs/api/octopus.client/using-resources sits under Octopus.Client
+// rather than beside it. Under the page the reader is on there is one more
+// level the docs nav has no equivalent of — an entry per endpoint. Those come
+// from the layout's own headings rather than from here: Posts.all() reads the
+// page set back from a JSON cache, which leaves the frontmatter intact but
+// drops getHeadings().
+//
+// The menu comes back in two halves. The hand-written pages are one, the ~100
+// generated ones under _generated are the other, and ApiNavigation.astro draws
+// a rule between them.
 
 export type ApiNavPage = {
+  /** The row's label. */
   title: string;
-  url: string;
+  /** null for a folder that has no page of its own, so the row is not a link. */
+  url: string | null;
+  /** The url without its trailing slash, and the one thing a folder with no
+      page still has: it is what decides whether the branch is open. */
+  path: string;
   order: number;
+  children: ApiNavPage[];
+};
+
+export type ApiMenu = {
+  /** The pages under /docs/api that somebody wrote. */
+  authored: ApiNavPage[];
+  /** The pages generated into /docs/api/_generated. */
+  generated: ApiNavPage[];
 };
 
 export function isApiPage(post: MarkdownInstance): boolean {
   return pageArea(post) === 'api';
 }
 
-// Same deal as menuTemplate(): the list is identical for every page in the
-// section, so it is built once and read by all of them.
-let pages: ApiNavPage[] | null = null;
+// Where the area's tree is rooted. The pages hang off this, and the segments
+// below it are the folders the tree is built out of.
+const API_ROOT = SITE.subfolder + (AREAS.api.path ?? '');
 
-export function apiMenu(): ApiNavPage[] {
+const trimSlash = (path: string) => path.replace(/\/$/, '');
+
+// A generated page is one whose source file sits under _generated. The url does
+// not say so — [...generatedFileName].astro serves them from /docs/api as if
+// the folder were not there — so the file is what has to be asked.
+function isGenerated(post: MarkdownInstance): boolean {
+  return isGeneratedApiPath(post.file ?? '');
+}
+
+// A folder with no index page of its own still needs a label. "openid-connect"
+// reads as "Openid Connect", which is a stand-in: a folder that wants a better
+// name gets an index.md, and its frontmatter names it.
+function titleFromSegment(segment: string): string {
+  return segment
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+// The tree under construction. One node per url segment, whether or not a page
+// lives at it, which is what keeps /docs/api/authentication/create-an-api-key
+// in the nav while /docs/api/authentication has no page.
+type TreeNode = {
+  segment: string;
+  path: string;
+  post: MarkdownInstance | null;
+  children: Map<string, TreeNode>;
+};
+
+function newNode(segment: string, path: string): TreeNode {
+  return { segment, path, post: null, children: new Map() };
+}
+
+function insert(root: TreeNode, post: MarkdownInstance): void {
+  const path = trimSlash(post.url ?? '');
+  const rest = path.slice(API_ROOT.length).replace(/^\//, '');
+  const segments = rest === '' ? [] : rest.split('/');
+
+  let node = root;
+  let walked = API_ROOT;
+  for (const segment of segments) {
+    walked += '/' + segment;
+    let child = node.children.get(segment);
+    if (child === undefined) {
+      child = newNode(segment, walked);
+      node.children.set(segment, child);
+    }
+    node = child;
+  }
+
+  node.post = post;
+}
+
+// Mirrors astro-accelerator's mapNavPage(): `navSection` names the branch,
+// `navTitle` names the row, and the title covers for both when neither is set.
+const rowTitle = (post: MarkdownInstance) =>
+  post.frontmatter.navTitle ?? post.frontmatter.title;
+const branchTitle = (post: MarkdownInstance) =>
+  post.frontmatter.navSection ?? rowTitle(post);
+const navOrder = (post: MarkdownInstance) =>
+  post.frontmatter.navOrder ?? Number.MAX_SAFE_INTEGER;
+
+const byOrderThenTitle = (a: ApiNavPage, b: ApiNavPage) =>
+  a.order - b.order || a.title.localeCompare(b.title);
+
+function toNavPage(node: TreeNode): ApiNavPage {
+  const url = node.post
+    ? accelerator.urlFormatter.addSlashToAddress(node.post.url ?? '/')
+    : null;
+  const children = [...node.children.values()].map(toNavPage);
+
+  // A branch with a page of its own lists that page first, the way the docs nav
+  // does: the summary opens the branch rather than linking, so without this row
+  // there is no way in to the section's own page.
+  if (children.length > 0 && node.post) {
+    children.push({
+      title: rowTitle(node.post),
+      url,
+      path: node.path,
+      // Ahead of anything an author can set, so the section's own page stays at
+      // the top of its section.
+      order: Number.MIN_SAFE_INTEGER,
+      children: [],
+    });
+  }
+
+  children.sort(byOrderThenTitle);
+
+  return {
+    title: node.post
+      ? children.length > 0
+        ? branchTitle(node.post)
+        : rowTitle(node.post)
+      : titleFromSegment(node.segment),
+    // A branch is opened by its summary, not by a link on it; the row for its
+    // own page is in `children`.
+    url: children.length > 0 ? null : url,
+    path: node.path,
+    // A folder with no page of its own sits where its earliest child would.
+    order: node.post
+      ? navOrder(node.post)
+      : Math.min(...children.map((child) => child.order)),
+    children,
+  };
+}
+
+function buildTree(posts: MarkdownInstance[]): ApiNavPage[] {
+  const root = newNode('', API_ROOT);
+  for (const post of posts) insert(root, post);
+
+  const pages = [...root.children.values()].map(toNavPage);
+
+  // /docs/api itself is a page, and a sibling of the sections rather than a
+  // branch over them: the tree is already rooted there.
+  if (root.post) {
+    pages.push({
+      title: rowTitle(root.post),
+      url: accelerator.urlFormatter.addSlashToAddress(root.post.url ?? '/'),
+      path: API_ROOT,
+      order: navOrder(root.post),
+      children: [],
+    });
+  }
+
+  return pages.sort(byOrderThenTitle);
+}
+
+// Same deal as menuTemplate(): the menu is identical for every page in the
+// section, so it is built once and read by all of them.
+let menu: ApiMenu | null = null;
+
+export function apiMenu(): ApiMenu {
   // Builds only. In dev, rebuild every time so a new or edited page shows up
   // in the nav without restarting the server.
-  if (pages !== null && import.meta.env.PROD) return pages;
+  if (menu !== null && import.meta.env.PROD) return menu;
 
-  const menu = accelerator.posts
+  // navMenu: false keeps a page out of the nav, and the redirect stubs left
+  // behind by moved pages all carry it. Without this they arrive as rows
+  // titled "Redirect", each one a section of its own.
+  const pages = accelerator.posts
     .all()
     .filter(isApiPage)
-    .map((post) => ({
-      title: post.frontmatter.navTitle ?? post.frontmatter.title,
-      url: accelerator.urlFormatter.addSlashToAddress(post.url ?? '/'),
-      order: post.frontmatter.navOrder ?? Number.MAX_SAFE_INTEGER,
-    }))
-    // The pages are generated one per API resource and carry no navOrder, so the
-    // fallback is the alphabetical order the index page already lists them in.
-    .sort((a, b) => a.order - b.order || a.title.localeCompare(b.title));
+    .filter(PostFiltering.showInMenu);
 
-  if (import.meta.env.PROD) pages = menu;
-  return menu;
+  const built: ApiMenu = {
+    authored: buildTree(pages.filter((post) => !isGenerated(post))),
+    // The generated pages carry no navOrder — there is nobody to write one —
+    // so they fall back to the alphabetical order the index page lists them in.
+    generated: buildTree(pages.filter(isGenerated)),
+  };
+
+  if (import.meta.env.PROD) menu = built;
+  return built;
 }

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -35,9 +35,10 @@ type AreaDefinition = {
 
 export const AREAS = {
   docs: { path: null, sectionCrumb: null },
-  // /docs/api has no page of its own yet: `_index.md` is underscore-prefixed so
-  // Astro does not route it, which is why the crumb has to be spliced in.
-  api: { path: '/api', sectionCrumb: 'Api' },
+  // /docs/api has a landing page of its own, so the generic crumb walk finds
+  // the section without help. It reads as "API" rather than as that page's
+  // title because index.md carries a `crumbTitle`.
+  api: { path: '/api', sectionCrumb: null },
 } as const satisfies Record<Area, AreaDefinition>;
 
 const DEFAULT_AREA: Area = 'docs';

--- a/src/pages/docs/api/index.md
+++ b/src/pages/docs/api/index.md
@@ -1,0 +1,149 @@
+---
+layout: src/layouts/Default.astro
+pubDate: 2026-08-21
+modDate: 2026-08-21
+title: Get started with the Octopus REST API
+navTitle: Get started
+crumbTitle: API
+description: Getting started with the Octopus REST API
+navOrder: 1
+hideInThisSectionHeader: true
+---
+
+## API clients
+
+Octopus provides API clients for popular programming languages and runtime environments. You can access the source code for these clients on GitHub:
+
+- [Go API Client for Octopus Deploy](https://github.com/OctopusDeploy/go-octopusdeploy)
+- [.NET C# API Client for Octopus Deploy](https://github.com/OctopusDeploy/OctopusClients)
+- [TypeScript API Client for Octopus Deploy](https://github.com/OctopusDeploy/api-client.ts)
+
+Code snippets using these clients for operations in the Octopus REST API are available in our [API examples](/docs/octopus-rest-api/examples) documentation.
+
+## REST API authentication \{#authentication}
+
+The Octopus Deploy API is available at:
+
+```text
+https://<your-octopus-url>/api
+```
+
+Replace `<your-octopus-url>` with the URL that you host your Octopus instance on.
+
+The API supports 2 methods of authentication.
+
+### Creating an API Key
+
+You can get your API key from your profile page on the Octopus Web Portal.
+
+After you have a key, you can provide it to the API in the following ways:
+
+1. Through the `X-Octopus-ApiKey` HTTP header with all requests. This is the preferred approach.
+1. As an `apikey` query string parameter with all requests. You should only be used for simple requests.
+
+:::div{.hint}
+Learn more about [how to create an API key](/docs/octopus-rest-api/how-to-create-an-api-key).
+:::
+
+### OpenID Connect
+
+OpenID Connect is a set of identity specifications that build on OAuth 2.0 to let software systems connect in a way that promotes security best practices.
+
+When using OIDC, Octopus validates an identity token from a trusted external system using [public key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography). Octopus then issues a short-lived access token that you can use to interact with the Octopus API.
+
+Some of the benefits of using OIDC in Octopus include:
+
+- You don't need to provision API keys and store them in external systems. This reduces the risk of unauthorized access to the Octopus API from exposed keys.
+- Administrators don't need to rotate API keys manually. This reduces the risk of disruption when updating to newer keys in external systems.
+- Access tokens issued by Octopus are short-lived. This reduces the risk of unauthorized access to the Octopus API.
+- Access tokens are only issued for requests from trusted external systems. This allows for controlled access to service accounts and promotes the principle of least access.
+
+We support any issuer that can generate signed OIDC tokens that can be validated anonymously. However, we provide built-in support for GitHub Actions with the [OctopusDeploy/login](https://github.com/OctopusDeploy/login) action.
+
+For more information see [Using OpenId Connect with the Octopus API](https://octopus.com/docs/octopus-rest-api/openid-connect).
+
+## REST API Swagger documentation \{#api-swagger-docs}
+
+Octopus includes the default Swagger UI for displaying the API documentation in a nice, human, readable way. To browse that UI just open your browser and go to `https://<your-octopus-url>/swaggerui/`. The original Non-Swagger API page is still available and you can access it via `https://<your-octopus-url>/api/`.
+
+:::figure
+![Server API](/docs/img/octopus-rest-api/images/server-api.png)
+:::
+
+You can view the API through the Octopus Demo server at [demo.octopus.app/swaggerui/index.html](https://demo.octopus.app/swaggerui/index.html).
+
+## REST API links \{#api-links}
+
+All resources returned by the REST API contain links to other resources. The idea is that instead of memorizing or hard-coding URLs when using the API, you should start with the root API resource and use links to navigate.
+
+For example, a `GET` request to `/api` returns a resource that looks like:
+
+```json
+{
+  "Application": "Octopus Deploy",
+  "Version": "2022.1.2386",
+  "ApiVersion": "3.0.0",
+  "InstallationId": "9f155416-5d9e-4e19-ba58-b710d4edf336",
+  "Links": {
+    "Self": "/api",
+    "Accounts": "/api/Spaces-1/accounts{/id}{?skip,take,ids,partialName,accountType}",
+    "Environments": "/api/Spaces-1/environments{/id}{?name,skip,ids,take,partialName}",
+    "Machines": "/api/Spaces-1/machines{/id}{?skip,take,name,ids,partialName,roles,isDisabled,healthStatuses,commStyles,tenantIds,tenantTags,environmentIds,thumbprint,deploymentId,shellNames,deploymentTargetTypes}",
+    "Projects": "/api/Spaces-1/projects{/id}{?name,skip,ids,clone,take,partialName,clonedFromProjectId}",
+    "RunbookProcesses": "/api/Spaces-1/runbookProcesses{/id}{?skip,take,ids}",
+    "RunbookRuns": "/api/Spaces-1/runbookRuns{/id}{?skip,take,ids,projects,environments,tenants,runbooks,taskState,partialName}",
+    "Runbooks": "/api/Spaces-1/runbooks{/id}{?skip,take,ids,partialName,clone,projectIds}",
+    "RunbookSnapshots": "/api/Spaces-1/runbookSnapshots{/id}{?skip,take,ids,publish}",
+    "Feeds": "/api/feeds{/id}{?skip,take,ids,partialName,feedType,name}",
+    "Tasks": "/api/tasks{/id}{?skip,active,environment,tenant,runbook,project,name,node,running,states,hasPendingInterruptions,hasWarningsOrErrors,take,ids,partialName,spaces,includeSystem,description,fromCompletedDate,toCompletedDate,fromQueueDate,toQueueDate,fromStartDate,toStartDate}",
+    "Variables": "/api/Spaces-1/variables{/id}{?ids}",
+    "Web": "/app"
+  }
+}
+```
+
+:::div{.hint}
+Note: the `Links` collection example above has been significantly reduced in size for demonstration purposes.
+:::
+
+You can follow the links in the result to navigate around the API. For example, by following the `Projects` link, you'll find a list of the projects on your Octopus server.
+
+Since the format and structure of links may change, it's essential that clients avoid hardcoding URL's to resources, and instead rely on starting at `/api` and navigating from there.
+
+### URI templates
+
+Some links (mainly to collections) use URI templates as defined in [RFC 6570](http://tools.ietf.org/html/rfc6570). If in doubt, a client should assume that any link is a URI template.
+
+### Collections
+
+Collections of resources also include links. For example, following the `Environments` link above will give you a list of environments.
+
+```json
+{
+  "ItemType": "Environment",
+  "TotalResults": 20,
+  "ItemsPerPage": 10,
+  "NumberOfPages": 2,
+  "LastPageNumber": 1,
+  "Items": [
+    // ... a list of environments ...
+  ],
+  "Links": {
+    "Self": "/api/Spaces-1/environments?skip=0&take=10",
+    "Template": "/api/Spaces-1/environments{?skip,ids,take,partialName}",
+    "Page.All": "/api/Spaces-1/environments?skip=0&take=2147483647",
+    "Page.Next": "/api/Spaces-1/environments?skip=10&take=10",
+    "Page.Current": "/api/Spaces-1/environments?skip=0&take=10"
+  }
+}
+```
+
+The links at the bottom of the resource allow you to traverse the pages of results. Again, instead of hard-coding query string parameters, you can look for a `Page.Next` link and follow that instead.
+
+## REST API and Spaces \{#api-and-spaces}
+
+If you are using spaces, you need to include the `SpaceID` in your API calls. If you do not include the `SpaceID`, your API calls will automatically use the default space.
+
+## REST API code samples \{#api-samples}
+
+Code snippet samples for various operations in the Octopus REST API are available both in our [API examples](/docs/octopus-rest-api/examples) and on the [OctopusDeploy-API GitHub repository](https://github.com/OctopusDeploy/OctopusDeploy-Api)

--- a/src/styles/api.css
+++ b/src/styles/api.css
@@ -132,6 +132,15 @@ section so its examples can sit beside it. */
   }
 }
 
+/* The rule between the hand-written pages and the generated reference. It sits
+   in a row of its own, so it takes the space of one and carries the line
+   through the middle of it. */
+.site-nav__separator {
+  margin-block: var(--space8);
+  border: 0;
+  border-top: var(--borderWidth1) solid var(--colorBorderPrimary);
+}
+
 /* ----- Styles for API badges ----- */
 
 /* A deprecated endpoint keeps its badge and its row, and reads as secondary

--- a/src/themes/octopus/utilities/breadcrumbs.ts
+++ b/src/themes/octopus/utilities/breadcrumbs.ts
@@ -38,7 +38,12 @@ export function buildCrumbs(
   const titles = crumbTitleMap();
 
   for (const page of navPages) {
-    page.title = titles.get(page.url) || page.section || page.title;
+    // The map is keyed with a trailing slash, and so is every crumb the walk
+    // builds - except the last, which Navigation.breadcrumbs() rewrites to the
+    // raw request path. Without normalizing, a `crumbTitle` was honoured
+    // everywhere above the current page and silently dropped on it.
+    const url = accelerator.urlFormatter.addSlashToAddress(page.url);
+    page.title = titles.get(url) || page.section || page.title;
   }
 
   return [...navPages, ...(extraCrumbs ?? [])];

--- a/tests/api-page.spec.ts
+++ b/tests/api-page.spec.ts
@@ -10,11 +10,14 @@ test.describe('api page chrome', () => {
     await page.goto(ENDPOINTS);
 
     const crumbs = page.locator('nav[aria-label="Breadcrumb"] li');
-    await expect(crumbs).toHaveText(['Docs', 'Api', 'Feeds']);
+    await expect(crumbs).toHaveText(['Docs', 'API', 'Feeds']);
 
-    // Nothing to link to until the section has a landing page, so the Api
-    // crumb is text rather than a link to a 404.
-    await expect(crumbs.nth(1).locator('a')).toHaveCount(0);
+    // The section has a landing page of its own, and the crumb links to it.
+    // "API" rather than that page's own title, which is a `crumbTitle` on it.
+    await expect(crumbs.nth(1).locator('a')).toHaveAttribute(
+      'href',
+      /\/docs\/api\/?$/
+    );
   });
 
   test('the breadcrumb trail is published as JSON-LD, not microdata', async ({
@@ -29,14 +32,13 @@ test.describe('api page chrome', () => {
 
     expect(list.itemListElement.map((item) => item.name)).toEqual([
       'Docs',
-      'Api',
+      'API',
       'Feeds',
     ]);
-    // The last crumb is the page itself and the Api crumb has no page, so only
-    // the first carries a URL.
+    // The last crumb is the page itself, so it is the only one without a URL.
     expect(list.itemListElement.map((item) => item.item ?? null)).toEqual([
       expect.stringContaining('/docs'),
-      null,
+      expect.stringContaining('/docs/api'),
       null,
     ]);
 
@@ -76,7 +78,12 @@ test.describe('api page chrome', () => {
   test('the pages Astro does not route are not published', async ({
     request,
   }) => {
-    for (const url of ['/docs/api/', '/docs/api/README', '/docs/api/index']) {
+    // The section's own landing page is routed, and so is every generated page
+    // - but from /docs/api, not from the folder it is written into.
+    expect((await request.get('/docs/api/')).status()).toBe(200);
+    expect((await request.get('/docs/api/channels')).status()).toBe(200);
+
+    for (const url of ['/docs/api/_generated/channels', '/docs/api/README']) {
       expect((await request.get(url)).status(), url).toBe(404);
     }
   });

--- a/tests/code-block.spec.ts
+++ b/tests/code-block.spec.ts
@@ -130,13 +130,22 @@ test.describe('code block', () => {
   }) => {
     await page.goto(GROUPED);
 
-    const select = page.locator('.code-block__language-select').first();
+    const block = page.locator('.code-block').first();
+    const select = block.locator('.code-block__language-select');
     await select.focus();
     await expect(select).toBeFocused();
 
-    // Free with <select>; the old menu hand-rolled all of this
-    await select.press('ArrowDown');
+    // Free with <select>; the old menu hand-rolled all of this. Type-ahead
+    // rather than ArrowDown, because Arrow keys open the picker instead of
+    // moving the selection on macOS - and type-ahead behaves the same
+    // everywhere, so this asserts one thing on all three platforms. One key
+    // only: consecutive letters accumulate into a search buffer, so pressing
+    // "c" then "p" looks for "cp" rather than moving twice.
+    await select.press('c');
     await expect(select).toHaveValue('1');
+
+    // The keyboard has to drive the panels, not just the select's own value.
+    await expect(block).toContainText('repository.Machines.Modify(machine)');
   });
 
   test('a one-member group gets no switcher', async ({ page }) => {

--- a/tests/docs-search.spec.ts
+++ b/tests/docs-search.spec.ts
@@ -8,6 +8,18 @@ const PAGE = '/components';
 const overlay = (page: Page) => page.locator('[data-docs-search="demo"]');
 const siteOverlay = (page: Page) => page.locator('[data-docs-search="site"]');
 
+// Mirrors the sniff in src/scripts/docs-search.ts, so the test presses the
+// modifier that page is actually listening for.
+const applePlatform = (page: Page) =>
+  page.evaluate(() => {
+    const nav = navigator as Navigator & {
+      userAgentData?: { platform: string };
+    };
+    return nav.userAgentData
+      ? nav.userAgentData.platform === 'macOS'
+      : (nav.platform || nav.userAgent).includes('Mac');
+  });
+
 async function opened(page: Page) {
   const demo = overlay(page);
   await page.locator('[data-docs-search-trigger="demo"]').click();
@@ -175,8 +187,18 @@ test('the left and right keys move through the tabs from the input', async ({
   );
   await expect(demo.locator('[role="option"]')).toHaveCount(4);
 
-  // Back the other way, from the start of the query where Left is free.
-  await page.keyboard.press('Home');
+  // Back the other way, from the start of the query where Left is free. Walking
+  // the caret rather than pressing Home, which is not "start of line" in an
+  // input on macOS - and walking it is the better test anyway, since every
+  // press has to keep editing the query until the caret runs out of room.
+  for (let i = 0; i < 'feed'.length; i++) {
+    await page.keyboard.press('ArrowLeft');
+  }
+  await expect(demo.locator('[data-facet="all"]')).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+
   await page.keyboard.press('ArrowLeft');
   await expect(demo.locator('[data-facet="cli"]')).toHaveAttribute(
     'aria-selected',
@@ -302,7 +324,11 @@ test('results stay on the host that served them', async ({ page }) => {
 test('the keyboard shortcut opens the site overlay', async ({ page }) => {
   await page.goto(PAGE);
 
-  const shortcut = process.platform === 'darwin' ? 'Meta+k' : 'Control+k';
+  // Which modifier the page honours is decided by the platform the *browser*
+  // advertises, not the one the test runs on, and Playwright's Desktop Chrome
+  // advertises Windows even on a Mac host. Asking process.platform there picks
+  // Meta for a page that is listening for Control.
+  const shortcut = (await applePlatform(page)) ? 'Meta+k' : 'Control+k';
   await page.keyboard.press(shortcut);
 
   await expect(siteOverlay(page)).toBeVisible();


### PR DESCRIPTION
We're adding a new "API" section, which will have it's own navigation menu. We want it to be structured like this, with a combination of "normal" articles which will move from the current docs, and the programatically generated API reference based on our swagger:

<img width="567" height="417" alt="image" src="https://github.com/user-attachments/assets/0bbcbfae-c737-4e55-9764-93c977c2ffc3" />

When attempting to implement this, I discovered that the API navigation was not equipped to handle more than one level of nesting, and there were some bugs around breadcrumbs.

# Results

This PR used claude to fix the bugs, and add a new horizontal divider line between the "normal" docs and generated reference.

It also adds an index page to the API section. This is currently just a copy-paste of the existing API getting started page, with a slightly tweaked nav title/breadcrumb title.

* On the staging site, you should observe no change to the normal docs
* The API section should now have the "Get started" page, a horizontal divider, then the generated reference

I've tested these myself, you're welcome to double check

Future PR's will improve the landing page and move content across from the "docs" section of the site, in accordance with the design
