### PR TITLE
Auto-approve generated docs sync PRs

### DIFF
--- a/.github/workflows/auto-approve-api-docs-sync.yml
+++ b/.github/workflows/auto-approve-api-docs-sync.yml
@@ -1,0 +1,28 @@
+name: Auto-approve API docs sync PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'team-backend-foundations-bot'
+      && github.actor == 'team-backend-foundations-bot'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.head.ref == 'api-docs-sync'
+      && github.event.pull_request.base.ref == 'main'
+      && contains(github.event.pull_request.labels.*.name, 'api-docs-sync')
+    steps:
+      - name: Approve PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
# Summary

We want automatically generated PRs like #3410 to merge automatically so long as the build passes. For this they need to be approved, so this PR will automatically approve them as the github-actions bot (which, importantly, is a different user to the author of the PR and thus satisfies the review required check).


# Risk

Automatically approving naturally always carries a risk of incorrectly approving a malicious PR; please sanity check that the workflow contains no holes in this regard!
