### PR TITLE
Ensure the area navigation always keeps the active item visible on page load

### DIFF
--- a/src/components/ApiNavigation.astro
+++ b/src/components/ApiNavigation.astro
@@ -81,7 +81,7 @@ stats.stop();
   aria-label={_(Translations.aria.site_navigation)}
 >
   <h2 class="site-nav-title">{_(Translations.navigation.title)}</h2>
-  <ul class="site-nav__list">
+  <ul class="site-nav__list" data-site-nav-scroll>
     {
       authored.map((page) => (
         <ApiNavigationItem

--- a/src/components/AreaNavigation.astro
+++ b/src/components/AreaNavigation.astro
@@ -36,3 +36,16 @@ const { area, lang, headings, apiMethods } = Astro.props satisfies Props;
     <ApiNavigation lang={lang} headings={headings} apiMethods={apiMethods} />
   )
 }
+
+{
+  /* Ensure the active element is always visible when the page loads in the area navigation */
+}
+<script is:inline>
+  (() => {
+    const active = document
+      .querySelector('[data-site-nav-scroll]')
+      ?.querySelector('[aria-current="page"]');
+
+    active?.scrollIntoView({ block: 'center' });
+  })();
+</script>

--- a/src/themes/octopus/components/Navigation.astro
+++ b/src/themes/octopus/components/Navigation.astro
@@ -71,7 +71,7 @@ stats.stop();
   aria-label={_(Translations.aria.site_navigation)}
 >
   <h2 class="site-nav-title">{_(Translations.navigation.title)}</h2>
-  <ul class="site-nav__list">
+  <ul class="site-nav__list" data-site-nav-scroll>
     {
       topLevel.map(({ page, leadsToSection }) => (
         <NavigationItem


### PR DESCRIPTION
When visiting a page that's deeply nested in the docs the item may not always be visible in the area navigation list. We therefore scroll the active element into view on page load to ensure user's don't have to actively scroll each and every time a page is navigated to.

# Before
https://github.com/user-attachments/assets/0305bcd8-c9af-415b-a5a0-9662ec5ca755

The area navigation list will jump to the top of the list after every page navigaiton.

# After

https://github.com/user-attachments/assets/c3a1c17d-ef2a-4b2b-87bb-7b002d4b2873

The area navigation list will now ensure the active item is visible when the page reloads
