### PR TITLE
Auto-approve generated go cli docs sync PRs

### DIFF
--- a/.github/workflows/auto-approve-docs-sync.yml
+++ b/.github/workflows/auto-approve-docs-sync.yml
@@ -1,4 +1,4 @@
-name: Auto-approve API docs sync PRs
+name: Auto-approve generated docs sync PRs
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  approve:
+  approve-api-docs-sync:
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.user.login == 'team-backend-foundations-bot'
@@ -20,6 +20,22 @@ jobs:
       && github.event.pull_request.head.ref == 'api-docs-sync'
       && github.event.pull_request.base.ref == 'main'
       && contains(github.event.pull_request.labels.*.name, 'api-docs-sync')
+    steps:
+      - name: Approve PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"
+
+  approve-cli-docs-sync:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'team-miscellaneous-branch-protections'
+      && github.actor == 'team-miscellaneous-branch-protections'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.head.ref == 'cli-docs-sync'
+      && github.event.pull_request.base.ref == 'main'
+      && contains(github.event.pull_request.labels.*.name, 'cli-docs-sync')
     steps:
       - name: Approve PR
         env:


### PR DESCRIPTION
# Summary

We added auto-approval for generated API docs in #3411.

We've had PRs for generated CLI docs being automatically created in this repo for a while but they haven't been automatically merged in the past. To reduce the maintenance burden, this PR adds auto-approval for those too, and they've also been updated to set auto-merge on such that they should be able to merge fully autonomously with this approval.