### PR TITLE
docs: call out UserInvite as a highly privileged permission

### DIFF
--- a/src/pages/docs/security/users-and-teams/user-roles.md
+++ b/src/pages/docs/security/users-and-teams/user-roles.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2023-01-01
-modDate: 2026-08-17
+modDate: 2026-09-08
 title: User roles
 description: User roles are a critical part of the Octopus security model whereby they are assigned to Teams and they dictate what the members of those teams can do in Octopus.
 ---
@@ -49,6 +49,14 @@ For more information regarding the *system or space level*, please see [system a
 :::
 
 ## Creating user roles {#UserRoles-CreatingUserRoles}
+
+:::div{.warning}
+**`UserInvite` is a highly privileged permission.** Of the built-in roles, only **System Administrator** and **System Manager** include it, and that is deliberate.
+
+Inviting a user requires `UserInvite` together with `TeamEdit`, and that combination lets you add someone to a team granting more access than you hold yourself. The only exception is that you cannot invite anyone into a team with the `AdministerSystem` permission unless you have it too.
+
+Grant `UserInvite` only to people you trust to administer the whole Octopus installation.
+:::
 
 A custom User Role can be created with any combination of permissions. To create a custom user role:
 


### PR DESCRIPTION
Pairs with the in-code documentation in [OctopusDeploy#47353](https://github.com/OctopusDeploy/OctopusDeploy/pull/47353).

## Why

`UserInvite` is more powerful than it looks. Combined with `TeamEdit` it lets you invite a user into a team granting more access than the inviter holds — `AdministerSystem` is the only exception. That is deliberate (`TeamEdit` is the "trusted to assign access" permission), but it isn't obvious from the docs, and it's a recurring bug bounty topic where someone builds a minimal custom role and reports it as privilege escalation.

Only two built-in roles include it — **System Administrator** and **System Manager** — and that's on purpose. Worth saying out loud so anyone building a custom role understands what they're handing out.

## What

One `:::div{.warning}` callout at the top of **Creating user roles** on [User roles](https://octopus.com/docs/security/users-and-teams/user-roles), since that's the page where someone would actually grant it. `modDate` bumped per convention.

No other content changes.

## Checks

`npm run spellcheck` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)