### PR TITLE
Make hyperlinks look better

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -90,7 +90,7 @@ hr {
 }
 
 .page-content :where(a:hover, a:focus) {
-  color: var(--body-link-color);
+  color: var(--colorScalesBlue600);
 }
 
 /* The tinted card is the callout's shape. Almost every `>` in the docs holds

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -84,7 +84,9 @@ hr {
 }
 
 .page-content :where(a) {
-  color: var(--octo-blue);
+  color: var(--colorScalesBlue500);
+  text-decoration: none;
+  font-weight: 500;
 }
 
 .page-content :where(a:hover, a:focus) {


### PR DESCRIPTION


Before:

<img width="921" height="819" alt="Screenshot 2026-09-03 at 8 58 13 am" src="https://github.com/user-attachments/assets/1e97b5fb-3d18-4b64-b1e4-8761b175bf5d" />

After:

<img width="921" height="819" alt="Screenshot 2026-09-03 at 8 57 49 am" src="https://github.com/user-attachments/assets/9ac967ed-17b7-40cc-a3b1-a0ed4b461e81" />
