### PR TITLE
Remove borders/background from <code> elements

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -109,9 +109,6 @@ blockquote cite {
 }
 
 code {
-  border-radius: var(--borderRadiusSmall);
-  border: var(--borderWidth1) solid var(--colorBorderPrimary);
-  background: var(--colorBackgroundSecondaryDefault);
   white-space: pre-wrap;
   overflow-wrap: break-word;
   padding: 0 var(--space4);


### PR DESCRIPTION
When we have code elements, especially many on a page, the borders and backgrounds are very distracting. Removing them. 

Before:

<img width="921" height="1041" alt="Screenshot 2026-09-03 at 8 42 56 am" src="https://github.com/user-attachments/assets/6295879c-5571-4977-94da-ab0d8319e549" />

After:

<img width="921" height="1041" alt="Screenshot 2026-09-03 at 8 43 12 am" src="https://github.com/user-attachments/assets/e6d6c72a-d145-45cc-9a09-5d2f48e152b8" />
