### PR TITLE
docs: fix broken OIDC links on the Buildkite page

### DIFF
--- a/src/pages/docs/packaging-applications/build-servers/buildkite.md
+++ b/src/pages/docs/packaging-applications/build-servers/buildkite.md
@@ -1,7 +1,7 @@
 ---
 layout: src/layouts/Default.astro
 pubDate: 2026-08-29
-modDate: 2026-08-29
+modDate: 2026-09-08
 title: Buildkite
 description: Buildkite pipelines can create releases in Octopus Deploy, authenticating with OpenID Connect so no API key is stored in the pipeline.
 navOrder: 45
@@ -40,7 +40,7 @@ Anything that sets these before your Octopus steps run will work, whether that i
 
 ### OpenID Connect
 
-Using [OpenID Connect](/docs/octopus-rest-api/openid-connect) means no Octopus API key is stored in Buildkite. Buildkite issues a signed token describing the running job, Octopus validates it, and returns an access token that is valid for one hour.
+Using [OpenID Connect](/docs/api/authentication/openid-connect) means no Octopus API key is stored in Buildkite. Buildkite issues a signed token describing the running job, Octopus validates it, and returns an access token that is valid for one hour.
 
 :::div{.hint}
 OpenID Connect can only be used with [service accounts](/docs/security/users-and-teams/service-accounts), not user accounts.
@@ -154,6 +154,6 @@ There is no Buildkite plugin for pushing [build information](/docs/packaging-app
 ## Learn more
 
 - [Octopus CLI](/docs/octopus-rest-api/cli)
-- [Using OpenID Connect with the Octopus API](/docs/octopus-rest-api/openid-connect)
-- [Using OpenID Connect with other issuers](/docs/octopus-rest-api/openid-connect/other-issuers)
+- [Using OpenID Connect with the Octopus API](/docs/api/authentication/openid-connect)
+- [Using OpenID Connect with other issuers](/docs/api/authentication/openid-connect/other-issuers)
 - [Create Release Buildkite plugin](https://github.com/OctopusDeploy/create-release-buildkite-plugin)


### PR DESCRIPTION
Fixes the link check that has been failing on `main` since 4 Sep.

## The failure

```
[404] dist/docs/octopus-rest-api/openid-connect/other-issuers
ERROR: Detected 1 broken links. Scanned 4505 links in 15.361 seconds.
```

## Cause

`d6c6dfe95` ("Move API content to the new toplevel API section") moved `index.md`, `github-actions.md` and `other-issuers.md` out of `octopus-rest-api/openid-connect/` into `api/authentication/openid-connect/`, but only created a redirect stub for the **parent** (`octopus-rest-api/openid-connect.md`). The two child pages have no stub.

The Buildkite page landed the same day and links to the old child path, so the crawl 404s. Found by running the build locally and re-running linkinator with `--format json`, which names the referrer:

```
url   : dist/docs/octopus-rest-api/openid-connect/other-issuers
status: 404
parent: dist/docs/packaging-applications/build-servers/buildkite
```

## The fix

Points all three OIDC links on the Buildkite page at the new canonical paths. Only line 158 was actually 404ing; lines 43 and 157 resolved via the parent redirect stub, but they're equally stale, so they're updated too — that also removes an unnecessary redirect hop and matches how every other page references these docs.

Fixing the referrer rather than adding child redirect stubs, since no other page links to the old child paths.

## Verification

Local `npm run build` + linkinator:

| | before | after |
|---|---|---|
| links scanned | 4505 | 4503 |
| broken | 1 | **0** |

(two fewer links scanned because the redirect hop is gone)

`npm run spellcheck` — 0 issues.

Unblocks #3452, which is red only because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)