### PR TITLE
Add Aug '26 Cloud uptime-slo stats

### DIFF
--- a/src/pages/docs/octopus-cloud/uptime-slo.md
+++ b/src/pages/docs/octopus-cloud/uptime-slo.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2026-08-04
+modDate: 2026-09-02
 title: Uptime SLO
 navTitle: Uptime SLO
 navOrder: 70
@@ -26,6 +26,7 @@ We list our achieved uptime percentage and weekly unplanned downtime duration. W
 
 | Month | Uptime % | Weekly unplanned downtime | Uptime % incl. planned maintenance | Weekly downtime incl. planned maintenance |
 | :----- | ------: | ------: | ------: | ------: |
+| August 2026 | 99.9973% | 21s | 99.8829% | 714s |
 | July 2026 | 99.9989% | 7s | 99.8643% | 826s |
 | June 2026 | 99.9987% | 14s | 99.9212% | 483s |
 | May 2026 | 99.9959% | 28s | 99.9234% | 469s |
@@ -37,7 +38,6 @@ We list our achieved uptime percentage and weekly unplanned downtime duration. W
 | November 2025 | 99.9702% | 182s | 99.8925% | 651s |
 | October 2025 | 99.9851% | 91s | 99.8663% | 812s |
 | September 2025 | 99.9989% | 7s | 99.8722% | 777s |
-| August 2025 | 99.9989% | 7s | 99.9281% | 441s |
 
 ### How we calculate uptime
 


### PR DESCRIPTION
Updates `uptime-slo.md` per [instructions](https://confluence.hq.octopus.com/wiki/x/A4AvGAE).

Fixes CLOUDPT-11796.