### PR TITLE
Add Remote MCP package sourcing use case

### DIFF
--- a/src/pages/docs/octopus-ai/mcp/remote/use-cases.md
+++ b/src/pages/docs/octopus-ai/mcp/remote/use-cases.md
@@ -1,10 +1,10 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-08-17
-modDate: 2026-08-17
+modDate: 2026-09-04
 title: Octopus Remote MCP use cases
 navTitle: Use cases
-description: Explore how Octopus Remote MCP helps teams track releases, diagnose failures, automate deployments, audit changes, and manage tenants.
+description: Explore how Octopus Remote MCP helps teams track releases, diagnose failures, automate deployments, source packages, audit changes, and manage tenants.
 navOrder: 2
 ---
 
@@ -44,6 +44,17 @@ Example prompts:
 - "Run the Restart payment workers runbook in Production."
 
 Operations that make changes run with the permissions of the API key used to connect the assistant. Use a dedicated [Agent Service Account](/docs/security/users-and-teams/service-accounts#agent-service-accounts) and grant it only the permissions it needs.
+
+## Package sourcing
+
+Package sourcing reveals how a feed is configured, including the registry or source it points at, and which versions of a package are available. Your assistant can confirm where a package comes from and pick a version a channel's rules will accept, without opening each feed by hand.
+
+Example prompts:
+
+- "Which registry does the worker-tools feed point at? I need Renovate to compare container versions against the right source."
+- "How is the Docker Hub feed configured, and what registry path does it use?"
+- "List the available versions of the Payments API package in the Releases feed."
+- "What's the latest version of the Payments API package the 2.x channel will accept?"
 
 ## Operational oversight
 


### PR DESCRIPTION
## Why

[OctopusDeploy/OctopusDeploy#47139](https://github.com/OctopusDeploy/OctopusDeploy/pull/47139) ("Expose feeds and package versions to the Remote MCP") shipped four new contract tools on the Remote MCP: `find_feeds`, `get_feed`, `find_package_versions`, and `get_latest_package_version`. An agent can now read how a feed is configured (including the registry or source it points at) and pick a package version a channel's rules will accept.

The [Remote MCP use cases page](/docs/octopus-ai/mcp/remote/use-cases) is structured as a catalog of what the server helps teams do, but had no entry for feeds or package versions, so the documentation trailed the implementation.

## What changed

- Added a **Package sourcing** use case to the Remote MCP use cases page, with example prompts covering the two capabilities the PR delivered: reading a feed's configuration/registry, and resolving package versions (including honouring a channel's version rule). The prompts are grounded in the real motivation for the feature — a Renovate user needing to know which registry a feed points at.
- Updated the page `description` and `modDate` to match.

The other Remote MCP page (`remote/index.md`) intentionally does not enumerate individual contract tools ("We'll add more operations to the contract tools over time"), so it needed no change.

## Notes

- No backend/product code here; documentation only.
- Wording and structure follow the existing sections on the same page (concise theme heading, short description, "Example prompts:" list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwiRZaThjbqCqxXeTwUBq1

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwiRZaThjbqCqxXeTwUBq1)_