### PR TITLE
Fix: document the account saved on discovered cloud targets

### DIFF
--- a/src/pages/docs/infrastructure/deployment-targets/cloud-target-discovery/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/cloud-target-discovery/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2024-06-27
+modDate: 2026-08-27
 title: Cloud Target Discovery
 description: Cloud resources can be discovered and registered as deployment targets by Octopus
 navOrder: 90
@@ -39,7 +39,7 @@ To discover Azure cloud resources, Octopus uses the following variables:
 
 | Name                    | Required | Description                                                                                                |
 | ----------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `Octopus.Azure.Account` | Y        | An [Azure account](/docs/projects/variables/azure-account-variables) to use when discovering cloud targets |
+| `Octopus.Azure.Account` | Y        | An [Azure account](/docs/projects/variables/azure-account-variables) to use when discovering cloud targets. This account is also saved on each target it discovers, and is the account Octopus uses to deploy to that target and to run its health checks. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account). |
 
 From **Octopus 2022.3**, Azure steps that support target discovery will allow you to configure the variables above from within the step configuration if they have not been configured within your project yet.
 
@@ -65,6 +65,10 @@ To switch off cloud target discovery for Azure:
 
 Once the variable is removed, cloud target discovery will be switched off for Azure resources in this project. The **Azure** tile in the **Cloud Connections** section of your Azure deployment steps will show **Configure** again, indicating that cloud target discovery is no longer active.
 
+:::div{.warning}
+Switching off discovery does not change the targets it has already discovered. Each one keeps the account it was discovered with. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account).
+:::
+
 ### AWS
 
 To discover AWS cloud resources, Octopus uses the following variables:
@@ -72,7 +76,7 @@ To discover AWS cloud resources, Octopus uses the following variables:
 | Name                                      | Required | Description                                                                                                                                                                                                                                               |
 | ----------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Octopus.Aws.Regions`                     | Y        | A comma separated list of AWS regions to perform target discovery in.                                                                                                                                                                                     |
-| `Octopus.Aws.Account`                     | N        | An [AWS account](/docs/projects/variables/aws-account-variables) account to use when discovering cloud targets. If this is not set then credentials from the worker on which the step is run will be used.                                                |
+| `Octopus.Aws.Account`                     | N        | An [AWS account](/docs/projects/variables/aws-account-variables) account to use when discovering cloud targets. If this is not set then credentials from the worker on which the step is run will be used. When set, this account is also saved on each target it discovers, and is the account Octopus uses to deploy to that target and to run its health checks. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account). |
 | `Octopus.Aws.WorkerPool`                  | N        | A [worker pool](/docs/projects/variables/worker-pool-variables) to use when discovering cloud targets. If this is not set then the worker pool from the step will be used. If this is set any discovered targets will have this set as their worker pool. |
 | `Octopus.Aws.AssumedRole.Arn`             | N        | The ARN of an IAM role to assume during the discovery of targets. See [Using IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) for more information on using and assuming roles.                                             |
 | `Octopus.Aws.AssumedRole.SessionName`     | N        | The name of the session to use if assuming a role during discovery. If not set then an automatically generated name provided by AWS will be used.                                                                                                         |
@@ -106,6 +110,10 @@ To switch off cloud target discovery for AWS:
 3. Click **SAVE**.
 
 Once the variables are removed, cloud target discovery will be switched off for AWS resources in this project. The **Amazon Web Services** tile in the **Cloud Connections** section of your AWS deployment steps will show **Configure** again, indicating that cloud target discovery is no longer active.
+
+:::div{.warning}
+Switching off discovery does not change the targets it has already discovered. Each one keeps the account it was discovered with. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account).
+:::
 
 ## Tag cloud resources
 
@@ -169,7 +177,7 @@ Cloud Target Discovery will often discover resources which already have targets 
 
 ### Previously discovered targets
 
-If a target has been created via Cloud Target Discovery, the next time the same cloud resource is discovered, the target will simply be updated. Existing targets are matched by target name, which is formatted depending on the discovered resource. The names are chosen to be unique but as readable as possible.
+If a target has been created via Cloud Target Discovery, the next time the same cloud resource is discovered, the target will simply be updated. The update replaces the target's connection details, including its account, with the values from the new discovery run. Existing targets are matched by target name, which is formatted depending on the discovered resource. The names are chosen to be unique but as readable as possible.
 
 - Azure Web App: `azure-web-app/{resource-group}/{web-app-name}`
 - ECS Cluster: `{ecs-cluster-arn}`
@@ -177,10 +185,22 @@ If a target has been created via Cloud Target Discovery, the next time the same 
 - EKS Cluster: `{eks-cluster-arn}`
 
 :::div{.warning}
-Renaming or moving cloud resources can cause target discovery to create duplicate targets. In most cases the old target will become unhealthy and be removed automatically by Octopus (see [Cleaning up unhealthy targets]) but in some cases the old target may still be healthy. In these cases, it must be removed manually.
+Renaming or moving cloud resources can cause target discovery to create duplicate targets. In most cases the old target will become unhealthy and be removed automatically by Octopus (see [Cleaning up unhealthy targets](#cleaning-up-unhealthy-targets)) but in some cases the old target may still be healthy. In these cases, it must be removed manually. Automatic removal only happens when a target fails its health checks; it is not triggered by a discovery run that no longer reports the resource.
 
 **Example:** If you move an AKS Cluster to a different subscription and then update your Account in Octopus to use the new subscription ID, the old target will still pass its health-check. When discovery occurs a new target will be created (with the new Subscription ID in the target name) and the old target will need to be removed manually.
 :::
+
+### Changing or removing the discovery account
+
+The account used for discovery is saved on every target it discovers. That account is what Octopus uses to deploy to the target and to run its health checks, so it stays on the target until another discovery run replaces it.
+
+This has a few consequences:
+
+- Changing the discovery account and deploying again will update the targets that discovery finds on that run, because the account is not part of the target name.
+- Removing the discovery account switches discovery off, so nothing updates the existing targets. They keep the old account until you change them yourself.
+- A target that references an account appears on that account's **Usage** tab, and will prevent that account from being deleted.
+
+To move a target off an account, go to **Infrastructure ➜ Deployment Targets**, edit the target and select a different account. You can also delete the target, which is safe if discovery will run again and recreate it.
 
 ### Overwriting manually added targets
 

--- a/src/pages/docs/infrastructure/deployment-targets/cloud-target-discovery/index.md
+++ b/src/pages/docs/infrastructure/deployment-targets/cloud-target-discovery/index.md
@@ -39,7 +39,9 @@ To discover Azure cloud resources, Octopus uses the following variables:
 
 | Name                    | Required | Description                                                                                                |
 | ----------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `Octopus.Azure.Account` | Y        | An [Azure account](/docs/projects/variables/azure-account-variables) to use when discovering cloud targets. This account is also saved on each target it discovers, and is the account Octopus uses to deploy to that target and to run its health checks. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account). |
+| `Octopus.Azure.Account` | Y        | An [Azure account](/docs/projects/variables/azure-account-variables) to use when discovering cloud targets |
+
+The account you set here is also saved on each target discovery creates, and is the account Octopus uses to deploy to that target and to run its health checks. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account).
 
 From **Octopus 2022.3**, Azure steps that support target discovery will allow you to configure the variables above from within the step configuration if they have not been configured within your project yet.
 
@@ -76,12 +78,14 @@ To discover AWS cloud resources, Octopus uses the following variables:
 | Name                                      | Required | Description                                                                                                                                                                                                                                               |
 | ----------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Octopus.Aws.Regions`                     | Y        | A comma separated list of AWS regions to perform target discovery in.                                                                                                                                                                                     |
-| `Octopus.Aws.Account`                     | N        | An [AWS account](/docs/projects/variables/aws-account-variables) account to use when discovering cloud targets. If this is not set then credentials from the worker on which the step is run will be used. When set, this account is also saved on each target it discovers, and is the account Octopus uses to deploy to that target and to run its health checks. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account). |
+| `Octopus.Aws.Account`                     | N        | An [AWS account](/docs/projects/variables/aws-account-variables) account to use when discovering cloud targets. If this is not set then credentials from the worker on which the step is run will be used.                                                |
 | `Octopus.Aws.WorkerPool`                  | N        | A [worker pool](/docs/projects/variables/worker-pool-variables) to use when discovering cloud targets. If this is not set then the worker pool from the step will be used. If this is set any discovered targets will have this set as their worker pool. |
 | `Octopus.Aws.AssumedRole.Arn`             | N        | The ARN of an IAM role to assume during the discovery of targets. See [Using IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html) for more information on using and assuming roles.                                             |
 | `Octopus.Aws.AssumedRole.SessionName`     | N        | The name of the session to use if assuming a role during discovery. If not set then an automatically generated name provided by AWS will be used.                                                                                                         |
 | `Octopus.Aws.AssumedRole.SessionDuration` | N        | The maximum duration the session will be available for if assuming a role during discovery. If not set then the default duration from the IAM role will be used.                                                                                          |
 | `Octopus.Aws.AssumedRole.ExternalId`      | N        | An external ID to use if assuming a role during discovery. See the AWS documentation for more information on the use of external IDs.                                                                                                                     |
+
+If you set `Octopus.Aws.Account`, that account is also saved on each target discovery creates, and is the account Octopus uses to deploy to that target and to run its health checks. See [changing or removing the discovery account](#changing-or-removing-the-discovery-account).
 
 From **Octopus 2022.3**, AWS steps that support target discovery will allow you to configure the variables above from within the step configuration if they have not been configured within your project yet:
 


### PR DESCRIPTION
# Background

Cloud target discovery saves the account it authenticated with onto every target it creates, and that account is what Octopus then uses to deploy to the target and run its health checks. The page never said so. It describes `Octopus.Azure.Account` as an account "to use when discovering cloud targets", which reads like the account is only used for the scan.

FD-731 came in because of that. Someone took the account out of their deployment and couldn't work out why an Azure Web App target still pointed at it, or whether they had to go and change the target themselves. Two other spots on the page steer you wrong: the switch-off instructions stop at "discovery is now off" and never mention existing targets, and the stale-target warning says Octopus removes them automatically. It only does that when a target fails its health checks.

# Results

Says where a discovered target's account comes from, and what happens to it when you change or remove the discovery account. Also fixes a broken in-page link.

Fixes FD-731

## Before

- `Octopus.Azure.Account` and `Octopus.Aws.Account` read as credentials for the discovery scan only.
- "Switching off ... cloud target discovery" ends once you delete the variable. Nothing about targets already discovered.
- "Previously discovered targets" says the target "will simply be updated" without saying what gets replaced.
- The stale-target warning implies Octopus cleans up: "the old target will become unhealthy and be removed automatically".
- `[Cleaning up unhealthy targets]` had no link destination.

## After

- Both variable tables say the account is saved on each discovered target and used for that target's deployments and health checks.
- Both switch-off sections warn that existing targets keep their account.
- New "Changing or removing the discovery account" section: rediscovery under a different account updates the target, because the account isn't part of the target name; removing the account switches discovery off, so nothing updates the existing targets; and a target holding an account blocks deleting that account.
- The auto-removal sentence now says removal only happens on health check failure.
- Link fixed to `#cleaning-up-unhealthy-targets`.


# Pre-requisites

- [ ] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/main/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [ ] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [ ] I have considered the [appropriate target version for this PR](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1145896982/Which+versions+should+I+patch#Process).
- [ ] I have considered appropriate testing for my change.
  - Automated testing / Exploratory testing / Nothing required?
- [ ] I have considered manually testing my changes on a [branch instance](https://octopushq.atlassian.net/wiki/spaces/RND/pages/1262256152/Use+a+Core+Feature+Branch+Instance) to check correctness, stability and performance on Octopus Cloud.
- [ ] I have considered safety nets to reduce any time-to-recovery for my change.
