### PR TITLE
docs: use Public Preview consistently for project templates

### DIFF
--- a/src/pages/docs/platform-hub/templates/index.md
+++ b/src/pages/docs/platform-hub/templates/index.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-05
-modDate: 2026-03-06
+modDate: 2026-09-03
 title: Templates
 subtitle: Reusable templates for processes and projects in Platform Hub
 icon: fa-solid fa-layer-group
@@ -17,7 +17,7 @@ Platform Hub provides two types of templates that help you standardize and share
 
 **[Process templates](/docs/platform-hub/templates/process-templates)** are reusable sets of deployment steps. Instead of copying and pasting deployment processes across projects, you define the steps once and share them. Teams can opt into using a process template within their deployment process, and can remove it if it no longer fits their needs.
 
-**[Project templates](/docs/platform-hub/templates/project-templates)** give platform engineering teams a way to define a golden path for how projects are structured. The deployment process is defined by the template and can't be modified in projects based on it. Through parameters exposed by the platform team, project teams can deploy using their own packages, accounts, worker pools, and target tags, while the underlying process stays consistent across every project based on the template. Project templates are currently in Alpha, see the [installation guide](/docs/platform-hub/templates/project-templates/installation-guide) to get started.
+**[Project templates](/docs/platform-hub/templates/project-templates)** give platform engineering teams a way to define a golden path for how projects are structured. The deployment process is defined by the template and can't be modified in projects based on it. Through parameters exposed by the platform team, project teams can deploy using their own packages, accounts, worker pools, and target tags, while the underlying process stays consistent across every project based on the template. Project templates are currently in Public Preview, see the [installation guide](/docs/platform-hub/templates/project-templates/installation-guide) to get started.
 
 Both template types use [parameters](/docs/platform-hub/templates/parameters) to expose configurable inputs, letting you define what a project must supply while keeping the core template consistent across teams and spaces.
 

--- a/src/pages/docs/platform-hub/templates/project-templates/troubleshooting.md
+++ b/src/pages/docs/platform-hub/templates/project-templates/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-03-05
-modDate: 2026-05-28
+modDate: 2026-09-03
 title: Troubleshooting
 subtitle: Known issues and limitations for project templates
 icon: fa-solid fa-layer-group
@@ -62,7 +62,7 @@ You can't clone a project template through the Octopus UI. To clone a template:
 
 ## Public API
 
-The Alpha release doesn't support creating and managing project templates through the REST API. We're planning REST API support for a future release.
+The Public Preview doesn't support creating and managing project templates through the REST API. We're planning REST API support for a future release.
 
 ## Losing access to an Octopus Enterprise license
 


### PR DESCRIPTION
## What

Two pages still describe project templates as being in **Alpha**, while the rest of the project templates documentation describes them as being in **Public Preview**.

- `platform-hub/templates/index.md` — "Project templates are currently in Alpha"
- `platform-hub/templates/project-templates/troubleshooting.md` — "The Alpha release doesn't support creating and managing project templates through the REST API"

Both now say Public Preview. `modDate` bumped on both pages.

## Why Public Preview is the correct status

- 12 occurrences of "Public Preview" across the project templates pages vs 2 of "Alpha".
- The two Alpha references sit on pages with **older** `modDate` values (2026-03-06 and 2026-05-28) than the pages using Public Preview, so they read as stale rather than as a deliberate distinction.
- `project-templates/installation-guide.md` is titled "Installing the Public Preview of project templates".

## Out of scope

`platform-hub/compliance-reports.md` also says "Alpha", but that's a **separate feature** with its own status and it's labelled consistently on its own page. Left untouched — flagging in case compliance reports have since moved to Public Preview too, which would be a follow-up.

## Checks

- `cspell` clean on both changed files.
- No markdownlint risk: changes are in-line word substitutions and `MD013` (line length) is disabled in `.markdownlint.json`.
- CRLF line endings preserved.

## Reviewer note

The mechanical consistency is easy to verify from the diff. The thing a tool can't check is whether **Public Preview** is genuinely the current status of project templates — please confirm against the current release state before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)