### PR TITLE
Set the Google Cloud OIDC version hint to 2026.3.5893

### DIFF
--- a/src/pages/docs/infrastructure/accounts/google-cloud/index.md
+++ b/src/pages/docs/infrastructure/accounts/google-cloud/index.md
@@ -8,7 +8,7 @@ navOrder: 30
 ---
 
 :::div{.hint}
-Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect Accounts were added in **2025.1**, and the OpenID Connect authentication method for Google Cloud Accounts was added in **{RELEASE_VERSION}**
+Google Cloud Accounts were added in Octopus **2021.2**, Generic OpenId Connect Accounts were added in **2025.1**, and the OpenID Connect authentication method for Google Cloud Accounts was added in **2026.3.5893**
 :::
 
 To deploy infrastructure to Google Cloud Platform, you can define a Google Cloud account or a Generic OpenId Connect account in Octopus.


### PR DESCRIPTION
# Background

The Google Cloud accounts page still carried a `{RELEASE_VERSION}` placeholder in its version hint, left behind when the OpenID Connect authentication method was first documented. It renders literally on the published page.

# Results

Replaces the placeholder with 2026.3.5893, the version the OpenID Connect authentication method for Google Cloud Accounts shipped in.

## Before

> ...the OpenID Connect authentication method for Google Cloud Accounts was added in **{RELEASE_VERSION}**

## After

> ...the OpenID Connect authentication method for Google Cloud Accounts was added in **2026.3.5893**
